### PR TITLE
Support front face/cull face operations

### DIFF
--- a/native/sapp-wasm/js/gl.js
+++ b/native/sapp-wasm/js/gl.js
@@ -696,13 +696,19 @@ var importObject = {
             return id;
         },
         glStencilFuncSeparate: function (face, func, ref_, mask) {
-            gl.glStencilFuncSeparate(face, func, ref_, mask);
+            gl.stencilFuncSeparate(face, func, ref_, mask);
         },
         glStencilMaskSeparate: function (face, mask) {
-            gl.glStencilMaskSeparate(face, mask);
+            gl.stencilMaskSeparate(face, mask);
         },
         glStencilOpSeparate: function (face, fail, zfail, zpass) {
-            gl.glStencilOpSeparate(face, fail, zfail, zpass);
+            gl.stencilOpSeparate(face, fail, zfail, zpass);
+        },
+        glFrontFace: function (mode) {
+            gl.frontFace(mode);
+        },
+        glCullFace: function (mode) {
+            gl.cullFace(mode);
         },
         glShaderSource: function (shader, count, string, length) {
             GL.validateGLObjectID(GL.shaders, shader, 'glShaderSource', 'shader');

--- a/native/sapp-windows/external/sokol/sokol_app.h
+++ b/native/sapp-windows/external/sokol/sokol_app.h
@@ -3533,8 +3533,14 @@ void glGenVertexArrays(GLsizei n, GLuint * arrays) {
 }
 typedef void  (GL_APIENTRY *PFN_glFrontFace)(GLenum mode);
 static PFN_glFrontFace _sapp_glFrontFace;
+void glFrontFace(GLenum mode) {
+    _sapp_glFrontFace(mode);
+}
 typedef void  (GL_APIENTRY *PFN_glCullFace)(GLenum mode);
 static PFN_glCullFace _sapp_glCullFace;
+void glCullFace(GLenum mode) {
+    _sapp_glCullFace(mode);
+}
 
 _SOKOL_PRIVATE void* _sapp_win32_glgetprocaddr(const char* name) {
     void* proc_addr = (void*) _sapp_wglGetProcAddress(name);

--- a/native/sapp-windows/src/sokol_app_gnu.rs
+++ b/native/sapp-windows/src/sokol_app_gnu.rs
@@ -42790,9 +42790,15 @@ pub type PFN_glFrontFace = ::std::option::Option<unsafe extern "C" fn(mode: GLen
 extern "C" {
     pub static mut _sapp_glFrontFace: PFN_glFrontFace;
 }
+extern "C" {
+    pub fn glFrontFace(mode: GLenum);
+}
 pub type PFN_glCullFace = ::std::option::Option<unsafe extern "C" fn(mode: GLenum)>;
 extern "C" {
     pub static mut _sapp_glCullFace: PFN_glCullFace;
+}
+extern "C" {
+    pub fn glCullFace(mode: GLenum);
 }
 pub type __builtin_va_list = *mut ::std::os::raw::c_char;
 #[repr(C)]

--- a/native/sapp-windows/src/sokol_app_msvc.rs
+++ b/native/sapp-windows/src/sokol_app_msvc.rs
@@ -42699,9 +42699,15 @@ pub type PFN_glFrontFace = ::std::option::Option<unsafe extern "C" fn(mode: GLen
 extern "C" {
     pub static mut _sapp_glFrontFace: PFN_glFrontFace;
 }
+extern "C" {
+    pub fn glFrontFace(mode: GLenum);
+}
 pub type PFN_glCullFace = ::std::option::Option<unsafe extern "C" fn(mode: GLenum)>;
 extern "C" {
     pub static mut _sapp_glCullFace: PFN_glCullFace;
+}
+extern "C" {
+    pub fn glCullFace(mode: GLenum);
 }
 pub type __builtin_va_list = *mut ::std::os::raw::c_char;
 #[repr(C)]

--- a/src/graphics.rs
+++ b/src/graphics.rs
@@ -599,15 +599,6 @@ impl Context {
                 }
             }
 
-            match pipeline.params.front_face_order {
-                FrontFaceOrder::Clockwise => unsafe {
-                    glFrontFace(GL_CW);
-                },
-                FrontFaceOrder::CounterClockwise => unsafe {
-                    glFrontFace(GL_CCW);
-                },
-            }
-
             match pipeline.params.cull_face {
                 CullFace::Nothing => unsafe {
                     glDisable(GL_CULL_FACE);
@@ -619,6 +610,15 @@ impl Context {
                 CullFace::Back => unsafe {
                     glEnable(GL_CULL_FACE);
                     glCullFace(GL_BACK);
+                },
+            }
+
+            match pipeline.params.front_face_order {
+                FrontFaceOrder::Clockwise => unsafe {
+                    glFrontFace(GL_CW);
+                },
+                FrontFaceOrder::CounterClockwise => unsafe {
+                    glFrontFace(GL_CCW);
                 },
             }
         }

--- a/src/graphics.rs
+++ b/src/graphics.rs
@@ -598,6 +598,29 @@ impl Context {
                     glDisable(GL_DEPTH_TEST);
                 }
             }
+
+            match pipeline.params.front_face_order {
+                FrontFaceOrder::Clockwise => unsafe {
+                    glFrontFace(GL_CW);
+                },
+                FrontFaceOrder::CounterClockwise => unsafe {
+                    glFrontFace(GL_CCW);
+                },
+            }
+
+            match pipeline.params.cull_face {
+                CullFace::Nothing => unsafe {
+                    glDisable(GL_CULL_FACE);
+                },
+                CullFace::Front => unsafe {
+                    glEnable(GL_CULL_FACE);
+                    glCullFace(GL_FRONT);
+                },
+                CullFace::Back => unsafe {
+                    glEnable(GL_CULL_FACE);
+                    glCullFace(GL_BACK);
+                },
+            }
         }
 
         if self.cache.blend != self.pipelines[pipeline.0].params.color_blend {


### PR DESCRIPTION
Verified 
```
cargo run --example quad
```
and 
```
cargo build --example quad --target wasm32-unknown-unknown
``` 
then run quad in browser and see quads. With properly copying gl.js to examples folder :)