### PR TITLE
graphics: Fix texure wrapping

### DIFF
--- a/src/graphics/texture.rs
+++ b/src/graphics/texture.rs
@@ -97,8 +97,6 @@ pub enum TextureWrap {
     Mirror,
     /// Samples at coord x + 1 map to coord 1.
     Clamp,
-    /// Same as Mirror, but only for one repetition.
-    MirrorClamp,
 }
 
 #[derive(Clone, Copy, Debug, PartialEq)]

--- a/src/graphics/texture.rs
+++ b/src/graphics/texture.rs
@@ -88,15 +88,14 @@ impl Default for TextureParams {
 }
 
 /// Sets the wrap parameter for texture.
-#[repr(u8)]
 #[derive(Debug, PartialEq, Eq, Clone, Copy)]
 pub enum TextureWrap {
     /// Samples at coord x + 1 map to coord x.
-    Repeat,
+    Repeat = GL_REPEAT as isize,
     /// Samples at coord x + 1 map to coord 1 - x.
-    Mirror,
+    Mirror = GL_MIRRORED_REPEAT as isize,
     /// Samples at coord x + 1 map to coord 1.
-    Clamp,
+    Clamp = GL_CLAMP_TO_EDGE as isize,
 }
 
 #[derive(Clone, Copy, Debug, PartialEq)]
@@ -179,8 +178,8 @@ impl Texture {
                 },
             );
 
-            glTexParameteri(GL_TEXTURE_2D, GL_TEXTURE_WRAP_S, GL_CLAMP_TO_EDGE as i32);
-            glTexParameteri(GL_TEXTURE_2D, GL_TEXTURE_WRAP_T, GL_CLAMP_TO_EDGE as i32);
+            glTexParameteri(GL_TEXTURE_2D, GL_TEXTURE_WRAP_S, params.wrap as i32);
+            glTexParameteri(GL_TEXTURE_2D, GL_TEXTURE_WRAP_T, params.wrap as i32);
             glTexParameteri(GL_TEXTURE_2D, GL_TEXTURE_MIN_FILTER, params.filter as i32);
             glTexParameteri(GL_TEXTURE_2D, GL_TEXTURE_MAG_FILTER, params.filter as i32);
         }


### PR DESCRIPTION
Hi. I noticed the TextureParams.wrap field wasn't wired up to the actual GL wrap mode, which was always Clamp. This fixes it. I just mimicked how TextureParams.filter works.