### PR TITLE
implemented sapp_dpi_scale

### DIFF
--- a/native/sapp-android/src/lib.rs
+++ b/native/sapp-android/src/lib.rs
@@ -481,7 +481,7 @@ pub unsafe fn sapp_high_dpi() -> bool {
 }
 
 pub unsafe fn sapp_dpi_scale() -> f32 {
-    unimplemented!()
+    lock_shared_state().dpi_scale
 }
 
 pub unsafe fn sapp_set_cursor_grab(_grab: bool) {}


### PR DESCRIPTION
implemented fn sapp_dpi_scale to avoid the panic when running into the function (happens to me when using macroquad/egui). 