### PR TITLE
Proof of concept for user-owned Context.

### DIFF
--- a/examples/instancing.rs
+++ b/examples/instancing.rs
@@ -141,7 +141,9 @@ impl EventHandler for Stage {
 }
 
 fn main() {
-    miniquad::start(conf::Conf::default(), |ctx| Box::new(Stage::new(ctx)));
+    miniquad::start(conf::Conf::default(), |mut ctx| {
+        UserData::owning(Stage::new(&mut ctx), ctx)
+    });
 }
 
 mod shader {

--- a/examples/offscreen.rs
+++ b/examples/offscreen.rs
@@ -200,7 +200,7 @@ impl EventHandler for Stage {
 }
 
 fn main() {
-    miniquad::start(conf::Conf::default(), |ctx| Box::new(Stage::new(ctx)));
+    miniquad::start(conf::Conf::default(), |mut ctx| UserData::owning(Stage::new(&mut ctx), ctx));
 }
 
 mod display_shader {

--- a/examples/quad.rs
+++ b/examples/quad.rs
@@ -86,7 +86,9 @@ impl EventHandler for Stage {
 }
 
 fn main() {
-    miniquad::start(conf::Conf::default(), |ctx| Box::new(Stage::new(ctx)));
+    miniquad::start(conf::Conf::default(), |mut ctx| {
+        UserData::owning(Stage::new(&mut ctx), ctx)
+    });
 }
 
 mod shader {

--- a/examples/window.rs
+++ b/examples/window.rs
@@ -8,5 +8,5 @@ impl EventHandler for Stage {
 }
 
 fn main() {
-    miniquad::start(conf::Conf::default(), |_| Box::new(Stage));
+    miniquad::start(conf::Conf::default(), |ctx| UserData::owning(Stage, ctx));
 }

--- a/examples/window_free.rs
+++ b/examples/window_free.rs
@@ -1,0 +1,16 @@
+use miniquad::*;
+
+struct Stage {
+    ctx: Context,
+}
+impl EventHandlerFree for Stage {
+    fn update(&mut self) {}
+
+    fn draw(&mut self) {
+        self.ctx.clear(Some((0., 1., 0., 1.)), None, None);
+    }
+}
+
+fn main() {
+    miniquad::start(conf::Conf::default(), |ctx| UserData::free(Stage { ctx }));
+}

--- a/examples/window_owned.rs
+++ b/examples/window_owned.rs
@@ -4,7 +4,9 @@ struct Stage;
 impl EventHandler for Stage {
     fn update(&mut self, _ctx: &mut Context) {}
 
-    fn draw(&mut self, _ctx: &mut Context) {}
+    fn draw(&mut self, ctx: &mut Context) {
+        ctx.clear(Some((0., 1., 0., 1.)), None, None);
+    }
 }
 
 fn main() {

--- a/src/event.rs
+++ b/src/event.rs
@@ -331,6 +331,7 @@ impl From<u32> for TouchPhase {
     }
 }
 
+/// A trait defining event callbacks.
 pub trait EventHandler {
     fn update(&mut self, _ctx: &mut Context);
     fn draw(&mut self, _ctx: &mut Context);
@@ -382,4 +383,28 @@ pub trait EventHandler {
     /// ctx.cancel_quit() to cancel the quit.
     /// If the event is ignored, the application will quit as usual.
     fn quit_requested_event(&mut self, _ctx: &mut Context) {}
+}
+
+/// A trait defining event callbacks.
+/// Used for miniquad's setup with user-owned Context.
+/// The only difference from EventHandler - will not receive "&mut Context"
+pub trait EventHandlerFree {
+    fn update(&mut self);
+    fn draw(&mut self);
+    fn resize_event(&mut self, _width: f32, _height: f32) {}
+    fn mouse_motion_event(&mut self, _x: f32, _y: f32, _dx: f32, _dy: f32) {}
+    fn mouse_wheel_event(&mut self, _x: f32, _y: f32) {}
+    fn mouse_button_down_event(&mut self, _button: MouseButton, _x: f32, _y: f32) {}
+    fn mouse_button_up_event(&mut self, _button: MouseButton, _x: f32, _y: f32) {}
+    fn char_event(&mut self, _character: char, _keymods: KeyMods, _repeat: bool) {}
+    fn key_down_event(&mut self, _keycode: KeyCode, _keymods: KeyMods, _repeat: bool) {}
+    fn key_up_event(&mut self, _keycode: KeyCode, _keymods: KeyMods) {}
+    fn touch_event(&mut self, _phase: TouchPhase, _id: u64, _x: f32, _y: f32) {}
+
+    /// This event is sent when the userclicks the window's close button
+    /// or application code calls the ctx.request_quit() function. The event
+    /// handler callback code can handle this event by calling
+    /// ctx.cancel_quit() to cancel the quit.
+    /// If the event is ignored, the application will quit as usual.
+    fn quit_requested_event(&mut self) {}
 }

--- a/src/graphics.rs
+++ b/src/graphics.rs
@@ -1284,7 +1284,7 @@ pub struct Buffer {
 
 impl Buffer {
     /// Create an immutable buffer resource object.
-    /// ```no_run
+    /// ```ignore
     /// #[repr(C)]
     /// struct Vertex {
     ///     pos: Vec2,

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -89,13 +89,36 @@ impl Context {
     }
 }
 
-struct UserData {
-    event_handler: Box<dyn EventHandler>,
-    context: Context,
+pub enum UserData {
+    Owning((Box<dyn EventHandler>, Context)),
+    Free(Box<dyn EventHandlerFree>),
+}
+
+impl UserData {
+    pub fn owning(event_handler: impl EventHandler + 'static, ctx: Context) -> UserData {
+        UserData::Owning((Box::new(event_handler), ctx))
+    }
+
+    pub fn free(event_handler: impl EventHandlerFree + 'static) -> UserData {
+        UserData::Free(Box::new(event_handler))
+    }
+}
+
+macro_rules! magic_call {
+    ( $event_handler:expr, $fn:ident $(, $args:expr)*) => {{
+        match $event_handler {
+            UserData::Owning((ref mut event_handler, ref mut context)) => {
+                event_handler.$fn(context, $($args,)*);
+            }
+            UserData::Free(ref mut event_handler) => {
+                event_handler.$fn($($args,)*);
+            }
+        }
+    }};
 }
 
 enum UserDataState {
-    Uninitialized(Box<dyn 'static + FnOnce(&mut Context) -> Box<dyn event::EventHandler>>),
+    Uninitialized(Box<dyn 'static + FnOnce(Context) -> UserData>),
     Intialized(UserData),
     Empty,
 }
@@ -112,10 +135,7 @@ extern "C" fn init(user_data: *mut ::std::os::raw::c_void) {
     };
     let mut context = graphics::Context::new();
 
-    let user_data = UserData {
-        event_handler: f(&mut context),
-        context,
-    };
+    let user_data = f(context);
     std::mem::replace(data, UserDataState::Intialized(user_data));
 }
 
@@ -128,8 +148,8 @@ extern "C" fn frame(user_data: *mut ::std::os::raw::c_void) {
         panic!()
     };
 
-    data.event_handler.update(&mut data.context);
-    data.event_handler.draw(&mut data.context);
+    magic_call!(data, update);
+    magic_call!(data, draw);
 }
 
 extern "C" fn event(event: *const sapp::sapp_event, user_data: *mut ::std::os::raw::c_void) {
@@ -144,68 +164,62 @@ extern "C" fn event(event: *const sapp::sapp_event, user_data: *mut ::std::os::r
 
     match event.type_ {
         sapp::sapp_event_type_SAPP_EVENTTYPE_MOUSE_MOVE => {
-            data.event_handler.mouse_motion_event(
-                &mut data.context,
+            magic_call!(
+                data,
+                mouse_motion_event,
                 event.mouse_x,
                 event.mouse_y,
                 0.,
-                0.,
+                0.
             );
         }
         sapp::sapp_event_type_SAPP_EVENTTYPE_MOUSE_SCROLL => {
-            data.event_handler
-                .mouse_wheel_event(&mut data.context, event.scroll_x, event.scroll_y);
+            magic_call!(data, mouse_wheel_event, event.scroll_x, event.scroll_y);
         }
         sapp::sapp_event_type_SAPP_EVENTTYPE_MOUSE_DOWN => {
-            data.event_handler.mouse_button_down_event(
-                &mut data.context,
+            magic_call!(
+                data,
+                mouse_button_down_event,
                 MouseButton::from(event.mouse_button),
                 event.mouse_x,
-                event.mouse_y,
+                event.mouse_y
             );
         }
         sapp::sapp_event_type_SAPP_EVENTTYPE_MOUSE_UP => {
             let btn = MouseButton::from(event.mouse_button);
-            data.event_handler.mouse_button_up_event(
-                &mut data.context,
+            magic_call!(
+                data,
+                mouse_button_up_event,
                 MouseButton::from(event.mouse_button),
                 event.mouse_x,
-                event.mouse_y,
+                event.mouse_y
             );
         }
         sapp::sapp_event_type_SAPP_EVENTTYPE_CHAR => {
             if let Some(character) = std::char::from_u32(event.char_code) {
                 let mut key_mods = KeyMods::from(event.modifiers);
 
-                data.event_handler.char_event(
-                    &mut data.context,
-                    character,
-                    key_mods,
-                    event.key_repeat,
-                )
+                magic_call!(data, char_event, character, key_mods, event.key_repeat)
             }
         }
         sapp::sapp_event_type_SAPP_EVENTTYPE_KEY_DOWN => {
             let keycode = KeyCode::from(event.key_code);
             let mut key_mods = KeyMods::from(event.modifiers);
 
-            data.event_handler
-                .key_down_event(&mut data.context, keycode, key_mods, false)
+            magic_call!(data, key_down_event, keycode, key_mods, false)
         }
         sapp::sapp_event_type_SAPP_EVENTTYPE_KEY_UP => {
             let keycode = KeyCode::from(event.key_code);
             let mut key_mods = KeyMods::from(event.modifiers);
 
-            data.event_handler
-                .key_up_event(&mut data.context, keycode, key_mods)
+            magic_call!(data, key_up_event, keycode, key_mods);
         }
         sapp::sapp_event_type_SAPP_EVENTTYPE_RESIZED => {
-            data.context
-                .resize(event.window_width as u32, event.window_height as u32);
-            data.event_handler.resize_event(
-                &mut data.context,
+            magic_call!(
+                data,
+                resize_event,
                 event.window_width as f32,
-                event.window_height as f32,
+                event.window_height as f32
             );
         }
         sapp::sapp_event_type_SAPP_EVENTTYPE_TOUCHES_BEGAN
@@ -214,18 +228,19 @@ extern "C" fn event(event: *const sapp::sapp_event, user_data: *mut ::std::os::r
         | sapp::sapp_event_type_SAPP_EVENTTYPE_TOUCHES_MOVED => {
             for i in 0..(event.num_touches as usize) {
                 if event.touches[i].changed {
-                    data.event_handler.touch_event(
-                        &mut data.context,
+                    magic_call!(
+                        data,
+                        touch_event,
                         event.type_.into(),
                         event.touches[i].identifier as u64,
                         event.touches[i].pos_x,
-                        event.touches[i].pos_y,
+                        event.touches[i].pos_y
                     );
                 }
             }
         }
         sapp::sapp_event_type_SAPP_EVENTTYPE_QUIT_REQUESTED => {
-            data.event_handler.quit_requested_event(&mut data.context);
+            magic_call!(data, quit_requested_event);
         }
         _ => {}
     }
@@ -233,7 +248,7 @@ extern "C" fn event(event: *const sapp::sapp_event, user_data: *mut ::std::os::r
 
 pub fn start<F>(_conf: conf::Conf, f: F)
 where
-    F: 'static + FnOnce(&mut Context) -> Box<dyn event::EventHandler>,
+    F: 'static + FnOnce(Context) -> UserData,
 {
     let mut desc: sapp::sapp_desc = unsafe { std::mem::zeroed() };
 


### PR DESCRIPTION
The issue this PR address: some libraries built on top of miniquad have their own Context structs. It would be nice to store miniquad's context inside those Contexts, without bothering with updating that reference on each event. 

The problem here - in rust its not possibe to have two mutable references to the same data. 

So, if we have `fn mouse_motion_event(..., ctx: &mut Context)` <- this `&mut Context` should be unique. 

Alternatives:
- use Arc and interior mutability. This will require each event handler to receive Arc<Mutex<_>> of Context instead of `&mut Context`, wich is not so nice. Its not possible to build code generic over thread safety here and this will force wasm single threaded users to use Arc/Mutex and will add some boilerplate.

- use interior mutability, but borrow data before event dispatching. This will keep EventHandler signatures the same. But this will make no sense - it will not be possible to use owned clone of Context without UB inside event handlers.

- Deprecate `&mut Context` references for EventHandler. This will solve most of problems, but API with context reference was quite nice.

This PR makes two options for miniquad initialization:

miniquad-owned context:
```
miniquad::start(conf::Conf::default(), |mut ctx| {
    EventHandler::managed((Stage::new(&mut ctx), ctx))
});
```
Use will get Context, but could move it back to miniquad and later receive in EventHandlder as a reference. Stage will implement old `EventHandler` trait with `&mut Context` argument in each function.

user-owned context:
```
miniquad::start(conf::Conf::default(), |ctx| EventHandler::owned(Stage::new(ctx)));
```
User consume ctx. `Stage` should implement new `EventHandler` trait without `&mut Context` argument.

This safety and correctness is guaranteed on type level, its impossible to implement wrong trait or occasionally store wrong reference. 
But implementation is not really nice. 
Will think a bit about all this. Maybe will just clean up naming in implementation and merge.