### PR TITLE
fixed shader link errors causing "MALFORMED ERROR MESSAGE"

### DIFF
--- a/src/graphics.rs
+++ b/src/graphics.rs
@@ -957,9 +957,14 @@ fn load_shader_internal(
                 &mut max_length as *mut _,
                 error_message.as_mut_ptr() as *mut _,
             );
+            // trim trailing zeros
+            while error_message.last().copied() == Some(0) {
+                error_message.pop();
+            }
 
             let error_message = std::string::String::from_utf8_lossy(&error_message);
-            panic!("{}", error_message);
+            eprintln!("Shader link error:\n{}", error_message);
+            panic!("can't link shader");
         }
 
         glUseProgram(program);
@@ -1012,6 +1017,10 @@ pub fn load_shader(shader_type: GLenum, source: &str) -> GLuint {
                 &mut max_length as *mut _,
                 error_message.as_mut_ptr() as *mut _,
             );
+            // trim trailing zeros
+            while error_message.last().copied() == Some(0) {
+                error_message.pop();
+            }
 
             #[cfg(target_arch = "wasm32")]
             console_log(error_message.as_ptr() as *const _);


### PR DESCRIPTION
I have got this when I exceeded limit of varying vectors, and this is reported during shader linking (some Apple Laptop with Intel UHD Graphics 630 got only 15 MAX_VARYING_VECTORS).
I did not test anything except for my project.

To clarify, when using eprintln! instead of panic!, the error was "data provided contains a nul byte".