### PR TITLE
Emulate mouse click from touch events

### DIFF
--- a/src/event.rs
+++ b/src/event.rs
@@ -374,7 +374,17 @@ pub trait EventHandler {
     }
 
     fn key_up_event(&mut self, _ctx: &mut Context, _keycode: KeyCode, _keymods: KeyMods) {}
-    fn touch_event(&mut self, _ctx: &mut Context, _phase: TouchPhase, _id: u64, _x: f32, _y: f32) {}
+
+    /// Default implementation emulates mouse clicks
+    fn touch_event(&mut self, ctx: &mut Context, phase: TouchPhase, _id: u64, x: f32, y: f32) {
+        if phase == TouchPhase::Started {
+            self.mouse_button_down_event(ctx, MouseButton::Left, x, y);
+        }
+
+        if phase == TouchPhase::Ended {
+            self.mouse_button_up_event(ctx, MouseButton::Left, x, y);
+        }
+    }
 
     /// Represents raw hardware mouse motion event
     /// Note that these events are delivered regardless of input focus and not in pixels, but in
@@ -403,7 +413,17 @@ pub trait EventHandlerFree {
     fn char_event(&mut self, _character: char, _keymods: KeyMods, _repeat: bool) {}
     fn key_down_event(&mut self, _keycode: KeyCode, _keymods: KeyMods, _repeat: bool) {}
     fn key_up_event(&mut self, _keycode: KeyCode, _keymods: KeyMods) {}
-    fn touch_event(&mut self, _phase: TouchPhase, _id: u64, _x: f32, _y: f32) {}
+
+    /// Default implementation emulates mouse clicks
+    fn touch_event(&mut self, phase: TouchPhase, _id: u64, x: f32, y: f32) {
+        if phase == TouchPhase::Started {
+            self.mouse_button_down_event(MouseButton::Left, x, y);
+        }
+
+        if phase == TouchPhase::Ended {
+            self.mouse_button_up_event(MouseButton::Left, x, y);
+        }
+    }
 
     /// Represents raw hardware mouse motion event
     /// Note that these events are delivered regardless of input focus and not in pixels, but in


### PR DESCRIPTION
Browsers automatically call mouse events from touch events: https://developer.mozilla.org/en-US/docs/Web/API/Touch_events
But android does not.

With this change on browsers automatical mouse events are disabled with "preventDefault", but the default "touch_event" implementation will call "mouse_down_event"/"mouse_up_event".

After this change API and events, behaviors will be the same in browsers and androids.