### PR TITLE
Pipeline::with_parms(): added assertion to catch vertex attribute stride above 255 ASAP (WebGL 1 limitation)

### DIFF
--- a/src/graphics.rs
+++ b/src/graphics.rs
@@ -962,6 +962,8 @@ impl Pipeline {
             } else {
                 cache.stride = layout.stride;
             }
+            // WebGL 1 limitation
+            assert!(cache.stride <= 255);
         }
 
         let program = ctx.shaders[shader.0].program;


### PR DESCRIPTION
I imagine it is nicer to be able to catch this in native build instead of debugging WebGL-one