### PR TITLE
expose sapp_android if on android target

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,5 +1,12 @@
 #[cfg(target_os = "android")]
 extern crate sapp_android as sapp;
+
+// if on android we need to expose sapp_android
+// to the user so they can call the appropriate sapp init
+// functions
+#[cfg(target_os = "android")]
+pub use sapp_android;
+
 #[cfg(target_os = "macos")]
 extern crate sapp_darwin as sapp;
 #[cfg(not(any(

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,9 +1,6 @@
 #[cfg(target_os = "android")]
 extern crate sapp_android as sapp;
 
-// if on android we need to expose sapp_android
-// to the user so they can call the appropriate sapp init
-// functions
 #[cfg(target_os = "android")]
 pub use sapp_android;
 


### PR DESCRIPTION
addresses #185 

I created a fork of it [here](https://github.com/nikita-skobov/android-ndk-rs/tree/miniglue)

The changes are basically the same that you had in your fork, but using the latest android-ndk-rs. I tested this and it now successfully compiles rust code that needs 1.50.0 features.

However, for it to successfully compile, it needs to expose `sapp_android` in miniquad if compiling for android. [see here](https://github.com/nikita-skobov/android-ndk-rs/commit/9cc4af43756d13d3940dd640a01e35ed994b8175#diff-97ba036ced5dadf173f84ad3cbf9db153d947f441cbc59a7bb77858a784c802bR112)