### PR TITLE
graphics: Return Result instead of panic for shaders compilation

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "miniquad"
-version = "0.3.0-alpha.4"
+version = "0.3.0-alpha.5"
 authors = ["not-fl3 <not.fl3@gmail.com>"]
 edition = "2018"
 license = "MIT/Apache-2.0"

--- a/examples/blobs.rs
+++ b/examples/blobs.rs
@@ -40,7 +40,7 @@ impl Stage {
             images: vec![],
         };
 
-        let shader = Shader::new(ctx, shader::VERTEX, shader::FRAGMENT, shader::META);
+        let shader = Shader::new(ctx, shader::VERTEX, shader::FRAGMENT, shader::META).unwrap();
 
         let pipeline = Pipeline::new(
             ctx,

--- a/examples/index.html
+++ b/examples/index.html
@@ -23,8 +23,8 @@
 <body>
     <canvas id="glcanvas" tabindex='1'></canvas>
     <!-- Minified and statically hosted version of https://github.com/not-fl3/miniquad/blob/master/native/sapp-wasm/js/gl.js -->
-    <script src="https://not-fl3.github.io/miniquad-samples/gl.js"></script>
-    <script>load("quad.wasm");</script> <!-- Your compiled wasm file -->
+    <script src="gl.js"></script>
+    <script>load("post_processing.wasm");</script> <!-- Your compiled wasm file -->
 </body>
 
 </html>

--- a/examples/instancing.rs
+++ b/examples/instancing.rs
@@ -50,7 +50,7 @@ impl Stage {
             images: vec![],
         };
 
-        let shader = Shader::new(ctx, shader::VERTEX, shader::FRAGMENT, shader::META);
+        let shader = Shader::new(ctx, shader::VERTEX, shader::FRAGMENT, shader::META).unwrap();
 
         let pipeline = Pipeline::new(
             ctx,

--- a/examples/offscreen.rs
+++ b/examples/offscreen.rs
@@ -100,7 +100,7 @@ impl Stage {
             display_shader::VERTEX,
             display_shader::FRAGMENT,
             display_shader::META,
-        );
+        ).unwrap();
 
         let display_pipeline = Pipeline::with_params(
             ctx,
@@ -123,7 +123,7 @@ impl Stage {
             offscreen_shader::VERTEX,
             offscreen_shader::FRAGMENT,
             offscreen_shader::META,
-        );
+        ).unwrap();
 
         let offscreen_pipeline = Pipeline::with_params(
             ctx,

--- a/examples/post_processing.rs
+++ b/examples/post_processing.rs
@@ -116,7 +116,7 @@ impl Stage {
             post_processing_shader::VERTEX,
             post_processing_shader::FRAGMENT,
             post_processing_shader::META,
-        );
+        ).unwrap();
 
         let post_processing_pipeline = Pipeline::new(
             ctx,
@@ -133,7 +133,7 @@ impl Stage {
             offscreen_shader::VERTEX,
             offscreen_shader::FRAGMENT,
             offscreen_shader::META,
-        );
+        ).unwrap();
 
         let offscreen_pipeline = Pipeline::with_params(
             ctx,

--- a/examples/quad.rs
+++ b/examples/quad.rs
@@ -45,7 +45,7 @@ impl Stage {
             images: vec![texture],
         };
 
-        let shader = Shader::new(ctx, shader::VERTEX, shader::FRAGMENT, shader::META);
+        let shader = Shader::new(ctx, shader::VERTEX, shader::FRAGMENT, shader::META).unwrap();
 
         let pipeline = Pipeline::new(
             ctx,


### PR DESCRIPTION
This breaks backward compatibility - old `Shader::new()`  should be replaced to `Shader::new().unwrap()` for the same behaviour.

But allows to build cool interactive playgrounds!
https://not-fl3.github.io/miniquad-samples/shadertoy.html
