### PR TITLE
set_mouse_cursor

### DIFF
--- a/examples/mouse_cursor.rs
+++ b/examples/mouse_cursor.rs
@@ -1,0 +1,47 @@
+use miniquad::*;
+
+struct Stage {
+    inited: bool,
+}
+
+impl EventHandler for Stage {
+    fn update(&mut self, ctx: &mut Context) {
+        if !self.inited {
+            ctx.set_mouse_cursor(CursorIcon::Crosshair);
+            self.inited = true;
+        }
+    }
+
+    fn draw(&mut self, _ctx: &mut Context) {}
+
+    fn char_event(&mut self, ctx: &mut Context, character: char, _: KeyMods, _: bool) {
+        match character {
+            'z' => ctx.show_mouse(false),
+            'x' => ctx.show_mouse(true),
+            _ => (),
+        }
+
+        let icon = match character {
+            '1' => CursorIcon::Default,
+            '2' => CursorIcon::Help,
+            '3' => CursorIcon::Pointer,
+            '4' => CursorIcon::Wait,
+            '5' => CursorIcon::Crosshair,
+            '6' => CursorIcon::Text,
+            '7' => CursorIcon::Move,
+            '8' => CursorIcon::NotAllowed,
+            '9' => CursorIcon::EWResize,
+            '0' => CursorIcon::NSResize,
+            'q' => CursorIcon::NESWResize,
+            'w' => CursorIcon::NWSEResize,
+            _ => return,
+        };
+        ctx.set_mouse_cursor(icon);
+    }
+}
+
+fn main() {
+    miniquad::start(conf::Conf::default(), |ctx| {
+        UserData::owning(Stage { inited: false }, ctx)
+    });
+}

--- a/native/sapp-linux/src/x_cursor.rs
+++ b/native/sapp-linux/src/x_cursor.rs
@@ -17,7 +17,23 @@ type Drawable = XID;
 
 pub type Cursor = XID;
 
+// See https://tronche.com/gui/x/xlib/appendix/b/
+pub const XC_crosshair: libc::c_ushort = 34;
+pub const XC_fleur: libc::c_ushort = 52;
+pub const XC_hand2: libc::c_ushort = 60;
+pub const XC_left_ptr: libc::c_ushort = 68;
+pub const XC_pirate: libc::c_ushort = 88;
+pub const XC_question_arrow: libc::c_ushort = 92;
+pub const XC_sb_h_double_arrow: libc::c_ushort = 108;
+pub const XC_sb_v_double_arrow: libc::c_ushort = 116;
+pub const XC_top_left_corner: libc::c_ushort = 134;
+pub const XC_top_right_corner: libc::c_ushort = 136;
+pub const XC_watch: libc::c_ushort = 150;
+pub const XC_xterm: libc::c_ushort = 152;
+
 extern "C" {
+    fn XCreateFontCursor(_: *mut Display, _: libc::c_ushort) -> Cursor;
+
     fn XCreateBitmapFromData(
         _: *mut Display,
         _: Drawable,
@@ -71,6 +87,10 @@ pub unsafe fn create_empty_cursor() -> Cursor {
     XFreePixmap(_sapp_x11_display, cursor_pixmap);
 
     empty_cursor
+}
+
+pub unsafe fn load_cursor(shape: libc::c_ushort) -> Cursor {
+    XCreateFontCursor(_sapp_x11_display, shape)
 }
 
 pub unsafe fn set_cursor(cursor: Cursor) {

--- a/native/sapp-wasm/js/gl.js
+++ b/native/sapp-wasm/js/gl.js
@@ -1228,6 +1228,9 @@ var importObject = {
             } else {
                 document.exitPointerLock();
             }
+        },
+        sapp_set_cursor: function(ptr, len) {
+            canvas.style.cursor = UTF8ToString(ptr, len);
         }
     }
 };

--- a/native/sapp-wasm/src/lib.rs
+++ b/native/sapp-wasm/src/lib.rs
@@ -205,6 +205,19 @@ pub const SAPP_MODIFIER_CTRL: u32 = 1 << 1;
 pub const SAPP_MODIFIER_ALT: u32 = 1 << 2;
 pub const SAPP_MODIFIER_SUPER: u32 = 1 << 3;
 
