### PR TITLE
native/sapp-wasm: key_up event includes modifiers

### DIFF
--- a/native/sapp-wasm/js/gl.js
+++ b/native/sapp-wasm/js/gl.js
@@ -1137,7 +1137,19 @@ var importObject = {
             };
             canvas.onkeyup = function (event) {
                 var sapp_key_code = into_sapp_keycode(event.code);
-                wasm_exports.key_up(sapp_key_code);
+
+                var modifiers = 0;
+                if (event.ctrlKey) {
+                    modifiers |= SAPP_MODIFIER_CTRL;
+                }
+                if (event.shiftKey) {
+                    modifiers |= SAPP_MODIFIER_SHIFT;
+                }
+                if (event.altKey) {
+                    modifiers |= SAPP_MODIFIER_ALT;
+                }
+
+                wasm_exports.key_up(sapp_key_code, modifiers);
             };
             canvas.onkeypress = function (event) {
                 var sapp_key_code = into_sapp_keycode(event.code);

--- a/native/sapp-wasm/src/lib.rs
+++ b/native/sapp-wasm/src/lib.rs
@@ -534,11 +534,12 @@ pub extern "C" fn key_press(key: u32) {
 }
 
 #[no_mangle]
-pub extern "C" fn key_up(key: u32) {
+pub extern "C" fn key_up(key: u32, modifiers: u32) {
     let mut event: sapp_event = unsafe { std::mem::zeroed() };
 
     event.type_ = sapp_event_type_SAPP_EVENTTYPE_KEY_UP;
     event.key_code = key;
+    event.modifiers = modifiers;
     unsafe {
         sapp_context().event(event);
     }


### PR DESCRIPTION
key_up event in wasm implementation did not include modifiers. This caused the application to lose modifier information when any key was released.

How to reproduce:
In a macroquad wasm application, while holding ctrl key, press and release alt key.
After releasing the alt key, macroquad thinks ctrl is also no longer pressed.