### PR TITLE
sapp: export raw gl module

### DIFF
--- a/native/sapp-linux/src/lib.rs
+++ b/native/sapp-linux/src/lib.rs
@@ -11,7 +11,7 @@
     unused_mut
 )]
 
-mod gl;
+pub mod gl;
 mod rand;
 mod x;
 mod x_cursor;

--- a/native/sapp-wasm/src/lib.rs
+++ b/native/sapp-wasm/src/lib.rs
@@ -1,7 +1,7 @@
 #![allow(non_snake_case, non_camel_case_types, non_upper_case_globals)]
 
 pub mod fs;
-mod gl;
+pub mod gl;
 mod rand;
 
 pub use gl::*;

--- a/native/sapp-windows/src/lib.rs
+++ b/native/sapp-windows/src/lib.rs
@@ -1,6 +1,6 @@
 #![allow(non_snake_case, non_camel_case_types, non_upper_case_globals)]
 
-mod gl;
+pub mod gl;
 mod rand;
 
 pub use gl::*;

--- a/src/graphics/texture.rs
+++ b/src/graphics/texture.rs
@@ -18,6 +18,10 @@ impl Texture {
         }
     }
 
+    pub fn gl_internal_id(&self) -> GLuint {
+        self.texture
+    }
+
     /// Delete GPU texture, leaving handle unmodified.
     ///
     /// More high-level code on top of miniquad probably is going to call this in Drop implementation of some

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -33,6 +33,8 @@ pub use event::*;
 
 pub use graphics::*;
 
+pub use sapp::gl;
+
 use std::ffi::CString;
 
 #[deprecated(


### PR DESCRIPTION
Revisiting this https://github.com/not-fl3/miniquad/pull/48 discussion I came to the conclusion that I was wrong. 

It is totally fine to re-export api-specific internals for some corner cases. 

Problem with this PR though: 
It is easy to break miniquad's gl state assumptions by doing some raw gl calls. 

Going to create an issue for "reset gl cache" function that is going to solve this: after GL calls possibly affecting miniquad's assumptions that function may be called to reset cache state and restore miniquad's internal state later. 