### PR TITLE
Mouse capture and relative movement

### DIFF
--- a/native/sapp-darwin/src/sokol_app_darwin.rs
+++ b/native/sapp-darwin/src/sokol_app_darwin.rs
@@ -47,7 +47,8 @@ pub const sapp_event_type_SAPP_EVENTTYPE_SUSPENDED: sapp_event_type = 17;
 pub const sapp_event_type_SAPP_EVENTTYPE_RESUMED: sapp_event_type = 18;
 pub const sapp_event_type_SAPP_EVENTTYPE_UPDATE_CURSOR: sapp_event_type = 19;
 pub const sapp_event_type_SAPP_EVENTTYPE_QUIT_REQUESTED: sapp_event_type = 20;
-pub const sapp_event_type__SAPP_EVENTTYPE_NUM: sapp_event_type = 21;
+pub const sapp_event_type_SAPP_EVENTTYPE_RAW_DEVICE: sapp_event_type = 21;
+pub const sapp_event_type__SAPP_EVENTTYPE_NUM: sapp_event_type = 22;
 pub const sapp_event_type__SAPP_EVENTTYPE_FORCE_U32: sapp_event_type = 2147483647;
 pub type sapp_event_type = u32;
 pub const sapp_keycode_SAPP_KEYCODE_INVALID: sapp_keycode = 0;
