### PR TITLE
add `#[derive(VertexLayout)]` that adds `VERTEX_ATTRIBUTES`

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,3 @@
-/target
+**/target
 **/*.rs.bk
 Cargo.lock

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -44,6 +44,9 @@ sapp-wasm = { path ="./native/sapp-wasm", version = "=0.1.25" }
 [target.'cfg(not(any(target_os="linux", target_os="macos", target_os="android", target_os="ios", target_arch="wasm32", windows)))'.dependencies]
 sapp-dummy = { path ="./native/sapp-dummy", version = "=0.1.5" }
 
+[dependencies]
+miniquad-derive = { path = "miniquad-derive", version = "0.1.0" }
+
 [dev-dependencies]
 glam = {version = "0.14", features = ["scalar-math"] }
 quad-rand = "0.1"

--- a/miniquad-derive/Cargo.toml
+++ b/miniquad-derive/Cargo.toml
@@ -1,0 +1,16 @@
+[package]
+name = "miniquad-derive"
+version = "0.1.0"
+edition = "2018"
+
+[lib]
+proc-macro = true
+
+[dependencies]
+proc-macro2 = "1.0.26"
+# need `extra-traits` feature for `Attribute` to implement `PartialEq`
+syn = { version = "1.0.70", features = ["derive", "parsing", "printing", "clone-impls", "proc-macro", "extra-traits"] }
+quote = "1.0.9"
+
+[dev-dependencies]
+miniquad = { path = "../" }

--- a/miniquad-derive/src/layout.rs
+++ b/miniquad-derive/src/layout.rs
@@ -1,0 +1,84 @@
+use proc_macro2::TokenStream as TokenStream2;
+use quote::*;
+use syn::*;
+
+pub fn impl_vertex_layout(ast: DeriveInput) -> TokenStream2 {
+    let ty_name = &ast.ident;
+
+    let input = match ast.data {
+        Data::Struct(ref data) => data,
+        _ => panic!("`#[derive(VertexLayout)]` is for structs"),
+    };
+
+    // force `#[repr(C)]`
+    let repr: syn::Attribute = parse_quote!(#[repr(C)]);
+    assert!(
+        ast.attrs.iter().any(|a| *a == repr),
+        "`#[repr(C)]` is required to derive `VertexLayout`"
+    );
+
+    // vertex attriubte/format
+    let va = quote!(miniquad::graphics::VertexAttribute);
+    let vf = quote!(miniquad::graphics::VertexFormat);
+
+    // SUPPORTED FIELD TYPES ARE LIMITED TO THESE TYPES:
+    let attr_decls = [
+        ("f32", quote! { #vf::Float }),
+        ("[f32; 1]", quote! { #vf::Float1 }),
+        ("[f32; 2]", quote! { #vf::Float2 }),
+        ("[f32; 3]", quote! { #vf::Float3 }),
+        ("[f32; 4]", quote! { #vf::Float4 }),
+        ("u8", quote! { #vf::Byte1 }),
+        ("[u8; 1]", quote! { #vf::Byte1 }),
+        ("[u8; 2]", quote! { #vf::Byte2 }),
+        ("[u8; 3]", quote! { #vf::Byte3 }),
+        ("[u8; 4]", quote! { #vf::Byte4 }),
+        ("u16", quote! { #vf::Short1 }),
+        ("[u16; 1]", quote! { #vf::Short1 }),
+        ("[u16; 2]", quote! { #vf::Short2 }),
+        ("[u16; 3]", quote! { #vf::Short3 }),
+        ("[u16; 4]", quote! { #vf::Short4 }),
+        ("[f32; 32]", quote! { #vf::Mat4 }),
+    ];
+
+    // maps type name tokens to vertex format
+    let format_map = attr_decls
+        .iter()
+        .map(|(s, quote)| (syn::parse_str::<syn::Type>(s).unwrap(), quote));
+
+    let fields = match input.fields {
+        Fields::Named(ref fields) => fields,
+        Fields::Unnamed(ref _fields) => todo!("impl `#[derive(VertexLayout)]` for tuple structs"),
+        Fields::Unit => {
+            unimplemented!("`#[derive(VertexLayout)]` for unit struct doesn't make sense!")
+        }
+    };
+
+    let vtx_attrs = fields.named.iter().map(|field| {
+        let format = format_map
+            .clone()
+            .find_map(|(ty, tokens)| if field.ty == ty { Some(tokens) } else { None })
+            .unwrap_or_else(|| {
+                // not found from the list
+                panic!(
+                    "Field `{}: {}` of type `{}` has unsupported type by `#[derive(VertexLayout)]`",
+                    field.ident.as_ref().unwrap(),
+                    field.ty.to_token_stream(),
+                    ty_name,
+                )
+            });
+
+        let field_ident = field.ident.as_ref().unwrap();
+        let field_name = format!("{}", field_ident);
+
+        quote! {
+            #va::new(#field_name, #format)
+        }
+    });
+
+    quote! {
+        impl #ty_name {
+            pub const VERTEX_ATTRIBUTES: &'static [#va] = &[#(#vtx_attrs,)*];
+        }
+    }
+}

--- a/miniquad-derive/src/lib.rs
+++ b/miniquad-derive/src/lib.rs
@@ -1,0 +1,16 @@
+mod layout;
+
+use {
+    proc_macro::TokenStream,
+    syn::{parse_macro_input, DeriveInput},
+};
+
+/// Adds `pub const VERTEX_ATTTRIBUTES: &'static [VertexAttribute]`
+///
+/// It requires the struct to be marked as `#[repr(C)]`.
+#[proc_macro_derive(VertexLayout)]
+pub fn vertex_layout(input: TokenStream) -> TokenStream {
+    let ast = parse_macro_input!(input as DeriveInput);
+    TokenStream::from(layout::impl_vertex_layout(ast))
+}
+

--- a/miniquad-derive/tests/layout_test.rs
+++ b/miniquad-derive/tests/layout_test.rs
@@ -1,0 +1,26 @@
+use miniquad_derive::VertexLayout;
+
+#[test]
+fn test() {
+    // `#[derive(VertexLayout)]` panics if we miss `#[repr(C)]`
+    #[repr(C)]
+    #[derive(Debug, Clone, PartialEq, VertexLayout)]
+    pub struct Vertex {
+        pos: [f32; 2],
+        color: [u8; 4],
+    }
+
+    assert_eq!(
+        Vertex::VERTEX_ATTRIBUTES,
+        &[
+            miniquad::graphics::VertexAttribute::new(
+                "pos",
+                miniquad::graphics::VertexFormat::Float2,
+            ),
+            miniquad::graphics::VertexAttribute::new(
+                "color",
+                miniquad::graphics::VertexFormat::Byte4,
+            ),
+        ]
+    );
+}

--- a/src/graphics.rs
+++ b/src/graphics.rs
@@ -6,6 +6,8 @@ use crate::sapp::*;
 
 use std::{error::Error, fmt::Display};
 
+pub use miniquad_derive::VertexLayout;
+
 pub use texture::{FilterMode, Texture, TextureAccess, TextureFormat, TextureParams, TextureWrap};
 
 fn get_uniform_location(program: GLuint, name: &str) -> Option<i32> {
@@ -225,7 +227,7 @@ impl Default for BufferLayout {
     }
 }
 
-#[derive(Clone, Debug)]
+#[derive(Clone, Debug, PartialEq)]
 pub struct VertexAttribute {
     pub name: &'static str,
     pub format: VertexFormat,


### PR DESCRIPTION
`#[derive(VertexLayout)]` generates `VERTEX_ATTRIBUTES` constant for limited types of fields.

## Background

I'm using Sokol and made such a macro. I thought it could be ported to `miniquad`.
Do you like it to be added?

## Example

```rust
use miniquad::VertexLayout;

#[test]
fn test() {
    // `#[derive(VertexLayout)]` panics at compile time if we miss `#[repr(C)]`
    #[repr(C)]
    #[derive(Debug, Clone, PartialEq, VertexLayout)]
    pub struct Vertex {
        pos: [f32; 2],
        color: [u8; 4],
    }

    assert_eq!(
        Vertex::VERTEX_ATTRIBUTES,
        &[
            miniquad::graphics::VertexAttribute::new(
                "pos",
                miniquad::graphics::VertexFormat::Float2,
            ),
            miniquad::graphics::VertexAttribute::new(
                "color",
                miniquad::graphics::VertexFormat::Byte4,
            ),
        ]
    );
}
````
