### PR TITLE
Load gl.js from WASM

### DIFF
--- a/examples/index.html
+++ b/examples/index.html
@@ -22,8 +22,8 @@
 
 <body>
     <canvas id="glcanvas" tabindex='1'></canvas>
-    <!-- Minified and statically hosted version of https://github.com/not-fl3/miniquad/blob/master/native/sapp-wasm/js/gl.js -->
-    <script src="https://not-fl3.github.io/miniquad-samples/gl.js"></script>
+    <!-- Minified and statically hosted version of https://github.com/not-fl3/miniquad/blob/master/native/sapp-wasm/js/loader.js -->
+    <script src="https://not-fl3.github.io/miniquad-samples/loader.js"></script>
     <script>load("quad.wasm");</script> <!-- Your compiled wasm file -->
 </body>
 

--- a/native/sapp-wasm/Cargo.toml
+++ b/native/sapp-wasm/Cargo.toml
@@ -9,4 +9,3 @@ Part of miniquad rendering library.
 Binding and JS implementation of GL and sokol-app API.
 """
 homepage = "https://github.com/not-fl3/miniquad"
-

--- a/native/sapp-wasm/js/loader.js
+++ b/native/sapp-wasm/js/loader.js
@@ -1,0 +1,141 @@
+const canvas = document.querySelector("#glcanvas");
+const gl = canvas.getContext("webgl");
+if (gl === null) {
+    alert("Unable to initialize WebGL. Your browser or machine may not support it.");
+}
+
+var plugins = [];
+var wasm_exports;
+var wasm_memory;
+
+var Module;
+
+canvas.focus();
+
+canvas.requestPointerLock = canvas.requestPointerLock ||
+    canvas.mozRequestPointerLock;
+document.exitPointerLock = document.exitPointerLock ||
+    document.mozExitPointerLock;
+
+function UTF8ToString(ptr, maxBytesToRead) {
+    let u8Array = new Uint8Array(wasm_memory.buffer, ptr);
+
+    var idx = 0;
+    var endIdx = idx + maxBytesToRead;
+
+    var str = '';
+    while (!(idx >= endIdx)) {
+        // For UTF8 byte structure, see:
+        // http://en.wikipedia.org/wiki/UTF-8#Description
+        // https://www.ietf.org/rfc/rfc2279.txt
+        // https://tools.ietf.org/html/rfc3629
+        var u0 = u8Array[idx++];
+
+        // If not building with TextDecoder enabled, we don't know the string length, so scan for \0 byte.
+        // If building with TextDecoder, we know exactly at what byte index the string ends, so checking for nulls here would be redundant.
+        if (!u0) return str;
+
+        if (!(u0 & 0x80)) { str += String.fromCharCode(u0); continue; }
+        var u1 = u8Array[idx++] & 63;
+        if ((u0 & 0xE0) == 0xC0) { str += String.fromCharCode(((u0 & 31) << 6) | u1); continue; }
+        var u2 = u8Array[idx++] & 63;
+        if ((u0 & 0xF0) == 0xE0) {
+            u0 = ((u0 & 15) << 12) | (u1 << 6) | u2;
+        } else {
+
+            if ((u0 & 0xF8) != 0xF0) console.warn('Invalid UTF-8 leading byte 0x' + u0.toString(16) + ' encountered when deserializing a UTF-8 string on the asm.js/wasm heap to a JS string!');
+
+            u0 = ((u0 & 7) << 18) | (u1 << 12) | (u2 << 6) | (u8Array[idx++] & 63);
+        }
+
+        if (u0 < 0x10000) {
+            str += String.fromCharCode(u0);
+        } else {
+            var ch = u0 - 0x10000;
+            str += String.fromCharCode(0xD800 | (ch >> 10), 0xDC00 | (ch & 0x3FF));
+        }
+    }
+
+    return str;
+}
+
+function load_js(value) {
+	window.eval(UTF8ToString(value));
+}
+
+function register_plugins(plugins) {
+    if (plugins == undefined)
+        return;
+
+    for (var i = 0; i < plugins.length; i++) {
+        if (plugins[i].register_plugin != undefined && plugins[i].register_plugin != null) {
+            plugins[i].register_plugin(importObject);
+        }
+    }
+}
+
+function init_plugins(plugins) {
+    if (plugins == undefined)
+        return;
+
+    for (var i = 0; i < plugins.length; i++) {
+        if (plugins[i].on_init != undefined && plugins[i].on_init != null) {
+            plugins[i].on_init();
+        }
+    }
+}
+
+function miniquad_add_plugin(plugin) {
+    plugins.push(plugin);
+}
+
+function load(wasm_path) {
+	// TODO: this will fail if any plugin is added because importObject isn't known here yet
+    register_plugins(plugins);
+
+	// Use a custom streaming function for older browser versions
+	if (!WebAssembly.compileStreaming) {
+		WebAssembly.compileStreaming = async(resp, importObject) => {
+			const source = await(await resp).arrayBuffer();
+			return await WebAssembly.compile(source, importObject);
+		};
+	}
+
+	var localImportObject = { env: {} };
+
+	WebAssembly.compileStreaming(fetch(wasm_path))
+		// First compile the module to get the list of imports and inject load_js
+		.then(mod => {
+			// Load a list of expected imports
+			var imports = WebAssembly.Module.imports(mod);
+
+			// Add all requested imports with an empty function
+			imports.forEach(func => localImportObject.env[func.name] = function() {});
+
+			// Implement the 'load_js' function
+			localImportObject.env.load_js = load_js
+
+			return WebAssembly.instantiate(mod, localImportObject);
+		})
+		// Then invoke load_js and override the functions for the imports
+		.then(obj => {
+			wasm_memory = obj.exports.memory;
+			wasm_exports = obj.exports;
+
+			// Load the gl.js data included in the wasm
+			wasm_exports.load_gl_js();
+
+			// Override the import object functions with the one from gl.js
+			localImportObject = importObject;
+			localImportObject.env.load_js = load_js;
+
+			// Start miniquad
+			init_plugins(plugins);
+			wasm_exports.main();
+		})
+		.catch(err => console.error(err));
+}
+
+// Resize
+canvas.width = canvas.clientWidth;
+canvas.height = canvas.clientHeight;

--- a/native/sapp-wasm/src/lib.rs
+++ b/native/sapp-wasm/src/lib.rs
@@ -321,6 +321,8 @@ extern "C" {
     /// Notice that this function will works only from "engaging" event callbacks - from
     /// "mouse_down"/"key_down" event handler functions.
     pub fn sapp_set_cursor_grab(grab: bool);
+
+    fn load_js(code: *const ::std::os::raw::c_char);
 }
 
 /// Do nothing on wasm - cursor will be hidden by "sapp_set_cursor_grab" anyway.
@@ -332,6 +334,12 @@ pub unsafe fn sapp_high_dpi() -> bool {
 
 pub unsafe fn sapp_dpi_scale() -> f32 {
     1.
+}
+
+#[no_mangle]
+pub extern "C" fn load_gl_js() {
+    let code = std::ffi::CString::new(include_str!("../js/gl.js")).unwrap();
+    unsafe { load_js(code.as_ptr()) };
 }
 
 #[no_mangle]


### PR DESCRIPTION
This PR includes the `gl.js` source in the WASM binary.

### How it works

1. In your `index.html` you load `loader.js` instead of `gl.js`.
2. The compiled Rust WASM exports the `load_gl_js` function which uses an imported `load_js` function.
3. The loader compiles the WASM file and creates an empty function for all requested imports and an implemented `load_js` function.
4. The loader instantiates the WASM and calls `load_gl_js` on it, this will load all the functions from `gl.js`.
5. The loader overwrites its imports with the ones from `gl.js`.
6. Miniquad is started!

There are few upsides and a few downsides to this approach:

### Pros

- The `gl.js` version is always correct since it's embedded, only the versions of `loader.js` might differ but since that doesn't contain any runtime logic code that shouldn't happen too often.
- Possibly no extra files in the future, `loader.js` might be small enough to include directly in `index.html`, which will result in just the WASM file and `index.html`.

### Cons

- `gl.js` cannot be changed without recompiling.
- Debugging might be harder since an `eval` is used to load `gl.js`, removing file information.

### Possible improvements

- `gl.js` could be minified as a build step before being included.