### PR TITLE
android ndk glue code rewrite

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -37,6 +37,8 @@ sapp-ios = { path = "./native/sapp-ios", version = "=0.1.2" }
 
 [target.'cfg(target_os = "android")'.dependencies]
 sapp-android = { path = "./native/sapp-android", version = "0.1.5" }
+ndk = { path = "../android-ndk-rs/ndk" }
+ndk-glue = { path = "../android-ndk-rs/ndk-glue" }
 
 [target.'cfg(target_arch = "wasm32")'.dependencies]
 sapp-wasm = { path ="./native/sapp-wasm", version = "=0.1.22" }
@@ -47,3 +49,12 @@ sapp-dummy = { path ="./native/sapp-dummy", version = "=0.1.5" }
 [dev-dependencies]
 glam = {version = "0.8", features = ["scalar-math"] }
 quad-rand = "0.1"
+
+[[example]]
+name = "quad-android"
+crate-type = ["cdylib"]
+path = "examples/quad.rs"
+
+[[example]]
+name = "quad"
+path = "examples/quad.rs"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -14,8 +14,9 @@ keywords = ["graphics", "3D", "opengl", "gamedev", "windowing"]
 categories = ["rendering::graphics-api"]
 
 [features]
-default = ["sapp-linux"]
+default = ["sapp-linux", "minimain"]
 kms = ["sapp-kms"]
+minimain = ["miniquad-main"]
 
 # Optional log-rs like macros implementation
 # disabled by default
@@ -37,14 +38,18 @@ sapp-ios = { path = "./native/sapp-ios", version = "=0.1.2" }
 
 [target.'cfg(target_os = "android")'.dependencies]
 sapp-android = { path = "./native/sapp-android", version = "0.1.5" }
-ndk = { path = "../android-ndk-rs/ndk" }
-ndk-glue = { path = "../android-ndk-rs/ndk-glue" }
+ndk = "0.3"
+ndk-glue = "0.3"
+
 
 [target.'cfg(target_arch = "wasm32")'.dependencies]
 sapp-wasm = { path ="./native/sapp-wasm", version = "=0.1.22" }
 
 [target.'cfg(not(any(target_os="linux", target_os="macos", target_os="android", target_os="ios", target_arch="wasm32", windows)))'.dependencies]
 sapp-dummy = { path ="./native/sapp-dummy", version = "=0.1.5" }
+
+[dependencies]
+miniquad-main = { path = "./miniquad-main", optional = true }
 
 [dev-dependencies]
 glam = {version = "0.8", features = ["scalar-math"] }

--- a/examples/quad.rs
+++ b/examples/quad.rs
@@ -85,7 +85,7 @@ impl EventHandler for Stage {
     }
 }
 
