### PR TITLE
Rename WASM time to now

### DIFF
--- a/native/sapp-wasm/js/gl.js
+++ b/native/sapp-wasm/js/gl.js
@@ -439,7 +439,7 @@ var importObject = {
         rand: function () {
             return Math.floor(Math.random() * 2147483647);
         },
-        time: function () {
+        now: function () {
             return Date.now() / 1000.0;
         },
         canvas_width: function () {

--- a/native/sapp-wasm/src/rand.rs
+++ b/native/sapp-wasm/src/rand.rs
@@ -1,5 +1,5 @@
 pub const RAND_MAX: u32 = 2147483647;
 extern "C" {
     pub fn rand() -> ::std::os::raw::c_int;
-    pub fn time() -> f64;
+    pub fn now() -> f64;
 }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -58,7 +58,7 @@ pub mod date {
 
     #[cfg(target_arch = "wasm32")]
     pub fn now() -> f64 {
-        unsafe { sapp::time() }
+        unsafe { sapp::now() }
     }
 }
 


### PR DESCRIPTION
This allows my PR to the instant library to work out of the box without any manual patches to the JS files: https://github.com/sebcrozet/instant/pull/14

It's also more consistent with the API itself since the Rust calling function is also `now()`.

As an aside the following can be added to your `Cargo.toml` to work with libraries depending on `instant` before the PR is merged:

```toml
[patch.crates-io]
instant = { git = "https://github.com/tversteeg/instant.git" }
```