### PR TITLE
graphics: Remove all 'static references from ShaderMeta

### DIFF
--- a/examples/blobs.rs
+++ b/examples/blobs.rs
@@ -40,7 +40,7 @@ impl Stage {
             images: vec![],
         };
 
-        let shader = Shader::new(ctx, shader::VERTEX, shader::FRAGMENT, shader::META).unwrap();
+        let shader = Shader::new(ctx, shader::VERTEX, shader::FRAGMENT, shader::meta()).unwrap();
 
         let pipeline = Pipeline::new(
             ctx,
@@ -208,16 +208,18 @@ mod shader {
         gl_FragColor = vec4( gradient(shade), 1.0 );
     }"#;
 
-    pub const META: ShaderMeta = ShaderMeta {
-        images: &[],
-        uniforms: UniformBlockLayout {
-            uniforms: &[
-                UniformDesc::new("time", UniformType::Float1),
-                UniformDesc::new("blobs_count", UniformType::Int1),
-                UniformDesc::with_array("blobs_positions", UniformType::Float2, 32),
-            ],
-        },
-    };
+    pub fn meta() -> ShaderMeta {
+        ShaderMeta {
+            images: vec![],
+            uniforms: UniformBlockLayout {
+                uniforms: vec![
+                    UniformDesc::new("time", UniformType::Float1),
+                    UniformDesc::new("blobs_count", UniformType::Int1),
+                    UniformDesc::new("blobs_positions", UniformType::Float2).array(32),
+                ],
+            },
+        }
+    }
 
     #[repr(C)]
     pub struct Uniforms {

--- a/examples/instancing.rs
+++ b/examples/instancing.rs
@@ -50,7 +50,7 @@ impl Stage {
             images: vec![],
         };
 
-        let shader = Shader::new(ctx, shader::VERTEX, shader::FRAGMENT, shader::META).unwrap();
+        let shader = Shader::new(ctx, shader::VERTEX, shader::FRAGMENT, shader::meta()).unwrap();
 
         let pipeline = Pipeline::new(
             ctx,
@@ -173,12 +173,14 @@ mod shader {
     }
     "#;
 
-    pub const META: ShaderMeta = ShaderMeta {
-        images: &[],
-        uniforms: UniformBlockLayout {
-            uniforms: &[UniformDesc::new("mvp", UniformType::Mat4)],
-        },
-    };
+    pub fn meta() -> ShaderMeta {
+        ShaderMeta {
+            images: vec![],
+            uniforms: UniformBlockLayout {
+                uniforms: vec![UniformDesc::new("mvp", UniformType::Mat4)],
+            },
+        }
+    }
 
     #[repr(C)]
     pub struct Uniforms {

--- a/examples/offscreen.rs
+++ b/examples/offscreen.rs
@@ -99,8 +99,9 @@ impl Stage {
             ctx,
             display_shader::VERTEX,
             display_shader::FRAGMENT,
-            display_shader::META,
-        ).unwrap();
+            display_shader::meta(),
+        )
+        .unwrap();
 
         let display_pipeline = Pipeline::with_params(
             ctx,
@@ -122,8 +123,9 @@ impl Stage {
             ctx,
             offscreen_shader::VERTEX,
             offscreen_shader::FRAGMENT,
-            offscreen_shader::META,
-        ).unwrap();
+            offscreen_shader::meta(),
+        )
+        .unwrap();
 
         let offscreen_pipeline = Pipeline::with_params(
             ctx,
@@ -236,12 +238,14 @@ mod display_shader {
     }
     "#;
 
-    pub const META: ShaderMeta = ShaderMeta {
-        images: &["tex"],
-        uniforms: UniformBlockLayout {
-            uniforms: &[UniformDesc::new("mvp", UniformType::Mat4)],
-        },
-    };
+    pub fn meta() -> ShaderMeta {
+        ShaderMeta {
+            images: vec!["tex".to_string()],
+            uniforms: UniformBlockLayout {
+                uniforms: vec![UniformDesc::new("mvp", UniformType::Mat4)],
+            },
+        }
+    }
 
     #[repr(C)]
     pub struct Uniforms {
@@ -274,10 +278,12 @@ mod offscreen_shader {
     }
     "#;
 
-    pub const META: ShaderMeta = ShaderMeta {
-        images: &[],
-        uniforms: UniformBlockLayout {
-            uniforms: &[UniformDesc::new("mvp", UniformType::Mat4)],
-        },
-    };
+    pub fn meta() -> ShaderMeta {
+        ShaderMeta {
+            images: vec![],
+            uniforms: UniformBlockLayout {
+                uniforms: vec![UniformDesc::new("mvp", UniformType::Mat4)],
+            },
+        }
+    }
 }

--- a/examples/post_processing.rs
+++ b/examples/post_processing.rs
@@ -115,8 +115,9 @@ impl Stage {
             ctx,
             post_processing_shader::VERTEX,
             post_processing_shader::FRAGMENT,
-            post_processing_shader::META,
-        ).unwrap();
+            post_processing_shader::meta(),
+        )
+        .unwrap();
 
         let post_processing_pipeline = Pipeline::new(
             ctx,
@@ -132,8 +133,9 @@ impl Stage {
             ctx,
             offscreen_shader::VERTEX,
             offscreen_shader::FRAGMENT,
-            offscreen_shader::META,
-        ).unwrap();
+            offscreen_shader::meta(),
+        )
+        .unwrap();
 
         let offscreen_pipeline = Pipeline::with_params(
             ctx,
@@ -284,12 +286,14 @@ mod post_processing_shader {
     }
     "#;
 
-    pub const META: ShaderMeta = ShaderMeta {
-        images: &["tex"],
-        uniforms: UniformBlockLayout {
-            uniforms: &[UniformDesc::new("resolution", UniformType::Float2)],
-        },
-    };
+    pub fn meta() -> ShaderMeta {
+        ShaderMeta {
+            images: vec!["tex".to_string()],
+            uniforms: UniformBlockLayout {
+                uniforms: vec![UniformDesc::new("resolution", UniformType::Float2)],
+            },
+        }
+    }
 
     #[repr(C)]
     pub struct Uniforms {
@@ -323,12 +327,14 @@ mod offscreen_shader {
     }
     "#;
 
-    pub const META: ShaderMeta = ShaderMeta {
-        images: &[],
-        uniforms: UniformBlockLayout {
-            uniforms: &[UniformDesc::new("mvp", UniformType::Mat4)],
-        },
-    };
+    pub fn meta() -> ShaderMeta {
+        ShaderMeta {
+            images: vec![],
+            uniforms: UniformBlockLayout {
+                uniforms: vec![UniformDesc::new("mvp", UniformType::Mat4)],
+            },
+        }
+    }
 
     #[repr(C)]
     pub struct Uniforms {

--- a/examples/quad.rs
+++ b/examples/quad.rs
@@ -45,7 +45,7 @@ impl Stage {
             images: vec![texture],
         };
 
-        let shader = Shader::new(ctx, shader::VERTEX, shader::FRAGMENT, shader::META).unwrap();
+        let shader = Shader::new(ctx, shader::VERTEX, shader::FRAGMENT, shader::meta()).unwrap();
 
         let pipeline = Pipeline::new(
             ctx,
@@ -116,12 +116,14 @@ mod shader {
         gl_FragColor = texture2D(tex, texcoord);
     }"#;
 
-    pub const META: ShaderMeta = ShaderMeta {
-        images: &["tex"],
-        uniforms: UniformBlockLayout {
-            uniforms: &[UniformDesc::new("offset", UniformType::Float2)],
-        },
-    };
+    pub fn meta() -> ShaderMeta {
+        ShaderMeta {
+            images: vec!["tex".to_string()],
+            uniforms: UniformBlockLayout {
+                uniforms: vec![UniformDesc::new("offset", UniformType::Float2)],
+            },
+        }
+    }
 
     #[repr(C)]
     pub struct Uniforms {

--- a/src/graphics.rs
+++ b/src/graphics.rs
@@ -50,39 +50,35 @@ impl UniformType {
 }
 
 pub struct UniformDesc {
-    name: &'static str,
+    name: String,
     uniform_type: UniformType,
     array_count: usize,
 }
 
 pub struct UniformBlockLayout {
-    pub uniforms: &'static [UniformDesc],
+    pub uniforms: Vec<UniformDesc>,
 }
 
 impl UniformDesc {
-    pub const fn new(name: &'static str, uniform_type: UniformType) -> UniformDesc {
+    pub fn new(name: &str, uniform_type: UniformType) -> UniformDesc {
         UniformDesc {
-            name,
+            name: name.to_string(),
             uniform_type,
             array_count: 1,
         }
     }
-    pub const fn with_array(
-        name: &'static str,
-        uniform_type: UniformType,
-        array_count: usize,
-    ) -> UniformDesc {
+
+    pub fn array(self, array_count: usize) -> UniformDesc {
         UniformDesc {
-            name,
-            uniform_type,
             array_count,
+            ..self
         }
     }
 }
 
 pub struct ShaderMeta {
     pub uniforms: UniformBlockLayout,
-    pub images: &'static [&'static str],
+    pub images: Vec<String>,
 }
 
 #[derive(Clone, Copy, PartialEq, Debug)]
@@ -1095,7 +1091,7 @@ fn load_shader_internal(
         #[rustfmt::skip]
         let uniforms = meta.uniforms.uniforms.iter().scan(0, |offset, uniform| {
             let res = ShaderUniform {
-                gl_loc: get_uniform_location(program, uniform.name),
+                gl_loc: get_uniform_location(program, &uniform.name),
                 offset: *offset,
                 size: uniform.uniform_type.size(1),
                 uniform_type: uniform.uniform_type,


### PR DESCRIPTION
**What happened:**

```
-    pub const META: ShaderMeta = ShaderMeta {
-        images: &["tex"],
-        uniforms: UniformBlockLayout {
-            uniforms: &[UniformDesc::new("resolution", UniformType::Float2)],
-        },
-    };
+    pub fn meta() -> ShaderMeta {
+        ShaderMeta {
+            images: vec!["tex".to_string()],
+            uniforms: UniformBlockLayout {
+                uniforms: vec![UniformDesc::new("resolution", UniformType::Float2)],
+            },
+        }
+    }

```

**Why:** 

&'static arrays were really unfriendly for runtime shader meta building.

**Problems:** 

- got couple of new allocations for arrays
- awkward looking `.to_string()` calls
- it is very very breaking change

**Alternative:** 

Keep ShaderMeta as is, but change Shader signature to

```
    pub fn new(
        ctx: &mut Context,
        vertex_shader: &str,
        fragment_shader: &str,
        meta: impl into<ShaderMetaRuntime>,
    ) -> Result<Shader, ShaderError> {
```
and introduce `ShaderMetaRuntime` struct usable in runtime. 
This will resolve all the issues but will introduce a bunch of new structs and probably will introduce some confusion on two sets on very same structs. 