### PR TITLE
RenderPass::delete

### DIFF
--- a/examples/post_processing.rs
+++ b/examples/post_processing.rs
@@ -217,7 +217,7 @@ impl EventHandler for Stage {
         ctx.begin_default_pass(PassAction::Nothing);
         ctx.apply_pipeline(&self.post_processing_pipeline);
         ctx.apply_bindings(&self.post_processing_bind);
-        ctx.draw(0, 36, 1);
+        ctx.draw(0, 6, 1);
         ctx.end_render_pass();
         ctx.commit_frame();
     }

--- a/examples/post_processing.rs
+++ b/examples/post_processing.rs
@@ -99,7 +99,7 @@ impl Stage {
             post_processing_shader::META,
         );
 
-        let post_processing_pipeline = Pipeline::with_params(
+        let post_processing_pipeline = Pipeline::new(
             ctx,
             &[BufferLayout::default()],
             &[
@@ -107,11 +107,6 @@ impl Stage {
                 VertexAttribute::new("uv", VertexFormat::Float2),
             ],
             default_shader,
-            PipelineParams {
-                depth_test: Comparison::LessOrEqual,
-                depth_write: true,
-                ..Default::default()
-            },
         );
 
         let offscreen_shader = Shader::new(
@@ -209,7 +204,7 @@ impl EventHandler for Stage {
         // the offscreen pass, rendering an rotating, untextured cube into a render target image
         ctx.begin_pass(
             self.offscreen_pass,
-            PassAction::clear_color(1.0, 1.0, 1.0, 1.),
+            PassAction::clear_color(1.0, 1.0, 1.0, 1.0),
         );
         ctx.apply_pipeline(&self.offscreen_pipeline);
         ctx.apply_bindings(&self.offscreen_bind);
@@ -219,10 +214,9 @@ impl EventHandler for Stage {
 
         // and the post-processing-pass, rendering a rotating, textured cube, using the
         // previously rendered offscreen render-target as texture
-        ctx.begin_default_pass(PassAction::clear_color(0.0, 0., 0.45, 1.));
+        ctx.begin_default_pass(PassAction::Nothing);
         ctx.apply_pipeline(&self.post_processing_pipeline);
         ctx.apply_bindings(&self.post_processing_bind);
-        ctx.apply_uniforms(&vs_params);
         ctx.draw(0, 36, 1);
         ctx.end_render_pass();
         ctx.commit_frame();

--- a/examples/post_processing.rs
+++ b/examples/post_processing.rs
@@ -183,8 +183,6 @@ impl EventHandler for Stage {
 
         self.offscreen_pass.delete(ctx);
         self.offscreen_pass = offscreen_pass;
-
-        self.post_processing_bind.images[0].delete();
         self.post_processing_bind.images[0] = color_img;
     }
 

--- a/native/sapp-wasm/js/gl.js
+++ b/native/sapp-wasm/js/gl.js
@@ -811,6 +811,20 @@ var importObject = {
                 GL.buffers[id] = null;
             }
         },
+        glDeleteFramebuffers: function (n, buffers) {
+            for (var i = 0; i < n; i++) {
+                var id = getArray(buffers + i * 4, Uint32Array, 1)[0];
+                var buffer = GL.framebuffers[id];
+
+                // From spec: "glDeleteFrameBuffers silently ignores 0's and names that do not
+                // correspond to existing buffer objects."
+                if (!buffer) continue;
+
+                gl.deleteFrameBuffer(buffer);
+                buffer.name = 0;
+                GL.framebuffers[id] = null;
+            }
+        },
         glDeleteTextures: function (n, textures) {
             for (var i = 0; i < n; i++) {
                 var id = getArray(textures + i * 4, Uint32Array, 1)[0];

--- a/native/sapp-wasm/js/gl.js
+++ b/native/sapp-wasm/js/gl.js
@@ -820,7 +820,7 @@ var importObject = {
                 // correspond to existing buffer objects."
                 if (!buffer) continue;
 
-                gl.deleteFrameBuffer(buffer);
+                gl.deleteFramebuffer(buffer);
                 buffer.name = 0;
                 GL.framebuffers[id] = null;
             }

--- a/native/sapp-windows/external/sokol/sokol_app.h
+++ b/native/sapp-windows/external/sokol/sokol_app.h
@@ -3283,6 +3283,10 @@ void glDrawElements(GLenum mode, GLsizei count, GLenum type, const void * indice
 }
 typedef void  (GL_APIENTRY *PFN_glDeleteFramebuffers)(GLsizei n, const GLuint * framebuffers);
 static PFN_glDeleteFramebuffers _sapp_glDeleteFramebuffers;
+void glDeleteFramebuffers(GLsizei n, const GLuint * buffers) {
+    _sapp_glDeleteFramebuffers(n, buffers);
+}
+static PFN_glDeleteFramebuffers _sapp_glDeleteFramebuffers;
 typedef void  (GL_APIENTRY *PFN_glBlendEquationSeparate)(GLenum modeRGB, GLenum modeAlpha);
 static PFN_glBlendEquationSeparate _sapp_glBlendEquationSeparate;
 typedef void  (GL_APIENTRY *PFN_glBlendEquationSeparate)(GLenum modeRGB, GLenum modeAlpha);

--- a/native/sapp-windows/src/sokol_app_gnu.rs
+++ b/native/sapp-windows/src/sokol_app_gnu.rs
@@ -42259,6 +42259,12 @@ pub type PFN_glDeleteFramebuffers =
 extern "C" {
     pub static mut _sapp_glDeleteFramebuffers: PFN_glDeleteFramebuffers;
 }
+extern "C" {
+    pub fn glDeleteFramebuffers(
+        n: GLsizei,
+        buffers: *const GLuint,
+    );
+}
 pub type PFN_glBlendEquationSeparate =
     ::std::option::Option<unsafe extern "C" fn(modeRGB: GLenum, modeAlpha: GLenum)>;
 extern "C" {

--- a/native/sapp-windows/src/sokol_app_msvc.rs
+++ b/native/sapp-windows/src/sokol_app_msvc.rs
@@ -42168,6 +42168,12 @@ pub type PFN_glDeleteFramebuffers =
 extern "C" {
     pub static mut _sapp_glDeleteFramebuffers: PFN_glDeleteFramebuffers;
 }
+extern "C" {
+    pub fn glDeleteFramebuffers(
+        n: GLsizei,
+        buffers: *const GLuint,
+    );
+}
 pub type PFN_glBlendEquationSeparate =
     ::std::option::Option<unsafe extern "C" fn(modeRGB: GLenum, modeAlpha: GLenum)>;
 extern "C" {

--- a/src/graphics.rs
+++ b/src/graphics.rs
@@ -468,6 +468,7 @@ pub struct RenderPass(usize);
 struct RenderPassInternal {
     gl_fb: GLuint,
     texture: Texture,
+    depth_texture: Option<Texture>,
 }
 
 impl RenderPass {
@@ -477,6 +478,8 @@ impl RenderPass {
         depth_img: impl Into<Option<Texture>>,
     ) -> RenderPass {
         let mut gl_fb = 0;
+
+        let depth_img = depth_img.into();
 
         unsafe {
             glGenFramebuffers(1, &mut gl_fb as *mut _);
@@ -488,7 +491,7 @@ impl RenderPass {
                 color_img.texture,
                 0,
             );
-            if let Some(depth_img) = depth_img.into() {
+            if let Some(depth_img) = depth_img {
                 glFramebufferTexture2D(
                     GL_FRAMEBUFFER,
                     GL_DEPTH_ATTACHMENT,
@@ -502,6 +505,7 @@ impl RenderPass {
         let pass = RenderPassInternal {
             gl_fb,
             texture: color_img,
+            depth_texture: depth_img
         };
 
         context.passes.push(pass);
@@ -514,6 +518,11 @@ impl RenderPass {
 
         unsafe {
             glDeleteFramebuffers(1, &mut render_pass.gl_fb as *mut _)
+        }
+
+        render_pass.texture.delete();
+        if let Some(depth_texture) = render_pass.depth_texture {
+            depth_texture.delete();
         }
     }
 }

--- a/src/graphics.rs
+++ b/src/graphics.rs
@@ -508,6 +508,14 @@ impl RenderPass {
 
         RenderPass(context.passes.len() - 1)
     }
+
+    pub fn delete(&self, ctx: &mut Context) {
+        let render_pass = &mut ctx.passes[self.0];
+
+        unsafe {
+            glDeleteFramebuffers(1, &mut render_pass.gl_fb as *mut _)
+        }
+    }
 }
 
 pub const MAX_VERTEX_ATTRIBUTES: usize = 16;

--- a/src/graphics/texture.rs
+++ b/src/graphics/texture.rs
@@ -200,6 +200,35 @@ impl Texture {
         ctx.cache.restore_texture_binding(0);
     }
 
+    pub fn resize(&mut self, ctx: &mut Context, width: u32, height: u32, bytes: Option<&[u8]>) {
+        ctx.cache.store_texture_binding(0);
+
+        let (internal_format, format, pixel_type) = self.format.into();
+
+        self.width = width;
+        self.height = height;
+
+        unsafe {
+            glTexImage2D(
+                GL_TEXTURE_2D,
+                0,
+                internal_format as i32,
+                self.width as i32,
+                self.height as i32,
+                0,
+                format,
+                pixel_type,
+                match bytes {
+                    Some(bytes) => bytes.as_ptr() as *const _,
+                    Option::None => std::ptr::null(),
+                },
+            );
+        }
+
+        ctx.cache.restore_texture_binding(0);
+
+    }
+
     /// Update whole texture content
     /// bytes should be width * height * 4 size - non rgba8 textures are not supported yet anyway
     pub fn update(&self, ctx: &mut Context, bytes: &[u8]) {


### PR DESCRIPTION
Now post_processing example can run without gpu memory leak 