### PR TITLE
miniquad: added mapping for most of the SAPP-keys

### DIFF
--- a/native/sapp-wasm/js/gl.js
+++ b/native/sapp-wasm/js/gl.js
@@ -363,6 +363,10 @@ into_sapp_mousebutton = function (btn) {
 
 into_sapp_keycode = function (key_code) {
     switch (key_code) {
+        case "Space": return 32;
+        case "Comma": return 44;
+        case "Minus": return 45;
+        case "Period": return 46;
         case "Digit0": return 48;
         case "Digit1": return 49;
         case "Digit2": return 50;
@@ -373,23 +377,109 @@ into_sapp_keycode = function (key_code) {
         case "Digit7": return 55;
         case "Digit8": return 56;
         case "Digit9": return 57;
+        case "Semicolon": return 59;
+        case "Equal": return 61;
         case "KeyA": return 65;
-        case "KeyS": return 83;
+        case "KeyB": return 66;
+        case "KeyC": return 67;
         case "KeyD": return 68;
+        case "KeyE": return 69;
+        case "KeyF": return 70;
+        case "KeyG": return 71;
+        case "KeyH": return 72;
+        case "KeyI": return 73;
+        case "KeyJ": return 74;
+        case "KeyK": return 75;
+        case "KeyL": return 76;
+        case "KeyM": return 77;
+        case "KeyN": return 78;
+        case "KeyO": return 79;
+        case "KeyP": return 80;
+        case "KeyQ": return 81;
+        case "KeyR": return 82;
+        case "KeyS": return 83;
+        case "KeyT": return 84;
+        case "KeyU": return 85;
+        case "KeyV": return 86;
         case "KeyW": return 87;
+        case "KeyX": return 88;
+        case "KeyY": return 89;
+        case "KeyZ": return 90;
+        case "BracketLeft": return 91;
+        case "Backslash": return 92;
+        case "BracketRight": return 93;
+        case "Escape": return 256;
+        case "Enter": return 257;
+        case "Tab": return 258;
+        case "Backspace": return 259;
+        case "Insert": return 260;
+        case "Delete": return 261;
         case "ArrowRight": return 262;
         case "ArrowLeft": return 263;
         case "ArrowDown": return 264;
         case "ArrowUp": return 265;
-        case "Space": return 32;
+        case "PageUp": return 266;
+        case "PageDown": return 267;
         case "Home": return 268;
         case "End": return 269;
-        case "Enter": return 257;
-        case "Delete": return 261;
-        case "Backspace": return 259;
+        case "CapsLock": return 280;
+        case "ScrollLock": return 281;
+        case "NumLock": return 282;
+        case "PrintScreen": return 283;
+        case "Pause": return 284;
+        case "F1": return 290;
+        case "F2": return 291;
+        case "F3": return 292;
+        case "F4": return 293;
+        case "F5": return 294;
+        case "F6": return 295;
+        case "F7": return 296;
+        case "F8": return 297;
+        case "F9": return 298;
+        case "F10": return 299;
+        case "F11": return 300;
+        case "F12": return 301;
+        case "F13": return 302;
+        case "F14": return 303;
+        case "F15": return 304;
+        case "F16": return 305;
+        case "F17": return 306;
+        case "F18": return 307;
+        case "F19": return 308;
+        case "F20": return 309;
+        case "F21": return 310;
+        case "F22": return 311;
+        case "F23": return 312;
+        case "F24": return 313;
+        case "Numpad0": return 320;
+        case "Numpad1": return 321;
+        case "Numpad2": return 322;
+        case "Numpad3": return 323;
+        case "Numpad4": return 324;
+        case "Numpad5": return 325;
+        case "Numpad6": return 326;
+        case "Numpad7": return 327;
+        case "Numpad8": return 328;
+        case "Numpad9": return 329;
+        case "NumpadDecimal": return 330;
+        case "NumpadDivide": return 331;
+        case "NumpadMultiply": return 332;
+        case "NumpadSubstract": return 333;
+        case "NumpadAdd": return 334;
+        case "NumpadEnter": return 335;
+        case "NumpadEqual": return 336;
+        case "ShiftLeft": return 340;
+        case "ControlLeft": return 341;
+        case "AltLeft": return 342;
+        case "OSLeft": return 343;
+        case "ShiftRight": return 344;
+        case "ControlRight": return 345;
+        case "AltRight": return 346;
+        case "OSRight": return 347;
+        case "ContextMenu": return 348;
     }
 
-    console.log("Unsupported keyboard key")
+    console.log("Unsupported keyboard key: ", key_code)
 }
 
 texture_size = function (internalFormat, width, height) {
@@ -858,6 +948,16 @@ var importObject = {
             };
             canvas.onkeydown = function (event) {
                 var sapp_key_code = into_sapp_keycode(event.code);
+                switch (sapp_key_code) {
+                    //  space, arrows - prevent scrolling of the page
+                    case 32: case 262: case 263: case 264: case 265: 
+                    // F1-F10
+                    case 290: case 291: case 292: case 293: case 294: case 295: case 296: case 297: case 298: case 299:
+                    // backspace is Back on Firefox/Windows
+                    case 259:
+                        event.preventDefault();
+                        break;
+                }
                 wasm_exports.key_down(sapp_key_code);
             };
             canvas.onkeyup = function (event) {


### PR DESCRIPTION
these are still missing:
APOSTROPHE: return 39;
SLASH: return 47;
GRAVE_ACCENT: return 96;
WORLD_1: return 161;
WORLD_2: return 162;

I am also keeping F11, F12 not mapped as I got complains from people who are using F11, and use F12 myself for debugging