+pub const SAPP_CURSOR_DEFAULT: u32 = 0;
+pub const SAPP_CURSOR_HELP: u32 = 1;
+pub const SAPP_CURSOR_POINTER: u32 = 2;
+pub const SAPP_CURSOR_WAIT: u32 = 3;
+pub const SAPP_CURSOR_CROSSHAIR: u32 = 4;
+pub const SAPP_CURSOR_TEXT: u32 = 5;
+pub const SAPP_CURSOR_MOVE: u32 = 6;
+pub const SAPP_CURSOR_NOTALLOWED: u32 = 7;
+pub const SAPP_CURSOR_EWRESIZE: u32 = 8;
+pub const SAPP_CURSOR_NSRESIZE: u32 = 9;
+pub const SAPP_CURSOR_NESWRESIZE: u32 = 10;
+pub const SAPP_CURSOR_NWSERESIZE: u32 = 11;
+
 #[repr(C)]
 #[derive(Debug, Copy, Clone)]
 pub struct sapp_event {
@@ -327,11 +340,32 @@ extern "C" {
     /// "mouse_down"/"key_down" event handler functions.
     pub fn sapp_set_cursor_grab(grab: bool);
 
+    pub fn sapp_set_cursor(cursor: *const u8, len: usize);
+
     pub fn sapp_is_elapsed_timer_supported() -> bool;
 }
 
 /// Do nothing on wasm - cursor will be hidden by "sapp_set_cursor_grab" anyway.
 pub unsafe fn sapp_show_mouse(_shown: bool) {}
+
+pub unsafe fn sapp_set_mouse_cursor(cursor: u32) {
+    let css_name = match cursor {
+        SAPP_CURSOR_DEFAULT => "default",
+        SAPP_CURSOR_HELP => "help",
+        SAPP_CURSOR_POINTER => "pointer",
+        SAPP_CURSOR_WAIT => "wait",
+        SAPP_CURSOR_CROSSHAIR => "crosshair",
+        SAPP_CURSOR_TEXT => "text",
+        SAPP_CURSOR_MOVE => "move",
+        SAPP_CURSOR_NOTALLOWED => "not-allowed",
+        SAPP_CURSOR_EWRESIZE => "ew-resize",
+        SAPP_CURSOR_NSRESIZE => "ns-resize",
+        SAPP_CURSOR_NESWRESIZE => "nesw-resize",
+        SAPP_CURSOR_NWSERESIZE => "nwse-resize",
+        _ => return,
+    };
+    sapp_set_cursor(css_name.as_ptr(), css_name.len());
+}
 
 pub unsafe fn sapp_high_dpi() -> bool {
     false

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -128,6 +128,47 @@ impl Context {
             sapp::sapp_show_mouse(shown);
         }
     }
+
+    /// Set the mouse cursor icon.
+    pub fn set_mouse_cursor(&self, _cursor_icon: CursorIcon) {
+        #[cfg(any(
+            target_arch = "wasm32",
+            all(target_os = "linux", not(feature = "kms")),
+            windows,
+        ))]
+        unsafe {
+            sapp::sapp_set_mouse_cursor(match _cursor_icon {
+                CursorIcon::Default => sapp::SAPP_CURSOR_DEFAULT,
+                CursorIcon::Help => sapp::SAPP_CURSOR_HELP,
+                CursorIcon::Pointer => sapp::SAPP_CURSOR_POINTER,
+                CursorIcon::Wait => sapp::SAPP_CURSOR_WAIT,
+                CursorIcon::Crosshair => sapp::SAPP_CURSOR_CROSSHAIR,
+                CursorIcon::Text => sapp::SAPP_CURSOR_TEXT,
+                CursorIcon::Move => sapp::SAPP_CURSOR_MOVE,
+                CursorIcon::NotAllowed => sapp::SAPP_CURSOR_NOTALLOWED,
+                CursorIcon::EWResize => sapp::SAPP_CURSOR_EWRESIZE,
+                CursorIcon::NSResize => sapp::SAPP_CURSOR_NSRESIZE,
+                CursorIcon::NESWResize => sapp::SAPP_CURSOR_NESWRESIZE,
+                CursorIcon::NWSEResize => sapp::SAPP_CURSOR_NWSERESIZE,
+            });
+        }
+    }
+}
+
+#[derive(Debug, Copy, Clone, PartialEq, Hash, Eq)]
+pub enum CursorIcon {
+    Default,
+    Help,
+    Pointer,
+    Wait,
+    Crosshair,
+    Text,
+    Move,
+    NotAllowed,
+    EWResize,
+    NSResize,
+    NESWResize,
+    NWSEResize,
 }
 
 pub enum UserData {


### PR DESCRIPTION
Hey. This is a sketch of an implementation of #171, setting the cursor icon. ~~I'm hoping to get feedback on whether you want this, if this is going in the right direction, if the public API is okay, etc. before I go too far.~~

Okay, well, I went on and finished up the Linux/X11, wasm, and Windows implementations anyway. There is a new `mouse_cursor` example you can try. Press `1234567890qw` to change the mouse cursor, `zx` to hide/show the mouse.

The interface looks like `ctx.set_mouse_cursor(CursorIcon::Pointer)`. The names in `CursorIcon` match the [CSS `cursor` property](https://developer.mozilla.org/en-US/docs/Web/CSS/cursor) names.

Notes about the implementations

* Windows uses `LoadCursor`. This is the main limiting factor in what cursor icons are available (see [here](https://docs.microsoft.com/en-us/windows/win32/api/winuser/nf-winuser-loadcursora) for a list); for example the "grabbing hand" requested in #171 is not on the list. AFAICT the way browsers get the "grabbing" hand is to embed their own .cur for it in the .exe.
* X11 uses `XCreateFontCursor`. The available cursors are listed [here](https://tronche.com/gui/x/xlib/appendix/b/). The grabbing hand isn't on this list. Neither are the nesw-resize/nwse-resize icons but I used ![](https://tronche.com/gui/x/xlib/appendix/b/136.gif) and ![](https://tronche.com/gui/x/xlib/appendix/b/134.gif) as approximations.

    An alternative is to use `XcursorLibraryLoadCursor` which would allow grabbing, nesw-resize, etc. However, it requires linking against `Xcursor` (or dlopening it or something). This works for me locally, but the CI machine doesn't have `Xcursor`, so I went with the simpler `XCreateFontCursor`.
* Wasm just sets the CSS `cursor` property on the canvas. This branch also makes `show_mouse` work for the first time on wasm.
* In X11 and wasm, where hiding the cursor is implemented by setting the cursor icon to an empty icon, miniquad needs to track the icon and whether the mouse is hidden so eg. (hide -> change icon -> show) will work correctly.
* I can't do darwin because I don't have a Mac.

Things to check

* Is the public API okay?
* The CursorIcon is passed to the backends by integer constants `SAPP_CURSOR_DEFAULT`, etc. repeated once in every backend. Is that the best way to do it?
* For X11/wasm, the variables to track the icon/visibility are globals. Should they be fields of sapp_state instead or something?