@@ -202,6 +203,8 @@ pub struct sapp_event {
     pub mouse_button: sapp_mousebutton,
     pub mouse_x: f32,
     pub mouse_y: f32,
+    pub mouse_dx: f32,
+    pub mouse_dy: f32,
     pub scroll_x: f32,
     pub scroll_y: f32,
     pub num_touches: ::std::os::raw::c_int,

--- a/native/sapp-darwin/src/sokol_app_darwin.rs
+++ b/native/sapp-darwin/src/sokol_app_darwin.rs
@@ -285,6 +285,8 @@ extern "C" {
 extern "C" {
     pub fn sapp_show_mouse(visible: bool);
 }
+pub unsafe extern "C" fn sapp_set_cursor_grab(mut _shown: bool) {}
+
 extern "C" {
     pub fn sapp_mouse_shown() -> bool;
 }

--- a/native/sapp-dummy/src/lib.rs
+++ b/native/sapp-dummy/src/lib.rs
@@ -312,8 +312,10 @@ pub unsafe extern "C" fn sapp_userdata() -> *mut libc::c_void {
 pub unsafe extern "C" fn sapp_mouse_shown() -> bool {
     return false;
 }
+pub unsafe extern "C" fn sapp_set_cursor_grab(mut _grab: bool) {}
 #[no_mangle]
 pub unsafe extern "C" fn sapp_show_mouse(mut shown: bool) {}
+
 #[no_mangle]
 pub unsafe extern "C" fn sapp_keyboard_shown() -> bool {
     false

--- a/native/sapp-dummy/src/lib.rs
+++ b/native/sapp-dummy/src/lib.rs
@@ -19,7 +19,8 @@ pub use rand::*;
 
 pub type sapp_event_type = libc::c_uint;
 pub const sapp_event_type__SAPP_EVENTTYPE_FORCE_U32: sapp_event_type = 2147483647;
-pub const sapp_event_type__SAPP_EVENTTYPE_NUM: sapp_event_type = 21;
+pub const sapp_event_type__SAPP_EVENTTYPE_NUM: sapp_event_type = 22;
+pub const sapp_event_type_SAPP_EVENTTYPE_RAW_DEVICE: sapp_event_type = 21;
 pub const sapp_event_type_SAPP_EVENTTYPE_QUIT_REQUESTED: sapp_event_type = 20;
 pub const sapp_event_type_SAPP_EVENTTYPE_UPDATE_CURSOR: sapp_event_type = 19;
 pub const sapp_event_type_SAPP_EVENTTYPE_RESUMED: sapp_event_type = 18;

--- a/native/sapp-linux/build.rs
+++ b/native/sapp-linux/build.rs
@@ -9,4 +9,5 @@ fn main() {
 
     println!("cargo:rustc-link-lib=dylib=GL");
     println!("cargo:rustc-link-lib=dylib=X11");
+    println!("cargo:rustc-link-lib=dylib=Xi");
 }

--- a/native/sapp-linux/src/lib.rs
+++ b/native/sapp-linux/src/lib.rs
@@ -2721,6 +2721,39 @@ pub unsafe extern "C" fn sapp_userdata() -> *mut libc::c_void {
 pub unsafe extern "C" fn sapp_mouse_shown() -> bool {
     return false;
 }
+
+pub unsafe extern "C" fn sapp_set_cursor_grab(mut grab: bool) {
+    XUngrabPointer(_sapp_x11_display, 0);
+
+    if grab {
+        XGrabPointer(
+            _sapp_x11_display,
+            _sapp_x11_window,
+            true as _,
+            (ButtonPressMask
+                | ButtonReleaseMask
+                | EnterWindowMask
+                | LeaveWindowMask
+                | PointerMotionMask
+                | PointerMotionHintMask
+                | Button1MotionMask
+                | Button2MotionMask
+                | Button3MotionMask
+                | Button4MotionMask
+                | Button5MotionMask
+                | ButtonMotionMask
+                | KeymapStateMask) as libc::c_uint,
+            GrabModeAsync,
+            GrabModeAsync,
+            _sapp_x11_window,
+            0,
+            0, // CurrentTime
+        );
+    }
+
+    XFlush(_sapp_x11_display);
+}
+
 #[no_mangle]
 pub unsafe extern "C" fn sapp_show_mouse(mut shown: bool) {}
 #[no_mangle]

--- a/native/sapp-linux/src/x.rs
+++ b/native/sapp-linux/src/x.rs
@@ -4,20 +4,22 @@ pub use stdlib_h::atof;
 pub use string_h::{memset, strcmp, strlen, strstr};
 pub use XKBlib_h::XkbSetDetectableAutoRepeat;
 pub use X_h::{
-    AllocNone, Atom, ButtonPressMask, ButtonReleaseMask, CWBorderPixel, CWColormap, CWEventMask,
-    Colormap, ControlMask, Cursor, EnterWindowMask, ExposureMask, FocusChangeMask, InputOutput,
-    IsViewable, KeyCode, KeyPressMask, KeyReleaseMask, KeySym, LeaveWindowMask, Mod1Mask, Mod4Mask,
-    Pixmap, PointerMotionMask, PropModeReplace, PropertyChangeMask, PropertyNewValue, ShiftMask,
+    AllocNone, Atom, Button1MotionMask, Button2MotionMask, Button3MotionMask, Button4MotionMask,
+    Button5MotionMask, ButtonMotionMask, ButtonPressMask, ButtonReleaseMask, CWBorderPixel,
+    CWColormap, CWEventMask, Colormap, ControlMask, Cursor, EnterWindowMask, ExposureMask,
+    FocusChangeMask, GrabModeAsync, InputOutput, IsViewable, KeyCode, KeyPressMask, KeyReleaseMask,
+    KeySym, KeymapStateMask, LeaveWindowMask, Mod1Mask, Mod4Mask, Pixmap, PointerMotionHintMask,
+    PointerMotionMask, PropModeReplace, PropertyChangeMask, PropertyNewValue, ShiftMask,
     StaticGravity, StructureNotifyMask, Success, VisibilityChangeMask, Window, XID,
 };
 pub use Xlib_h::{
     Display, Screen, Visual, XChangeProperty, XCloseDisplay, XCreateColormap, XCreateWindow,
     XDestroyWindow, XErrorEvent, XErrorHandler, XEvent, XFlush, XFree, XFreeColormap,
-    XGetKeyboardMapping, XGetWindowAttributes, XGetWindowProperty, XInitThreads, XInternAtom,
-    XKeyEvent, XMapWindow, XNextEvent, XOpenDisplay, XPending, XPointer, XRaiseWindow,
+    XGetKeyboardMapping, XGetWindowAttributes, XGetWindowProperty, XGrabPointer, XInitThreads,
+    XInternAtom, XKeyEvent, XMapWindow, XNextEvent, XOpenDisplay, XPending, XPointer, XRaiseWindow,
     XResourceManagerString, XSelectionEvent, XSelectionRequestEvent, XSetErrorHandler,
-    XSetWMProtocols, XSetWindowAttributes, XSync, XUnmapWindow, XWindowAttributes, XrmInitialize,
-    _XEvent, _XPrivDisplay, _XrmHashBucketRec,
+    XSetWMProtocols, XSetWindowAttributes, XSync, XUngrabPointer, XUnmapWindow, XWindowAttributes,
+    XrmInitialize, _XEvent, _XPrivDisplay, _XrmHashBucketRec,
 };
 pub use Xmd_h::CARD32;
 pub use Xresource_h::{
@@ -781,6 +783,21 @@ pub mod Xlib_h {
         pub fn XFlush(_: *mut Display) -> libc::c_int;
         #[no_mangle]
         pub fn XCloseDisplay(_: *mut Display) -> libc::c_int;
+        #[no_mangle]
+        pub fn XGrabPointer(
+            _: *mut Display,
+            _: Window,
+            _: libc::c_int,
+            _: libc::c_uint,
+            _: libc::c_int,
+            _: libc::c_int,
+            _: Window,
+            _: Cursor,
+            _: Time,
+        ) -> libc::c_int;
+        #[no_mangle]
+        pub fn XUngrabPointer(_: *mut Display, _: Time) -> libc::c_int;
+
     }
 }
 pub mod X_h {
@@ -800,6 +817,17 @@ pub mod X_h {
     pub const KeyPressMask: libc::c_long = (1 as libc::c_long) << 0 as libc::c_int;
     pub const KeyReleaseMask: libc::c_long = (1 as libc::c_long) << 1 as libc::c_int;
     pub const PointerMotionMask: libc::c_long = (1 as libc::c_long) << 6 as libc::c_int;
+    pub const PointerMotionHintMask: libc::c_long = (1 as libc::c_long) << 7 as libc::c_int;
+    pub const Button1MotionMask: libc::c_long = (1 as libc::c_long) << 8 as libc::c_int;
+    pub const Button2MotionMask: libc::c_long = (1 as libc::c_long) << 9 as libc::c_int;
+    pub const Button3MotionMask: libc::c_long = (1 as libc::c_long) << 10 as libc::c_int;
+    pub const Button4MotionMask: libc::c_long = (1 as libc::c_long) << 11 as libc::c_int;
+    pub const Button5MotionMask: libc::c_long = (1 as libc::c_long) << 12 as libc::c_int;
+    pub const ButtonMotionMask: libc::c_long = (1 as libc::c_long) << 13 as libc::c_int;
+    pub const KeymapStateMask: libc::c_long = (1 as libc::c_long) << 14 as libc::c_int;
+
+    pub const GrabModeAsync: libc::c_int = 1 as libc::c_int;
+
     pub const ButtonPressMask: libc::c_long = (1 as libc::c_long) << 2 as libc::c_int;
     pub const ButtonReleaseMask: libc::c_long = (1 as libc::c_long) << 3 as libc::c_int;
     pub const ExposureMask: libc::c_long = (1 as libc::c_long) << 15 as libc::c_int;

--- a/native/sapp-linux/src/x_cursor.rs
+++ b/native/sapp-linux/src/x_cursor.rs
@@ -1,0 +1,82 @@
+use crate::x::{Display, Window};
+use crate::{_sapp_x11_display, _sapp_x11_window};
+
+#[derive(Copy, Clone)]
+#[repr(C)]
+struct XColor {
+    pub pixel: libc::c_ulong,
+    pub red: libc::c_ushort,
+    pub green: libc::c_ushort,
+    pub blue: libc::c_ushort,
+    pub flags: libc::c_char,
+    pub pad: libc::c_char,
+}
+type XID = libc::c_ulong;
+type Pixmap = XID;
+type Drawable = XID;
+
+pub type Cursor = XID;
+
+extern "C" {
+    #[no_mangle]
+    fn XCreateBitmapFromData(
+        _: *mut Display,
+        _: Drawable,
+        _: *const libc::c_char,
+        _: libc::c_uint,
+        _: libc::c_uint,
+    ) -> Pixmap;
+
+    #[no_mangle]
+    fn XCreatePixmapCursor(
+        _: *mut Display,
+        _: Pixmap,
+        _: Pixmap,
+        _: *mut XColor,
+        _: *mut XColor,
+        _: libc::c_uint,
+        _: libc::c_uint,
+    ) -> Cursor;
+
+    #[no_mangle]
+    fn XFreePixmap(_: *mut Display, _: Pixmap) -> libc::c_int;
+
+    #[no_mangle]
+    pub fn XDefineCursor(_: *mut Display, _: Window, _: Cursor) -> libc::c_int;
+}
+
+pub unsafe fn create_empty_cursor() -> Cursor {
+    let mut cursor_color = XColor {
+        pixel: 0 as libc::c_int as libc::c_ulong,
+        red: 0,
+        green: 0,
+        blue: 0,
+        flags: 0,
+        pad: 0,
+    };
+
+    let mut cursor_color_data: [libc::c_char; 1] = [0 as libc::c_int as libc::c_char];
+    let mut cursor_pixmap = XCreateBitmapFromData(
+        _sapp_x11_display,
+        _sapp_x11_window,
+        cursor_color_data.as_mut_ptr(),
+        1 as libc::c_int as libc::c_uint,
+        1 as libc::c_int as libc::c_uint,
+    );
+    let mut empty_cursor = XCreatePixmapCursor(
+        _sapp_x11_display,
+        cursor_pixmap,
+        cursor_pixmap,
+        &mut cursor_color,
+        &mut cursor_color,
+        0 as libc::c_int as libc::c_uint,
+        0 as libc::c_int as libc::c_uint,
+    );
+    XFreePixmap(_sapp_x11_display, cursor_pixmap);
+
+    empty_cursor
+}
+
+pub unsafe fn set_cursor(cursor: Cursor) {
+    XDefineCursor(_sapp_x11_display, _sapp_x11_window, cursor);
+}

--- a/native/sapp-linux/src/xi_input.rs
+++ b/native/sapp-linux/src/xi_input.rs
@@ -1,0 +1,135 @@
+use crate::_sapp_x11_display;
+
+use crate::x::{Display, Window, _XPrivDisplay};
+
+pub const XIAllDevices: libc::c_int = 0 as libc::c_int;
+pub const XI_RawMotion: libc::c_int = 17 as libc::c_int;
+pub const XI_RawMotionMask: libc::c_int = (1 as libc::c_int) << XI_RawMotion;
+
+#[derive(Copy, Clone)]
+#[repr(C)]
+pub struct XIEventMask {
+    pub deviceid: libc::c_int,
+    pub mask_len: libc::c_int,
+    pub mask: *mut libc::c_uchar,
+}
+
+#[derive(Copy, Clone)]
+#[repr(C)]
+pub struct XIValuatorState {
+    pub mask_len: libc::c_int,
+    pub mask: *mut libc::c_uchar,
+    pub values: *mut libc::c_double,
+}
+
+pub type Time = libc::c_ulong;
+
+#[derive(Copy, Clone)]
+#[repr(C)]
+pub struct XIRawEvent {
+    pub type_0: libc::c_int,
+    pub serial: libc::c_ulong,
+    pub send_event: libc::c_int,
+    pub display: *mut Display,
+    pub extension: libc::c_int,
+    pub evtype: libc::c_int,
+    pub time: Time,
+    pub deviceid: libc::c_int,
+    pub sourceid: libc::c_int,
+    pub detail: libc::c_int,
+    pub flags: libc::c_int,
+    pub valuators: XIValuatorState,
+    pub raw_values: *mut libc::c_double,
+}
+
+extern "C" {
+    pub fn XQueryExtension(
+        _: *mut Display,
+        _: *const libc::c_char,
+        _: *mut libc::c_int,
+        _: *mut libc::c_int,
+        _: *mut libc::c_int,
+    ) -> libc::c_int;
+
+    pub fn XIQueryVersion(
+        dpy: *mut Display,
+        major_version_inout: *mut libc::c_int,
+        minor_version_inout: *mut libc::c_int,
+    ) -> libc::c_int;
+
+    pub fn XISelectEvents(
+        dpy: *mut Display,
+        win: Window,
+        masks: *mut XIEventMask,
+        num_masks: libc::c_int,
+    );
+
+    pub fn XGetEventData(
+        _: *mut Display,
+        _: *mut crate::x::Xlib_h::XGenericEventCookie,
+    ) -> libc::c_int;
+    pub fn XFreeEventData(_: *mut Display, _: *mut crate::x::Xlib_h::XGenericEventCookie);
+
+}
+
+fn XISetMask(ptr: *mut (), event: usize) {}
+
+pub unsafe fn query_xi_extension() -> Option<i32> {
+    let mut ev = 0;
+    let mut err = 0;
+    let mut xi_opcode = 0;
+
+    if XQueryExtension(
+        _sapp_x11_display,
+        b"XInputExtension\x00" as *const u8 as *const libc::c_char,
+        &mut xi_opcode,
+        &mut ev,
+        &mut err,
+    ) == 0
+    {
+        return None;
+    }
+
+    // check the version of XInput
+    let mut rc = 0;
+    let mut major = 2;
+    let mut minor = 3;
+    if XIQueryVersion(_sapp_x11_display, &mut major, &mut minor) != 0 {
+        return None;
+    }
+
+    // select events to listen
+    let mut mask = XI_RawMotionMask;
+    let mut masks = XIEventMask {
+        deviceid: XIAllDevices,
+        mask_len: ::std::mem::size_of::<libc::c_int>() as _,
+        mask: &mut mask as *mut _ as *mut _,
+    };
+    XISelectEvents(
+        _sapp_x11_display,
+        // this weird pointers is macro expansion of DefaultRootWindow(_sapp_x11_display)
+        (*(*(_sapp_x11_display as _XPrivDisplay))
+            .screens
+            .offset((*(_sapp_x11_display as _XPrivDisplay)).default_screen as isize))
+        .root,
+        &mut masks,
+        1 as libc::c_int,
+    );
+    return Some(xi_opcode);
+}
+
+/// Get mouse delta from XI_RawMotion's event XGenericEventCookie data
+pub unsafe fn read_cookie(xcookie: &mut crate::x::Xlib_h::XGenericEventCookie) -> (f64, f64) {
+    assert!(xcookie.evtype == crate::xi_input::XI_RawMotion);
+
+    crate::xi_input::XGetEventData(_sapp_x11_display, xcookie);
+
+    let raw_event = (*xcookie).data as *mut crate::xi_input::XIRawEvent;
+
+    let dx = *(*raw_event).raw_values;
+    let dy = *(*raw_event).raw_values.offset(1);
+
+    crate::xi_input::XFreeEventData(_sapp_x11_display, &mut (*xcookie) as *mut _);
+
+    (dx, dy)
+}

--- a/native/sapp-wasm/src/lib.rs
+++ b/native/sapp-wasm/src/lib.rs
@@ -65,7 +65,8 @@ pub const sapp_event_type_SAPP_EVENTTYPE_SUSPENDED: sapp_event_type = 17;
 pub const sapp_event_type_SAPP_EVENTTYPE_RESUMED: sapp_event_type = 18;
 pub const sapp_event_type_SAPP_EVENTTYPE_UPDATE_CURSOR: sapp_event_type = 19;
 pub const sapp_event_type_SAPP_EVENTTYPE_QUIT_REQUESTED: sapp_event_type = 20;
-pub const sapp_event_type__SAPP_EVENTTYPE_NUM: sapp_event_type = 21;
+pub const sapp_event_type_SAPP_EVENTTYPE_RAW_DEVICE: sapp_event_type = 21;
+pub const sapp_event_type__SAPP_EVENTTYPE_NUM: sapp_event_type = 22;
 pub const sapp_event_type__SAPP_EVENTTYPE_FORCE_U32: sapp_event_type = 2147483647;
 
 pub const sapp_keycode_SAPP_KEYCODE_INVALID: sapp_keycode = 0;
@@ -212,6 +213,8 @@ pub struct sapp_event {
     pub mouse_button: sapp_mousebutton,
     pub mouse_x: f32,
     pub mouse_y: f32,
+    pub mouse_dx: f32,
+    pub mouse_dy: f32,
     pub scroll_x: f32,
     pub scroll_y: f32,
     pub num_touches: ::std::os::raw::c_int,

--- a/native/sapp-wasm/src/lib.rs
+++ b/native/sapp-wasm/src/lib.rs
@@ -314,6 +314,13 @@ extern "C" {
     pub fn console_info(msg: *const ::std::os::raw::c_char);
     pub fn console_warn(msg: *const ::std::os::raw::c_char);
     pub fn console_error(msg: *const ::std::os::raw::c_char);
+
+    /// call "requestPointerLock" and "exitPointerLock" internally.
+    /// Will hide cursor and will disable mouse_move events, but instead will
+    /// will make inifinite mouse field for raw_device_input event.
+    /// Notice that this function will works only from "engaging" event callbacks - from
+    /// "mouse_down"/"key_down" event handler functions.    
+    pub fn sapp_set_cursor_grab(grab: bool);
 }
 
 #[no_mangle]
@@ -330,6 +337,18 @@ pub extern "C" fn mouse_move(x: i32, y: i32) {
     event.type_ = sapp_event_type_SAPP_EVENTTYPE_MOUSE_MOVE;
     event.mouse_x = x as f32;
     event.mouse_y = y as f32;
+    unsafe {
+        sapp_context().event(event);
+    }
+}
+
+#[no_mangle]
+pub extern "C" fn raw_mouse_move(dx: i32, dy: i32) {
+    let mut event: sapp_event = unsafe { std::mem::zeroed() };
+
+    event.type_ = sapp_event_type_SAPP_EVENTTYPE_RAW_DEVICE;
+    event.mouse_dx = dx as f32;
+    event.mouse_dy = dy as f32;
     unsafe {
         sapp_context().event(event);
     }

--- a/native/sapp-wasm/src/lib.rs
+++ b/native/sapp-wasm/src/lib.rs
@@ -319,9 +319,12 @@ extern "C" {
     /// Will hide cursor and will disable mouse_move events, but instead will
     /// will make inifinite mouse field for raw_device_input event.
     /// Notice that this function will works only from "engaging" event callbacks - from
-    /// "mouse_down"/"key_down" event handler functions.    
+    /// "mouse_down"/"key_down" event handler functions.
     pub fn sapp_set_cursor_grab(grab: bool);
 }
+
+/// Do nothing on wasm - cursor will be hidden by "sapp_set_cursor_grab" anyway.
+pub fn sapp_show_mouse(_shown: bool) {}
 
 #[no_mangle]
 pub extern "C" fn frame() {

--- a/native/sapp-windows/src/sokol_app_gnu.rs
+++ b/native/sapp-windows/src/sokol_app_gnu.rs
@@ -8434,7 +8434,8 @@ pub const sapp_event_type_SAPP_EVENTTYPE_SUSPENDED: sapp_event_type = 17;
 pub const sapp_event_type_SAPP_EVENTTYPE_RESUMED: sapp_event_type = 18;
 pub const sapp_event_type_SAPP_EVENTTYPE_UPDATE_CURSOR: sapp_event_type = 19;
 pub const sapp_event_type_SAPP_EVENTTYPE_QUIT_REQUESTED: sapp_event_type = 20;
-pub const sapp_event_type__SAPP_EVENTTYPE_NUM: sapp_event_type = 21;
+pub const sapp_event_type_SAPP_EVENTTYPE_RAW_DEVICE: sapp_event_type = 21;
+pub const sapp_event_type__SAPP_EVENTTYPE_NUM: sapp_event_type = 22;
 pub const sapp_event_type__SAPP_EVENTTYPE_FORCE_U32: sapp_event_type = 2147483647;
 pub type sapp_event_type = u32;
 pub const sapp_keycode_SAPP_KEYCODE_INVALID: sapp_keycode = 0;
@@ -8589,6 +8590,8 @@ pub struct sapp_event {
     pub mouse_button: sapp_mousebutton,
     pub mouse_x: f32,
     pub mouse_y: f32,
+    pub mouse_dx: f32,
+    pub mouse_dy: f32,
     pub scroll_x: f32,
     pub scroll_y: f32,
     pub num_touches: ::std::os::raw::c_int,

--- a/native/sapp-windows/src/sokol_app_gnu.rs
+++ b/native/sapp-windows/src/sokol_app_gnu.rs
@@ -8669,6 +8669,7 @@ extern "C" {
 extern "C" {
     pub fn sapp_keyboard_shown() -> bool;
 }
+pub unsafe extern "C" fn sapp_set_cursor_grab(mut _grab: bool) {}
 extern "C" {
     pub fn sapp_show_mouse(visible: bool);
 }

--- a/native/sapp-windows/src/sokol_app_msvc.rs
+++ b/native/sapp-windows/src/sokol_app_msvc.rs
@@ -8624,6 +8624,9 @@ extern "C" {
 extern "C" {
     pub fn sapp_keyboard_shown() -> bool;
 }
+
+pub unsafe extern "C" fn sapp_set_cursor_grab(mut _grab: bool) {}
+
 extern "C" {
     pub fn sapp_show_mouse(visible: bool);
 }

--- a/native/sapp-windows/src/sokol_app_msvc.rs
+++ b/native/sapp-windows/src/sokol_app_msvc.rs
@@ -8389,7 +8389,8 @@ pub const sapp_event_type_SAPP_EVENTTYPE_SUSPENDED: sapp_event_type = 17;
 pub const sapp_event_type_SAPP_EVENTTYPE_RESUMED: sapp_event_type = 18;
 pub const sapp_event_type_SAPP_EVENTTYPE_UPDATE_CURSOR: sapp_event_type = 19;
 pub const sapp_event_type_SAPP_EVENTTYPE_QUIT_REQUESTED: sapp_event_type = 20;
-pub const sapp_event_type__SAPP_EVENTTYPE_NUM: sapp_event_type = 21;
+pub const sapp_event_type_SAPP_EVENTTYPE_RAW_DEVICE: sapp_event_type = 21;
+pub const sapp_event_type__SAPP_EVENTTYPE_NUM: sapp_event_type = 22;
 pub const sapp_event_type__SAPP_EVENTTYPE_FORCE_U32: sapp_event_type = 2147483647;
 pub type sapp_event_type = u32;
 pub const sapp_keycode_SAPP_KEYCODE_INVALID: sapp_keycode = 0;
@@ -8544,6 +8545,8 @@ pub struct sapp_event {
     pub mouse_button: sapp_mousebutton,
     pub mouse_x: f32,
     pub mouse_y: f32,
+    pub mouse_dx: f32,
+    pub mouse_dy: f32,
     pub scroll_x: f32,
     pub scroll_y: f32,
     pub num_touches: ::std::os::raw::c_int,

--- a/src/event.rs
+++ b/src/event.rs
@@ -336,7 +336,7 @@ pub trait EventHandler {
     fn update(&mut self, _ctx: &mut Context);
     fn draw(&mut self, _ctx: &mut Context);
     fn resize_event(&mut self, _ctx: &mut Context, _width: f32, _height: f32) {}
-    fn mouse_motion_event(&mut self, _ctx: &mut Context, _x: f32, _y: f32, _dx: f32, _dy: f32) {}
+    fn mouse_motion_event(&mut self, _ctx: &mut Context, _x: f32, _y: f32) {}
     fn mouse_wheel_event(&mut self, _ctx: &mut Context, _x: f32, _y: f32) {}
     fn mouse_button_down_event(
         &mut self,
@@ -374,8 +374,12 @@ pub trait EventHandler {
     }
 
     fn key_up_event(&mut self, _ctx: &mut Context, _keycode: KeyCode, _keymods: KeyMods) {}
-
     fn touch_event(&mut self, _ctx: &mut Context, _phase: TouchPhase, _id: u64, _x: f32, _y: f32) {}
+
+    /// Represents raw hardware mouse motion event
+    /// Note that these events are delivered regardless of input focus and not in pixels, but in
+    /// hardware units instead. And those units may be different from pixels depending on the target platform
+    fn raw_mouse_motion(&mut self, _ctx: &mut Context, _dx: f32, _dy: f32) {}
 
     /// This event is sent when the userclicks the window's close button
     /// or application code calls the ctx.request_quit() function. The event
@@ -392,7 +396,7 @@ pub trait EventHandlerFree {
     fn update(&mut self);
     fn draw(&mut self);
     fn resize_event(&mut self, _width: f32, _height: f32) {}
-    fn mouse_motion_event(&mut self, _x: f32, _y: f32, _dx: f32, _dy: f32) {}
+    fn mouse_motion_event(&mut self, _x: f32, _y: f32) {}
     fn mouse_wheel_event(&mut self, _x: f32, _y: f32) {}
     fn mouse_button_down_event(&mut self, _button: MouseButton, _x: f32, _y: f32) {}
     fn mouse_button_up_event(&mut self, _button: MouseButton, _x: f32, _y: f32) {}
@@ -400,6 +404,11 @@ pub trait EventHandlerFree {
     fn key_down_event(&mut self, _keycode: KeyCode, _keymods: KeyMods, _repeat: bool) {}
     fn key_up_event(&mut self, _keycode: KeyCode, _keymods: KeyMods) {}
     fn touch_event(&mut self, _phase: TouchPhase, _id: u64, _x: f32, _y: f32) {}
+
+    /// Represents raw hardware mouse motion event
+    /// Note that these events are delivered regardless of input focus and not in pixels, but in
+    /// hardware units instead. And those units may be different from pixels depending on the target platform
+    fn raw_mouse_motion(&mut self, _dx: f32, _dy: f32) {}
 
     /// This event is sent when the userclicks the window's close button
     /// or application code calls the ctx.request_quit() function. The event

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -87,9 +87,22 @@ impl Context {
         }
     }
 
+    /// Capture mouse cursor to the current window
+    /// On WASM this will automatically hide cursor
+    /// On desktop this will bound cursor to windows border
+    /// NOTICE: on desktop cursor will not be automatically released after window lost focus
+    ///         so set_cursor_grab(false) on window's focus lost is recommended.
+    /// TODO: implement window focus events
     pub fn set_cursor_grab(&self, grab: bool) {
         unsafe {
             sapp::sapp_set_cursor_grab(grab);
+        }
+    }
+
+    /// Show or hide the mouse cursor
+    pub fn show_mouse(&self, shown: bool) {
+        unsafe {
+            sapp::sapp_show_mouse(shown);
         }
     }
 }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -164,14 +164,7 @@ extern "C" fn event(event: *const sapp::sapp_event, user_data: *mut ::std::os::r
 
     match event.type_ {
         sapp::sapp_event_type_SAPP_EVENTTYPE_MOUSE_MOVE => {
-            event_call!(
-                data,
-                mouse_motion_event,
-                event.mouse_x,
-                event.mouse_y,
-                0.,
-                0.
-            );
+            event_call!(data, mouse_motion_event, event.mouse_x, event.mouse_y);
         }
         sapp::sapp_event_type_SAPP_EVENTTYPE_MOUSE_SCROLL => {
             event_call!(data, mouse_wheel_event, event.scroll_x, event.scroll_y);
@@ -240,6 +233,9 @@ extern "C" fn event(event: *const sapp::sapp_event, user_data: *mut ::std::os::r
         }
         sapp::sapp_event_type_SAPP_EVENTTYPE_QUIT_REQUESTED => {
             event_call!(data, quit_requested_event);
+        }
+        sapp::sapp_event_type_SAPP_EVENTTYPE_RAW_DEVICE => {
+            event_call!(data, raw_mouse_motion, event.mouse_dx, event.mouse_dy);
         }
         _ => {}
     }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -86,6 +86,12 @@ impl Context {
             sapp::sapp_cancel_quit();
         }
     }
+
+    pub fn set_cursor_grab(&self, grab: bool) {
+        unsafe {
+            sapp::sapp_set_cursor_grab(grab);
+        }
+    }
 }
 
 pub enum UserData {


### PR DESCRIPTION
Related issue: https://github.com/not-fl3/miniquad/issues/26 

It works for linux and wasm
But for linux it required linking with an additional library: libXi - library for the X Input Extension. 

Need to think about how bad it is. If libXi is not preinstalled on Ubuntu - it will be a problem. 