### PR TITLE
sapp-wasm: fix clipboard miss chars

### DIFF
--- a/native/sapp-wasm/js/gl.js
+++ b/native/sapp-wasm/js/gl.js
@@ -1202,7 +1202,7 @@ var importObject = {
                 var pastedData = clipboardData.getData('Text');
 
                 if (pastedData != undefined && pastedData != null && pastedData.length != 0) {
-                    var len = pastedData.length;
+                    var len = (new TextEncoder().encode(pastedData)).length;
                     var msg = wasm_exports.allocate_vec_u8(len);
                     var heap = new Uint8Array(wasm_memory.buffer, msg, len);
                     stringToUTF8(pastedData, heap, 0, len);


### PR DESCRIPTION
Previously byte length of pasted data was counted as count of char, which is wrong for UTF8. Now this is fixed by calculating exact count of needed bytes.