-#[cfg_attr(target_os = "android", ndk_glue::main(ndk_glue = "::miniquad::sapp_android"))]
+#[miniquad::main]
 fn main() {
     miniquad::start(conf::Conf::default(), |mut ctx| {
         UserData::owning(Stage::new(&mut ctx), ctx)

--- a/examples/quad.rs
+++ b/examples/quad.rs
@@ -85,6 +85,7 @@ impl EventHandler for Stage {
     }
 }
 
+#[cfg_attr(target_os = "android", ndk_glue::main(ndk_glue = "::miniquad::sapp_android"))]
 fn main() {
     miniquad::start(conf::Conf::default(), |mut ctx| {
         UserData::owning(Stage::new(&mut ctx), ctx)

--- a/miniquad-main/Cargo.toml
+++ b/miniquad-main/Cargo.toml
@@ -1,0 +1,12 @@
+[package]
+name = "miniquad-main"
+version = "0.1.0"
+authors = ["nikita-skobov"]
+edition = "2018"
+
+[dependencies]
+syn = { version = "1.0", features = ["full"] }
+quote = "1.0"
+
+[lib]
+proc-macro = true

--- a/miniquad-main/src/lib.rs
+++ b/miniquad-main/src/lib.rs
@@ -19,7 +19,7 @@ pub fn main(attr_input: TokenStream, item_input: TokenStream) -> TokenStream {
     let input = parse_macro_input!(item_input as ItemFn);
 
     let expanded = quote! {
-        #[cfg_attr(target_os = "android", ndk_glue::main(ndk_glue = "::miniquad::sapp_android"))]
+        #[cfg_attr(target_os = "android", ::miniquad::sapp_android::ndk_glue::main(ndk_glue = "::miniquad::sapp_android"))]
         #input
     };
 

--- a/miniquad-main/src/lib.rs
+++ b/miniquad-main/src/lib.rs
@@ -1,0 +1,27 @@
+use proc_macro::TokenStream;
+use quote::quote;
+use syn::{parse_macro_input, ItemFn};
+
+/// we offer a convenience wrapper to be used as
+/// ```
+/// #[miniquad::main]
+/// pub fn main() {}
+/// ```
+/// Basically we just wrap the ndk glue main where
+/// we specify our custom glue code. Alternatively, you can do
+/// this yourself with:
+/// ```
+/// #[cfg_attr(target_os = "android", ndk_glue::main(ndk_glue = "::miniquad::sapp_android"))]
+/// pub fn main() {}
+/// ```
+#[proc_macro_attribute]
+pub fn main(attr_input: TokenStream, item_input: TokenStream) -> TokenStream {
+    let input = parse_macro_input!(item_input as ItemFn);
+
+    let expanded = quote! {
+        #[cfg_attr(target_os = "android", ndk_glue::main(ndk_glue = "::miniquad::sapp_android"))]
+        #input
+    };
+
+    TokenStream::from(expanded)
+}

--- a/native/sapp-android/Cargo.toml
+++ b/native/sapp-android/Cargo.toml
@@ -15,6 +15,6 @@ homepage = "https://github.com/not-fl3/miniquad"
 cc = "1.0"
 
 [dependencies]
-ndk = { path = "../../../android-ndk-rs/ndk" }
-ndk-glue = { path = "../../../android-ndk-rs/ndk-glue" }
-ndk-sys = { path = "../../../android-ndk-rs/ndk-sys" }
+ndk = "0.3"
+ndk-glue = "0.3"
+ndk-sys = "0.2"

--- a/native/sapp-android/Cargo.toml
+++ b/native/sapp-android/Cargo.toml
@@ -13,3 +13,8 @@ homepage = "https://github.com/not-fl3/miniquad"
 
 [build-dependencies]
 cc = "1.0"
+
+[dependencies]
+ndk = { path = "../../../android-ndk-rs/ndk" }
+ndk-glue = { path = "../../../android-ndk-rs/ndk-glue" }
+ndk-sys = { path = "../../../android-ndk-rs/ndk-sys" }

--- a/native/sapp-android/src/lib.rs
+++ b/native/sapp-android/src/lib.rs
@@ -12,6 +12,7 @@ mod rand;
 mod sokol_app_android;
 
 use ndk_sys::ANativeActivity;
+pub use ndk_glue;
 
 pub use egl::*;
 pub use gl3::*;

--- a/native/sapp-android/src/lib.rs
+++ b/native/sapp-android/src/lib.rs
@@ -11,6 +11,8 @@ pub mod gl3;
 mod rand;
 mod sokol_app_android;
 
+use ndk_sys::ANativeActivity;
+
 pub use egl::*;
 pub use gl3::*;
 pub use rand::*;
@@ -28,4 +30,19 @@ pub use query_stab::*;
 
 pub unsafe fn sapp_is_elapsed_timer_supported() -> bool {
     return false;
+}
+
+/// glue code for android. this is called by
+/// android-ndk-rs because we specify an override
+/// in the glue code crate:
+/// ```
+/// #[cfg_attr(target_os = "android", ndk_glue::main(ndk_glue = "::miniquad::sapp_android"))]
+/// ```
+pub unsafe fn init(
+    activity: *mut ANativeActivity,
+    _saved_state: *mut u8,
+    _saved_state_size: usize,
+    main: fn(),
+) {
+
 }

--- a/native/sapp-android/src/lib.rs
+++ b/native/sapp-android/src/lib.rs
@@ -32,6 +32,10 @@ pub unsafe fn sapp_is_elapsed_timer_supported() -> bool {
     return false;
 }
 
+#[link(name = "EGL")]
+#[link(name = "GLESv3")]
+extern "C" {}
+
 fn noop() {
     panic!("Unexpected noop invocation. Something is wrong with the android initialization glue code");
 }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -36,6 +36,9 @@ pub mod graphics;
 #[cfg(feature = "log-impl")]
 pub mod log;
 
+#[cfg(feature = "minimain")]
+pub use miniquad_main::main;
+
 pub use event::*;
 
 pub use graphics::*;


### PR DESCRIPTION
This is still a work in progress.

This is the first part of the proposed rewrite of the android glue code. The changes can be summarized by:

- adds dependency to the `sapp_android` package on `ndk`, `ndk-sys`, and `ndk-glue`.
- `sapp_android` provides an `init` function that can be specified by the `ndk_glue::main()` macro via: `#[cfg_attr(target_os = "android", ndk_glue::main(ndk_glue = "::miniquad::sapp_android"))]`
- our `init` function calls the sokol glue code that sets up android stuff for us.
- the sokol code implicitly calls a function called `sokol_main` so we also define one here which will call the users real `main` function.
- we provide an optional (but default included) macro to be used via: `#[miniquad::main]` which simply adds the `#[cfg_attr...]` for the ndk glue code mentioned above. basically this is a convenience wrapper that lets peoples projects be easily compiled for both android and non-android targets simply.
- adds example to Cargo.toml on how they could have multiple targets for android and non-android builds. ie: android builds would be required to be a `cdylib`, so theres a seperate example target that points to the same file. so if user wants to build for android they would do: `cargo apk build --example quad-android`, or otherwise to build for anything else: `cargo build --example quad`

**This PR is a work in progress and it doesnt actually include the rewrite of the sokol glue code like we talked about. Instead this is the kind of foundation/boilerplate of what I imagine that rewrite would look like.** So if we like what this looks like, then the next step would be to actually re-implement the code in `sapp-android/external/sokol_app.h` in rust, but I wanted to check in with the current progress before I start on that