### PR TITLE
Fix DPI on windows (issue #136)

### DIFF
--- a/native/sapp-windows/src/lib.rs
+++ b/native/sapp-windows/src/lib.rs
@@ -1165,7 +1165,7 @@ unsafe fn init_dpi() {
 
     if shcore.is_null() == false {
         _sapp_win32_setprocessdpiawareness = get_proc_address(shcore, b"SetProcessDpiAwareness\0");
-        _sapp_win32_getdpiformonitor = get_proc_address(user32, b"GetDpiForMonitor\0");
+        _sapp_win32_getdpiformonitor = get_proc_address(shcore, b"GetDpiForMonitor\0");
     }
 
     if let Some(setprocessdpiawareness) = _sapp_win32_setprocessdpiawareness {
@@ -1194,7 +1194,7 @@ unsafe fn init_dpi() {
                 &mut dpix as *mut _ as _,
                 &mut dpiy as *mut _ as _,
             );
-            assert!(hr != 0);
+            assert_eq!(hr, 0);
             //  clamp window scale to an integer factor
             _sapp_win32_window_scale = dpix as f32 / 96.0;
         }


### PR DESCRIPTION
`GetDpiForMonitor` is a part of shcore not user32 according to
https://docs.microsoft.com/en-us/windows/win32/api/shellscalingapi/nf-shellscalingapi-getdpiformonitor.

And it returns `S_OK` on success that is an alias to 0 as defined here:
https://docs.microsoft.com/en-us/windows/win32/seccrypto/common-hresult-values

Should resolve https://github.com/not-fl3/miniquad/issues/136