### PR TITLE
Focus on canvas to capture keyboard input

### DIFF
--- a/native/sapp-wasm/js/gl.js
+++ b/native/sapp-wasm/js/gl.js
@@ -12,6 +12,8 @@ if (gl === null) {
     alert("Unable to initialize WebGL. Your browser or machine may not support it.");
 }
 
+canvas.focus();
+
 function assert(flag, message) {
     if (flag == false) {
         alert(message)


### PR DESCRIPTION
If canvas doesn't get focus, the user must click with mouse before keyboard input is accepted (tested on Firefox).