### PR TITLE
Fix gl.js for iOS

### DIFF
--- a/native/sapp-wasm/js/gl.js
+++ b/native/sapp-wasm/js/gl.js
@@ -26,9 +26,11 @@ var high_dpi = false;
 canvas.focus();
 
 canvas.requestPointerLock = canvas.requestPointerLock ||
-    canvas.mozRequestPointerLock;
+    canvas.mozRequestPointerLock ||
+    (function () {});
 document.exitPointerLock = document.exitPointerLock ||
-    document.mozExitPointerLock;
+    document.mozExitPointerLock ||
+    (function () {});
 
 function assert(flag, message) {
     if (flag == false) {


### PR DESCRIPTION
`canvas.requestPointerLock` and `document.exitPointerLock` are not supported in Safari on iOS

<img width="843" alt="Screenshot 2021-04-21 at 06 32 28" src="https://user-images.githubusercontent.com/3097956/115492932-70a51700-a26b-11eb-81c8-ea02b831b046.png">
