### PR TITLE
Make `console_*` console log levels available for `sapp-console-log`

### DIFF
--- a/native/sapp-wasm/Cargo.toml
+++ b/native/sapp-wasm/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "sapp-wasm"
-version = "0.1.3"
+version = "0.1.4"
 authors = ["not-fl3 <not.fl3@gmail.com>"]
 edition = "2018"
 license = "MIT/Apache-2.0"

--- a/native/sapp-wasm/js/gl.js
+++ b/native/sapp-wasm/js/gl.js
@@ -333,8 +333,20 @@ var emscripten_shaders_hack = false;
 var start;
 var importObject = {
     env: {
-        test_log: function (ptr) {
+        console_debug: function (ptr) {
+            console.debug(UTF8ToString(ptr));
+        },
+        console_log: function (ptr) {
             console.log(UTF8ToString(ptr));
+        },
+        console_info: function (ptr) {
+            console.info(UTF8ToString(ptr));
+        },
+        console_warn: function (ptr) {
+            console.warn(UTF8ToString(ptr));
+        },
+        console_error: function (ptr) {
+            console.error(UTF8ToString(ptr));
         },
         set_emscripten_shader_hack: function (flag) {
             emscripten_shaders_hack = flag;

--- a/native/sapp-wasm/src/lib.rs
+++ b/native/sapp-wasm/src/lib.rs
@@ -252,7 +252,7 @@ pub unsafe fn sapp_run(desc: *const sapp_desc) -> ::std::os::raw::c_int {
             let msg = CString::new(format!("{:?}", info)).unwrap_or_else(|_| {
                 CString::new(format!("MALFORMED ERROR MESSAGE {:?}", info.location())).unwrap()
             });
-            test_log(msg.as_ptr());
+            console_log(msg.as_ptr());
         }));
     }
 
@@ -276,21 +276,18 @@ pub unsafe fn sapp_height() -> ::std::os::raw::c_int {
     canvas_height()
 }
 
+#[no_mangle]
 extern "C" {
     pub fn init_opengl();
     pub fn canvas_width() -> i32;
     pub fn canvas_height() -> i32;
-    pub fn test_log(msg: *const ::std::os::raw::c_char);
+    pub fn console_debug(msg: *const ::std::os::raw::c_char);
+    pub fn console_log(msg: *const ::std::os::raw::c_char);
+    pub fn console_info(msg: *const ::std::os::raw::c_char);
+    pub fn console_warn(msg: *const ::std::os::raw::c_char);
+    pub fn console_error(msg: *const ::std::os::raw::c_char);
 }
 
-pub fn console_log(msg: &str) {
-    use std::ffi::CString;
-
-    let string = CString::new(msg).unwrap();
-    unsafe {
-        test_log(string.as_ptr());
-    }
-}
 #[no_mangle]
 pub extern "C" fn frame() {
     unsafe {

--- a/src/graphics.rs
+++ b/src/graphics.rs
@@ -846,7 +846,7 @@ pub fn load_shader(shader_type: GLenum, source: &str) -> GLuint {
             );
 
             #[cfg(target_arch = "wasm32")]
-            test_log(error_message.as_ptr() as *const _);
+            console_log(error_message.as_ptr() as *const _);
 
             let error_message = std::string::String::from_utf8_lossy(&error_message);
             eprintln!("{} {:?}", max_length, error_message);


### PR DESCRIPTION
This supercedes #13 and allows for a separate create to take care of `log-rs`-compatibility for wasm32 target.