### PR TITLE
Fix link to macroquad from Readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -13,7 +13,7 @@ For higher level API take a look on:
 
 [good-web-game](https://github.com/not-fl3/good-web-game): implementation of some [ggez](https://github.com/ggez/ggez) subset on top of miniquad, made as compatibility layer to run ggez games on wasm
 
-[macroquad](github.com/not-fl3/macroquad/): raylib-like library on top of miniquad. [100loc arkanoid with macroquad](https://github.com/not-fl3/macroquad/blob/master/examples/arkanoid.rs)
+[macroquad](https://github.com/not-fl3/macroquad): raylib-like library on top of miniquad. [100loc arkanoid with macroquad](https://github.com/not-fl3/macroquad/blob/master/examples/arkanoid.rs)
 
 ## Supported platforms
 


### PR DESCRIPTION
`github.com/not-fl3/macroquad` actually redirects to `https://github.com/not-fl3/miniquad/blob/master/github.com/not-fl3/macroquad` which is a wrong link