### PR TITLE
use Option::None explicitly in src/graphics/texture.rs

### DIFF
--- a/src/graphics/texture.rs
+++ b/src/graphics/texture.rs
@@ -123,7 +123,7 @@ pub struct TextureParams {
 impl Texture {
     /// Shorthand for `new(ctx, TextureAccess::RenderTarget, params)`
     pub fn new_render_texture(ctx: &mut Context, params: TextureParams) -> Texture {
-        Self::new(ctx, TextureAccess::RenderTarget, None, params)
+        Self::new(ctx, TextureAccess::RenderTarget, Option::None, params)
     }
 
     pub fn new(


### PR DESCRIPTION
Fixes a compilation error:
```
error[E0308]: mismatched types
   --> /usr/local/cargo/registry/src/github.com-1ecc6299db9ec823/miniquad-0.3.0-alpha.10/src/graphics/texture.rs:126:53
    |
126 |         Self::new(ctx, TextureAccess::RenderTarget, None, params)
    |                                                     ^^^^ expected enum `std::option::Option`, found `u32`
    |
    = note: expected enum `std::option::Option<&[u8]>`
               found type `u32`

error: aborting due to previous error

For more information about this error, try `rustc --explain E0308`.
error: could not compile `miniquad`.
warning: build failed, waiting for other jobs to finish...
error: build failed
```


Turns out `sapp` publicly defines `None` to `0u32` and `src/graphics/texture.rs` imports all items from `sapp`. This is bound to introduce more bugs and errors in the future, please get rid of the `use crate::sapp::*;` in [`texture.rs`](https://github.com/not-fl3/miniquad/blob/master/src/graphics/texture.rs#L1). Import all items you need explicitly.