### PR TITLE
Add ability to use wasm exports from plugins

### DIFF
--- a/native/sapp-wasm/js/gl.js
+++ b/native/sapp-wasm/js/gl.js
@@ -760,12 +760,12 @@ function init_plugins(plugins) {
     }
 }
 
-function set_mem_plugins(plugins) {
+function init_plugins_wasm(plugins) {
     if (plugins == undefined)
         return;
 
     for (var i = 0; i < plugins.length; i++) {
-        plugins[i].set_mem(memory);
+        plugins[i].init_wasm(memory, wasm_exports);
     }
 }
 
@@ -781,7 +781,7 @@ function load(wasm_path, plugins) {
                 memory = obj.instance.exports.memory;
                 wasm_exports = obj.instance.exports;
 
-                set_mem_plugins(plugins);
+                init_plugins_wasm(plugins);
                 obj.instance.exports.main();
             });
     } else {
@@ -792,7 +792,7 @@ function load(wasm_path, plugins) {
                 memory = obj.instance.exports.memory;
                 wasm_exports = obj.instance.exports;
 
-                set_mem_plugins(plugins);
+                init_plugins_wasm(plugins);
                 obj.instance.exports.main();
             });
     }

--- a/native/sapp-wasm/js/gl.js
+++ b/native/sapp-wasm/js/gl.js
@@ -756,19 +756,19 @@ function init_plugins(plugins) {
         return;
 
     for (var i = 0; i < plugins.length; i++) {
-        plugins[i].init(importObject);
+        plugins[i].register_plugin(importObject);
     }
 }
 
-function init_plugins_wasm(plugins) {
+function expose_wasm(plugins) {
     if (plugins == undefined)
         return;
 
     for (var i = 0; i < plugins.length; i++) {
-        plugins[i].init_wasm(memory, wasm_exports);
+        plugins[i].set_wasm_refs(memory, wasm_exports);
     }
 }
-
+    
 
 function load(wasm_path, plugins) {
     var req = fetch(wasm_path);
@@ -781,7 +781,7 @@ function load(wasm_path, plugins) {
                 memory = obj.instance.exports.memory;
                 wasm_exports = obj.instance.exports;
 
-                init_plugins_wasm(plugins);
+                expose_wasm(plugins);
                 obj.instance.exports.main();
             });
     } else {
@@ -792,7 +792,7 @@ function load(wasm_path, plugins) {
                 memory = obj.instance.exports.memory;
                 wasm_exports = obj.instance.exports;
 
-                init_plugins_wasm(plugins);
+                expose_wasm(plugins);
                 obj.instance.exports.main();
             });
     }


### PR DESCRIPTION
Currently it's not possible to use wasm(rust) functions in js plugins. This PR exposes `wasm_exports` into plugins.

