### PR TITLE
Support different upload format than texture format

### DIFF
--- a/examples/post_processing.rs
+++ b/examples/post_processing.rs
@@ -1,0 +1,304 @@
+use miniquad::*;
+
+use glam::{vec3, Mat4};
+
+struct Stage {
+    post_processing_pipeline: Pipeline,
+    post_processing_bind: Bindings,
+    offscreen_pipeline: Pipeline,
+    offscreen_bind: Bindings,
+    offscreen_pass: RenderPass,
+    rx: f32,
+    ry: f32,
+}
+
+impl Stage {
+    pub fn new(ctx: &mut Context) -> Stage {
+        let color_img = Texture::new_render_texture(
+            ctx,
+            TextureParams {
+                width: 256,
+                height: 256,
+                format: TextureFormat::RGBA8,
+                ..Default::default()
+            },
+        );
+        let depth_img = Texture::new_render_texture(
+            ctx,
+            TextureParams {
+                width: 256,
+                height: 256,
+                format: TextureFormat::Depth,
+                ..Default::default()
+            },
+        );
+
+        let offscreen_pass = RenderPass::new(ctx, color_img, depth_img);
+
+        #[rustfmt::skip]
+        let vertices: &[f32] = &[
+            /* pos               color                   uvs */
+            -1.0, -1.0, -1.0,    1.0, 0.5, 0.5, 1.0,     0.0, 0.0,
+             1.0, -1.0, -1.0,    1.0, 0.5, 0.5, 1.0,     1.0, 0.0,
+             1.0,  1.0, -1.0,    1.0, 0.5, 0.5, 1.0,     1.0, 1.0,
+            -1.0,  1.0, -1.0,    1.0, 0.5, 0.5, 1.0,     0.0, 1.0,
+    
+            -1.0, -1.0,  1.0,    0.5, 1.0, 0.5, 1.0,     0.0, 0.0, 
+             1.0, -1.0,  1.0,    0.5, 1.0, 0.5, 1.0,     1.0, 0.0,
+             1.0,  1.0,  1.0,    0.5, 1.0, 0.5, 1.0,     1.0, 1.0,
+            -1.0,  1.0,  1.0,    0.5, 1.0, 0.5, 1.0,     0.0, 1.0,
+    
+            -1.0, -1.0, -1.0,    0.5, 0.5, 1.0, 1.0,     0.0, 0.0,
+            -1.0,  1.0, -1.0,    0.5, 0.5, 1.0, 1.0,     1.0, 0.0,
+            -1.0,  1.0,  1.0,    0.5, 0.5, 1.0, 1.0,     1.0, 1.0,
+            -1.0, -1.0,  1.0,    0.5, 0.5, 1.0, 1.0,     0.0, 1.0,
+    
+             1.0, -1.0, -1.0,    1.0, 0.5, 0.0, 1.0,     0.0, 0.0,
+             1.0,  1.0, -1.0,    1.0, 0.5, 0.0, 1.0,     1.0, 0.0,
+             1.0,  1.0,  1.0,    1.0, 0.5, 0.0, 1.0,     1.0, 1.0,
+             1.0, -1.0,  1.0,    1.0, 0.5, 0.0, 1.0,     0.0, 1.0,
+    
+            -1.0, -1.0, -1.0,    0.0, 0.5, 1.0, 1.0,     0.0, 0.0,
+            -1.0, -1.0,  1.0,    0.0, 0.5, 1.0, 1.0,     1.0, 0.0,
+             1.0, -1.0,  1.0,    0.0, 0.5, 1.0, 1.0,     1.0, 1.0,
+             1.0, -1.0, -1.0,    0.0, 0.5, 1.0, 1.0,     0.0, 1.0,
+    
+            -1.0,  1.0, -1.0,    1.0, 0.0, 0.5, 1.0,     0.0, 0.0,
+            -1.0,  1.0,  1.0,    1.0, 0.0, 0.5, 1.0,     1.0, 0.0,
+             1.0,  1.0,  1.0,    1.0, 0.0, 0.5, 1.0,     1.0, 1.0,
+             1.0,  1.0, -1.0,    1.0, 0.0, 0.5, 1.0,     0.0, 1.0
+        ];
+
+        let vertex_buffer = Buffer::immutable(ctx, BufferType::VertexBuffer, &vertices);
+
+        #[rustfmt::skip]
+        let indices: &[u16] = &[
+            0, 1, 2,  0, 2, 3,
+            6, 5, 4,  7, 6, 4,
+            8, 9, 10,  8, 10, 11,
+            14, 13, 12,  15, 14, 12,
+            16, 17, 18,  16, 18, 19,
+            22, 21, 20,  23, 22, 20
+        ];
+
+        let index_buffer = Buffer::immutable(ctx, BufferType::IndexBuffer, &indices);
+
+        let offscreen_bind = Bindings {
+            vertex_buffers: vec![vertex_buffer.clone()],
+            index_buffer: index_buffer.clone(),
+            images: vec![],
+        };
+
+        #[rustfmt::skip]
+        let vertices: &[f32] = &[
+            /* pos         uvs */
+            -1.0, -1.0,    0.0, 0.0,
+             1.0, -1.0,    1.0, 0.0,
+             1.0,  1.0,    1.0, 1.0,
+            -1.0,  1.0,    0.0, 1.0,
+        ];
+
+        let vertex_buffer = Buffer::immutable(ctx, BufferType::VertexBuffer, &vertices);
+
+        let indices: &[u16] = &[0, 1, 2,  0, 2, 3];
+
+        let index_buffer = Buffer::immutable(ctx, BufferType::IndexBuffer, &indices);
+
+        let post_processing_bind = Bindings {
+            vertex_buffers: vec![vertex_buffer],
+            index_buffer: index_buffer,
+            images: vec![color_img],
+        };
+
+        let default_shader = Shader::new(
+            ctx,
+            post_processing_shader::VERTEX,
+            post_processing_shader::FRAGMENT,
+            post_processing_shader::META,
+        );
+
+        let post_processing_pipeline = Pipeline::with_params(
+            ctx,
+            &[BufferLayout::default()],
+            &[
+                VertexAttribute::new("pos", VertexFormat::Float2),
+                VertexAttribute::new("uv", VertexFormat::Float2),
+            ],
+            default_shader,
+            PipelineParams {
+                depth_test: Comparison::LessOrEqual,
+                depth_write: true,
+                ..Default::default()
+            },
+        );
+
+        let offscreen_shader = Shader::new(
+            ctx,
+            offscreen_shader::VERTEX,
+            offscreen_shader::FRAGMENT,
+            offscreen_shader::META,
+        );
+
+        let offscreen_pipeline = Pipeline::with_params(
+            ctx,
+            &[BufferLayout {
+                stride: 36,
+                ..Default::default()
+            }],
+            &[
+                VertexAttribute::new("pos", VertexFormat::Float3),
+                VertexAttribute::new("color0", VertexFormat::Float4),
+            ],
+            offscreen_shader,
+            PipelineParams {
+                depth_test: Comparison::LessOrEqual,
+                depth_write: true,
+                ..Default::default()
+            },
+        );
+
+        Stage {
+            post_processing_pipeline,
+            post_processing_bind,
+            offscreen_pipeline,
+            offscreen_bind,
+            offscreen_pass,
+            rx: 0.,
+            ry: 0.,
+        }
+    }
+}
+
+impl EventHandler for Stage {
+    fn update(&mut self, _ctx: &mut Context) {}
+
+    fn draw(&mut self, ctx: &mut Context) {
+        let (width, height) = ctx.screen_size();
+        let proj = Mat4::perspective_rh_gl(60.0f32.to_radians(), width / height, 0.01, 10.0);
+        let view = Mat4::look_at_rh(
+            vec3(0.0, 1.5, 3.0),
+            vec3(0.0, 0.0, 0.0),
+            vec3(0.0, 1.0, 0.0),
+        );
+        let view_proj = proj * view;
+
+        self.rx += 0.01;
+        self.ry += 0.03;
+        let model = Mat4::from_rotation_ypr(self.rx, self.ry, 0.);
+
+        let vs_params = post_processing_shader::Uniforms {
+            mvp: view_proj * model,
+        };
+
+        // the offscreen pass, rendering an rotating, untextured cube into a render target image
+        ctx.begin_pass(
+            self.offscreen_pass,
+            PassAction::clear_color(1.0, 1.0, 1.0, 1.),
+        );
+        ctx.apply_pipeline(&self.offscreen_pipeline);
+        ctx.apply_bindings(&self.offscreen_bind);
+        ctx.apply_uniforms(&vs_params);
+        ctx.draw(0, 36, 1);
+        ctx.end_render_pass();
+
+        // and the post-processing-pass, rendering a rotating, textured cube, using the
+        // previously rendered offscreen render-target as texture
+        ctx.begin_default_pass(PassAction::clear_color(0.0, 0., 0.45, 1.));
+        ctx.apply_pipeline(&self.post_processing_pipeline);
+        ctx.apply_bindings(&self.post_processing_bind);
+        ctx.apply_uniforms(&vs_params);
+        ctx.draw(0, 36, 1);
+        ctx.end_render_pass();
+        ctx.commit_frame();
+    }
+}
+
+fn main() {
+    miniquad::start(conf::Conf::default(), |mut ctx| {
+        UserData::owning(Stage::new(&mut ctx), ctx)
+    });
+}
+
+mod post_processing_shader {
+    use miniquad::*;
+
+    pub const VERTEX: &str = r#"#version 100
+    attribute vec2 pos;
+    attribute vec2 uv;
+
+    varying lowp vec2 texcoord;
+
+    void main() {
+        gl_Position = vec4(pos, 0, 1);
+        texcoord = uv;
+    }
+    "#;
+
+    pub const FRAGMENT: &str = r#"#version 100
+    varying lowp vec2 texcoord;
+
+    uniform sampler2D tex;
+
+    precision lowp float;
+
+    // Source: https://github.com/Jam3/glsl-fast-gaussian-blur/blob/master/5.glsl
+    vec4 blur5(sampler2D image, vec2 uv, vec2 resolution, vec2 direction) {
+        vec4 color = vec4(0.0);
+        vec2 off1 = vec2(1.3333333333333333) * direction;
+        color += texture2D(image, uv) * 0.29411764705882354;
+        color += texture2D(image, uv + (off1 / resolution)) * 0.35294117647058826;
+        color += texture2D(image, uv - (off1 / resolution)) * 0.35294117647058826;
+        return color;
+    }
+
+    void main() {
+        gl_FragColor = blur5(tex, texcoord, vec2(256.0), vec2(3.0));
+    }
+    "#;
+
+    pub const META: ShaderMeta = ShaderMeta {
+        images: &["tex"],
+        uniforms: UniformBlockLayout {
+            uniforms: &[],
+        },
+    };
+
+    #[repr(C)]
+    pub struct Uniforms {
+        pub mvp: glam::Mat4,
+    }
+}
+
+mod offscreen_shader {
+    use miniquad::*;
+
+    pub const VERTEX: &str = r#"#version 100
+    attribute vec4 pos;
+    attribute vec4 color0;
+
+    varying lowp vec4 color;
+
+    uniform mat4 mvp;
+
+    void main() {
+        gl_Position = mvp * pos;
+        color = color0;
+    }
+    "#;
+
+    pub const FRAGMENT: &str = r#"#version 100
+
+    varying lowp vec4 color;
+
+    void main() {
+        gl_FragColor = color;
+    }
+    "#;
+
+    pub const META: ShaderMeta = ShaderMeta {
+        images: &[],
+        uniforms: UniformBlockLayout {
+            uniforms: &[UniformDesc::new("mvp", UniformType::Mat4)],
+        },
+    };
+}

