### PR TITLE
Implement color mask

### DIFF
--- a/native/sapp-wasm/js/gl.js
+++ b/native/sapp-wasm/js/gl.js
@@ -431,6 +431,9 @@ var importObject = {
         glClearStencil: function (s) {
             gl.clearColorStencil(s);
         },
+        glColorMask: function (red, green, blue, alpha) {
+            gl.colorMask(red, green, blue, alpha);
+        },
         glScissor: function (x, y, w, h) {
             gl.scissor(x, y, w, h);
         },

--- a/native/sapp-windows/external/sokol/sokol_app.h
+++ b/native/sapp-windows/external/sokol/sokol_app.h
@@ -3369,6 +3369,9 @@ void glDisable(GLenum cap) {
 }
 typedef void  (GL_APIENTRY *PFN_glColorMask)(GLboolean red, GLboolean green, GLboolean blue, GLboolean alpha);
 static PFN_glColorMask _sapp_glColorMask;
+void glColorMask(GLboolean red, GLboolean green, GLboolean blue, GLboolean alpha) {
+    _sapp_glColorMask(red, green, blue, alpha);
+}
 typedef void  (GL_APIENTRY *PFN_glBindBuffer)(GLenum target, GLuint buffer);
 static PFN_glBindBuffer _sapp_glBindBuffer;
 void glBindBuffer(GLenum target, GLuint buffer) {

--- a/native/sapp-windows/src/sokol_app_gnu.rs
+++ b/native/sapp-windows/src/sokol_app_gnu.rs
@@ -42469,6 +42469,9 @@ pub type PFN_glColorMask = ::std::option::Option<
 extern "C" {
     pub static mut _sapp_glColorMask: PFN_glColorMask;
 }
+extern "C" {
+    pub fn glColorMask(red: GLboolean, green: GLboolean, blue: GLboolean, alpha: GLboolean);
+}
 pub type PFN_glBindBuffer =
     ::std::option::Option<unsafe extern "C" fn(target: GLenum, buffer: GLuint)>;
 extern "C" {

--- a/native/sapp-windows/src/sokol_app_msvc.rs
+++ b/native/sapp-windows/src/sokol_app_msvc.rs
@@ -42378,6 +42378,9 @@ pub type PFN_glColorMask = ::std::option::Option<
 extern "C" {
     pub static mut _sapp_glColorMask: PFN_glColorMask;
 }
+extern "C" {
+    pub fn glColorMask(red: GLboolean, green: GLboolean, blue: GLboolean, alpha: GLboolean);
+}
 pub type PFN_glBindBuffer =
     ::std::option::Option<unsafe extern "C" fn(target: GLenum, buffer: GLuint)>;
 extern "C" {

--- a/src/graphics.rs
+++ b/src/graphics.rs
@@ -220,6 +220,7 @@ struct ShaderInternal {
 }
 
 type BlendState = Option<(Equation, BlendFactor, BlendFactor)>;
+type ColorMask = (bool, bool, bool, bool);
 
 #[derive(Default, Copy, Clone)]
 struct CachedAttribute {
@@ -236,6 +237,7 @@ struct GlCache {
     textures: [GLuint; MAX_SHADERSTAGE_IMAGES],
     cur_pipeline: Option<Pipeline>,
     blend: BlendState,
+    color_write: ColorMask,
     attributes: [Option<CachedAttribute>; MAX_VERTEX_ATTRIBUTES],
 }
 
@@ -422,6 +424,7 @@ impl Context {
                     vertex_buffer: 0,
                     cur_pipeline: None,
                     blend: None,
+                    color_write: (true, true, true, true),
                     stored_texture: 0,
                     textures: [0; MAX_SHADERSTAGE_IMAGES],
                     attributes: [None; MAX_VERTEX_ATTRIBUTES],
@@ -488,6 +491,12 @@ impl Context {
 
                 self.cache.blend = pipeline.params.color_blend;
             }
+        }
+
+        if self.cache.color_write != pipeline.params.color_write {
+            let (r, g, b, a) = pipeline.params.color_write;
+            unsafe { glColorMask(r as _, g as _, b as _, a as _) }
+            self.cache.color_write = pipeline.params.color_write;
         }
     }
 
@@ -900,7 +909,7 @@ pub struct PipelineParams {
     pub depth_write: bool,
     pub depth_write_offset: Option<(f32, f32)>,
     pub color_blend: BlendState,
-    pub color_write: (bool, bool, bool, bool),
+    pub color_write: ColorMask,
 }
 
 #[derive(Copy, Clone, Debug)]


### PR DESCRIPTION
Actually use `color_write` field of PipelineParams for masking pipeline channels