### PR TITLE
native/sapp-wasm: JS Versioning

### DIFF
--- a/native/sapp-wasm/js/gl.js
+++ b/native/sapp-wasm/js/gl.js
@@ -8,6 +8,8 @@
 
 "use strict";
 
+const version = [0, 1, 20];
+
 const canvas = document.querySelector("#glcanvas");
 const gl = canvas.getContext("webgl");
 if (gl === null) {
@@ -1195,6 +1197,21 @@ function register_plugins(plugins) {
     }
 }
 
+function validate_version(version) {
+    let crate_version = wasm_exports.crate_version();
+    let crate_major_version = (crate_version >> 24) & 0xff;
+    let crate_minor_version = (crate_version >> 16) & 0xff;
+    let crate_patch_version = crate_version & 0xffff;
+
+    if (crate_major_version != version[0] || crate_minor_version != version[1] ||  crate_patch_version != version[2]) {
+        console.error(
+            "Version mismatch: gl.js version is: " + version +
+                ", rust sapp-wasm crate version is: " +
+                crate_major_version + "," + crate_minor_version + "," + crate_patch_version
+        );
+    }
+}
+
 function init_plugins(plugins) {
     if (plugins == undefined)
         return;
@@ -1243,6 +1260,9 @@ function load(wasm_path) {
                     wasm_memory = obj.exports.memory;
                     wasm_exports = obj.exports;
 
+                    if (validate_version(version) == false) {
+                        console.error("Incompatible gl.js version!");
+                    }
                     init_plugins(plugins);
                     obj.exports.main();
                 })
@@ -1261,6 +1281,10 @@ function load(wasm_path) {
             .then(function (obj) {
                 wasm_memory = obj.exports.memory;
                 wasm_exports = obj.exports;
+
+                if (validate_version(version) == false) {
+                    console.error("Incompatible gl.js version!");
+                }
 
                 init_plugins(plugins);
                 obj.exports.main();

--- a/native/sapp-wasm/src/lib.rs
+++ b/native/sapp-wasm/src/lib.rs
@@ -340,6 +340,15 @@ pub unsafe fn sapp_dpi_scale() -> f32 {
 }
 
 #[no_mangle]
+pub extern "C" fn crate_version() -> u32 {
+    let major = env!("CARGO_PKG_VERSION_MAJOR").parse::<u32>().unwrap();
+    let minor = env!("CARGO_PKG_VERSION_MINOR").parse::<u32>().unwrap();
+    let patch = env!("CARGO_PKG_VERSION_PATCH").parse::<u32>().unwrap();
+
+    (major << 24) + (minor << 16) + patch
+}
+
+#[no_mangle]
 pub extern "C" fn allocate_vec_u8(len: usize) -> *mut u8 {
     let mut string = vec![0u8; len];
     let ptr = string.as_mut_ptr();

--- a/native/sapp-wasm/src/lib.rs
+++ b/native/sapp-wasm/src/lib.rs
@@ -308,7 +308,6 @@ pub unsafe fn sapp_height() -> ::std::os::raw::c_int {
     canvas_height()
 }
 
-#[no_mangle]
 extern "C" {
     pub fn init_opengl();
     pub fn canvas_width() -> i32;


### PR DESCRIPTION
Before this change:

![2020-12-28-220405_844x26_scrot](https://user-images.githubusercontent.com/910977/103301471-200d6380-49c7-11eb-8a48-919401770485.png)

After this change:

![2020-12-29-111908_621x21_scrot](https://user-images.githubusercontent.com/910977/103301656-72e71b00-49c7-11eb-9363-6c367de7c000.png)

![2020-12-29-094207_677x24_scrot](https://user-images.githubusercontent.com/910977/103301474-20a5fa00-49c7-11eb-9bd2-505320f40477.png)

The first step towards fixing our very long-standing problem with javascript dependencies.
Related PR: https://github.com/not-fl3/miniquad/pull/97