--- a/native/sapp-linux/src/lib.rs
+++ b/native/sapp-linux/src/lib.rs
@@ -1129,7 +1129,7 @@ pub unsafe extern "C" fn _sapp_fail(mut msg: *const libc::c_char) {
         } else {
             use std::ffi::CString;
 
-            let rust_msg = CString::from_raw(msg as *mut i8);
+            let rust_msg = CString::from_raw(msg as *mut _);
 
             println!("{}", rust_msg.to_str().unwrap());
         }

--- a/native/sapp-wasm/js/gl.js
+++ b/native/sapp-wasm/js/gl.js
@@ -658,6 +658,9 @@ var importObject = {
             gl.linkProgram(GL.programs[program]);
             GL.populateUniformTable(program);
         },
+        glPixelStorei: function (pname, param) {
+            gl.pixelStorei(pname, param);
+        },
         glFramebufferTexture2D: function (target, attachment, textarget, texture, level) {
             GL.validateGLObjectID(GL.textures, texture, 'glFramebufferTexture2D', 'texture');
             gl.framebufferTexture2D(target, attachment, textarget, GL.textures[texture], level);

--- a/native/sapp-windows/external/sokol/sokol_app.h
+++ b/native/sapp-windows/external/sokol/sokol_app.h
@@ -3181,6 +3181,11 @@ static PFN_glLinkProgram _sapp_glLinkProgram;
 void glLinkProgram(GLuint program) {
     _sapp_glLinkProgram(program);
 }
+typedef void  (GL_APIENTRY *PFN_glPixelStorei)(GLenum pname, GLint param);
+static PFN_glPixelStorei _sapp_glPixelStorei;
+void glPixelStorei(GLenum pname, GLint param) {
+    _sapp_glPixelStorei(pname, param);
+}
 typedef GLint (GL_APIENTRY *PFN_glGetUniformLocation)(GLuint program, const GLchar * name);
 static PFN_glGetUniformLocation _sapp_glGetUniformLocation;
 GLint glGetUniformLocation(GLuint program, const GLchar * name) {
@@ -3572,6 +3577,7 @@ _SOKOL_PRIVATE  void _sapp_win32_gl_loadfuncs(void) {
     _SAPP_GLPROC(glUseProgram);
     _SAPP_GLPROC(glShaderSource);
     _SAPP_GLPROC(glLinkProgram);
+    _SAPP_GLPROC(glPixelStorei);
     _SAPP_GLPROC(glGetUniformLocation);
     _SAPP_GLPROC(glGetShaderiv);
     _SAPP_GLPROC(glGetProgramInfoLog);
@@ -3674,6 +3680,7 @@ _SOKOL_PRIVATE  void _sapp_win32_gl_loadfuncs(void) {
 #define glUseProgram _sapp_glUseProgram
 #define glShaderSource _sapp_glShaderSource
 #define glLinkProgram _sapp_glLinkProgram
+#define glPixelStorei _sapp_glPixelStorei
 #define glGetUniformLocation _sapp_glGetUniformLocation
 #define glGetShaderiv _sapp_glGetShaderiv
 #define glGetProgramInfoLog _sapp_glGetProgramInfoLog

--- a/native/sapp-windows/src/sokol_app_gnu.rs
+++ b/native/sapp-windows/src/sokol_app_gnu.rs
@@ -8262,6 +8262,7 @@ pub const GL_TRUE: u32 = 1;
 pub const GL_NEVER: u32 = 512;
 pub const GL_POINTS: u32 = 0;
 pub const GL_ONE_MINUS_SRC_COLOR: u32 = 769;
+pub const GL_UNPACK_ALIGNMENT: u32 = 3317;
 pub const GL_MIRRORED_REPEAT: u32 = 33648;
 pub const GL_MAX_COMBINED_TEXTURE_IMAGE_UNITS: u32 = 35661;
 pub const GL_R11F_G11F_B10F: u32 = 35898;
@@ -41985,6 +41986,13 @@ extern "C" {
 }
 extern "C" {
     pub fn glLinkProgram(program: GLuint);
+}
+pub type PFN_glPixelStorei = ::std::option::Option<unsafe extern "C" fn(pname: GLenum, param: GLint)>;
+extern "C" {
+    pub static mut _sapp_glPixelStorei: PFN_glPixelStorei;
+}
+extern "C" {
+    pub fn glPixelStorei(pname: GLenum, param: GLint);
 }
 pub type PFN_glGetUniformLocation =
     ::std::option::Option<unsafe extern "C" fn(program: GLuint, name: *const GLchar) -> GLint>;

--- a/native/sapp-windows/src/sokol_app_msvc.rs
+++ b/native/sapp-windows/src/sokol_app_msvc.rs
@@ -8217,6 +8217,7 @@ pub const GL_TRUE: u32 = 1;
 pub const GL_NEVER: u32 = 512;
 pub const GL_POINTS: u32 = 0;
 pub const GL_ONE_MINUS_SRC_COLOR: u32 = 769;
+pub const GL_UNPACK_ALIGNMENT: u32 = 3317;
 pub const GL_MIRRORED_REPEAT: u32 = 33648;
 pub const GL_MAX_COMBINED_TEXTURE_IMAGE_UNITS: u32 = 35661;
 pub const GL_R11F_G11F_B10F: u32 = 35898;
@@ -41894,6 +41895,13 @@ extern "C" {
 }
 extern "C" {
     pub fn glLinkProgram(program: GLuint);
+}
+pub type PFN_glPixelStorei = ::std::option::Option<unsafe extern "C" fn(pname: GLenum, param: GLint)>;
+extern "C" {
+    pub static mut _sapp_glPixelStorei: PFN_glPixelStorei;
+}
+extern "C" {
+    pub fn glPixelStorei(pname: GLenum, param: GLint);
 }
 pub type PFN_glGetUniformLocation =
     ::std::option::Option<unsafe extern "C" fn(program: GLuint, name: *const GLchar) -> GLint>;

--- a/src/graphics.rs
+++ b/src/graphics.rs
@@ -7,7 +7,7 @@ use crate::sapp::*;
 // workaround sapp::* also contains None on Android
 use std::option::Option::None;
 
-pub use texture::{FilterMode, Texture, TextureAccess, TextureFormat, TextureParams, TextureWrap};
+pub use texture::{FilterMode, PixelFormat, Texture, TextureAccess, TextureFormat, TextureParams, TextureWrap};
 
 fn get_uniform_location(program: GLuint, name: &str) -> i32 {
     let cname = CString::new(name).unwrap_or_else(|e| panic!(e));

--- a/src/graphics.rs
+++ b/src/graphics.rs
@@ -7,7 +7,7 @@ use crate::sapp::*;
 // workaround sapp::* also contains None on Android
 use std::option::Option::None;
 
-pub use texture::{FilterMode, PixelFormat, Texture, TextureAccess, TextureFormat, TextureParams, TextureWrap};
+pub use texture::{FilterMode, Texture, TextureAccess, TextureFormat, TextureParams, TextureWrap};
 
 fn get_uniform_location(program: GLuint, name: &str) -> i32 {
     let cname = CString::new(name).unwrap_or_else(|e| panic!(e));

--- a/src/graphics/texture.rs
+++ b/src/graphics/texture.rs
@@ -32,7 +32,7 @@ impl Texture {
     }
 }
 
-/// List of all the possible internal texture formats for storing texture array in GPU memory
+/// List of all the possible texture formats for storing texture array in GPU memory or uploading data to GPU
 /// The list is built by intersection of texture formats supported by 3.3 core profile and webgl1.
 #[repr(u8)]
 #[derive(Debug, PartialEq, Eq, Clone, Copy)]
@@ -43,7 +43,6 @@ pub enum TextureFormat {
 
     /// Alpha textures on the GPU are not yet supported
     /// Alpha is supported only for uploading data
-    /// Will `panic!` if used to create alpha texture.
     Alpha,
 }
 

--- a/src/graphics/texture.rs
+++ b/src/graphics/texture.rs
@@ -140,9 +140,8 @@ impl Texture {
         pixel_format: TextureFormat,
         params: TextureParams,
     ) -> Texture {
-        if params.format == TextureFormat::Alpha {
-            panic!("TextureFormat::Alpha textures are not supported yet. Use TextureFormat::RGBA textures instead and upload TextureFormat::Alpha data");
-        }
+        assert!(params.format != TextureFormat::Alpha, "TextureFormat::Alpha textures are not supported yet. Use TextureFormat::RGBA textures instead and upload TextureFormat::Alpha data");
+        assert!(params.format == pixel_format, "Different GPU and CPU pixel formats are not supported when creating texture (OK when updating texture data), because of limitations in WebGL1 and not yet implemented support.");
 
         if let Some(bytes_data) = bytes {
             assert_eq!(


### PR DESCRIPTION
Can now upload alpha pixel format (1 byte per pixel) to RGBA8 texture.
Breaking changes to Texture class.

Very useful to upload effectively Alpha texture data to platforms that only support RGBA8 (like WebGL1) without having to make 4x larger array (4 bytes per pixel vs 1 byte per pixel) on the CPU side