### PR TITLE
Fix wasm32 dependencies in Cargo.toml

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -38,7 +38,7 @@ sapp-ios = { path = "./native/sapp-ios", version = "=0.1.1" }
 [target.'cfg(target_os = "android")'.dependencies]
 sapp-android = { path = "./native/sapp-android", version = "0.1.4" }
 
-[target.wasm32-unknown-unknown.dependencies]
+[target.'cfg(target_arch = "wasm32")'.dependencies]
 sapp-wasm = { path ="./native/sapp-wasm", version = "=0.1.19" }
 
 [target.'cfg(not(any(target_os="linux", target_os="macos", target_os="android", target_os="ios", target_arch="wasm32", windows)))'.dependencies]


### PR DESCRIPTION
It looks like this patch is the only thing needed to make microquad compile for `wasm32-wasi` target.

P.S. Great work with microquad and macroquad, I love it!