### PR TITLE
Fix WASM glStencil...() functions

### DIFF
--- a/native/sapp-wasm/js/gl.js
+++ b/native/sapp-wasm/js/gl.js
@@ -695,13 +695,13 @@ var importObject = {
             GL.shaders[id] = gl.createShader(shaderType);
             return id;
         },
-        stencilFuncSeparate: function (face, func, ref_, mask) {
+        glStencilFuncSeparate: function (face, func, ref_, mask) {
             gl.glStencilFuncSeparate(face, func, ref_, mask);
         },
-        stencilMaskSeparate: function (face, mask) {
+        glStencilMaskSeparate: function (face, mask) {
             gl.glStencilMaskSeparate(face, mask);
         },
-        stencilOpSeparate: function (face, fail, zfail, zpass) {
+        glStencilOpSeparate: function (face, fail, zfail, zpass) {
             gl.glStencilOpSeparate(face, fail, zfail, zpass);
         },
         glShaderSource: function (shader, count, string, length) {


### PR DESCRIPTION
hmm, I forgot to copy the gl.js from my running folder back to sapp-wasm/js/gl.js.

Just re-tested WASM from clean branch and it failed. This is the fix.

Wondering if there's a way to add something else to GitHub actions to ensure samples will fail in case of issues like the one below.

**Edit:** or maybe we treat these type of issues as one-off and I'll be more careful next time.