### PR TITLE
Fix 'ShowCursor' logic

### DIFF
--- a/native/sapp-windows/src/gl.rs
+++ b/native/sapp-windows/src/gl.rs
@@ -247,6 +247,10 @@ pub const GL_QUERY_RESULT_AVAILABLE: u32 = 34919;
 pub const GL_VENDOR: u32 = 0x1F00;
 pub const GL_VERSION: u32 = 0x1F02;
 
+pub const GL_TEXTURE_BINDING_2D: u32 = 32873u32;
+pub const GL_TEXTURE_COMPARE_MODE: u32 = 0x884C;
+pub const GL_COMPARE_REF_TO_TEXTURE: u32 = 0x884E;
+
 pub const WGL_NUMBER_PIXEL_FORMATS_ARB: u32 = 0x2000;
 pub const WGL_SUPPORT_OPENGL_ARB: u32 = 0x2010;
 pub const WGL_DRAW_TO_WINDOW_ARB: u32 = 0x2001;
@@ -632,5 +636,6 @@ gl_loader!(
     fn glGenQueries(n: GLsizei, ids: *mut GLuint) -> (),
     fn glGetQueryObjectiv(id: GLuint, pname: GLenum, params: *mut GLint) -> (),
     fn glGetQueryObjectui64v(id: GLuint, pname: GLenum, params: *mut GLuint64) -> (),
-    fn glFinish() -> ()
+    fn glFinish() -> (),
+    fn glGenerateMipmap(target: u32) -> ()
 );

--- a/native/sapp-windows/src/lib.rs
+++ b/native/sapp-windows/src/lib.rs
@@ -535,7 +535,17 @@ pub unsafe fn sapp_set_cursor_grab(grab: bool) {
 }
 
 pub unsafe fn sapp_show_mouse(shown: bool) {
-    ShowCursor(shown as _);
+    if shown {
+        let mut display_count = ShowCursor(shown as _);
+        while display_count < 0 {
+            display_count = ShowCursor(shown as _);
+        } 
+    } else {
+        let mut display_count = ShowCursor(shown as _);
+        while display_count >= 0 {
+            display_count = ShowCursor(shown as _);
+        }
+    }
 }
 
 pub unsafe fn sapp_set_mouse_cursor(cursor_icon: u32) {

--- a/src/graphics.rs
+++ b/src/graphics.rs
@@ -1042,8 +1042,8 @@ impl Context {
     }
 
     /// start rendering to the default frame buffer
-    pub fn begin_default_pass(&mut self, action: PassAction) {
-        self.begin_pass(None, action);
+    pub fn begin_default_pass(&mut self, action: PassAction, _width: u32, _height: u32) {
+        self.begin_pass(None, action, _width, _height);
     }
 
     /// start rendering to an offscreen framebuffer

--- a/src/graphics.rs
+++ b/src/graphics.rs
@@ -1047,12 +1047,12 @@ impl Context {
     }
 
     /// start rendering to an offscreen framebuffer
-    pub fn begin_pass(&mut self, pass: impl Into<Option<RenderPass>>, action: PassAction) {
+    pub fn begin_pass(&mut self, pass: impl Into<Option<RenderPass>>, action: PassAction, _width: u32, _height: u32) {
         let (framebuffer, w, h) = match pass.into() {
             None => (
                 self.default_framebuffer,
-                unsafe { sapp_width() } as i32,
-                unsafe { sapp_height() } as i32,
+                _width as i32,
+                _height as i32,
             ),
             Some(pass) => {
                 let pass = &self.passes[pass.0];

--- a/src/graphics.rs
+++ b/src/graphics.rs
@@ -1042,17 +1042,17 @@ impl Context {
     }
 
     /// start rendering to the default frame buffer
-    pub fn begin_default_pass(&mut self, action: PassAction, _width: u32, _height: u32) {
-        self.begin_pass(None, action, _width, _height);
+    pub fn begin_default_pass(&mut self, action: PassAction) {
+        self.begin_pass(None, action);
     }
 
     /// start rendering to an offscreen framebuffer
-    pub fn begin_pass(&mut self, pass: impl Into<Option<RenderPass>>, action: PassAction, _width: u32, _height: u32) {
+    pub fn begin_pass(&mut self, pass: impl Into<Option<RenderPass>>, action: PassAction) {
         let (framebuffer, w, h) = match pass.into() {
             None => (
                 self.default_framebuffer,
-                _width as i32,
-                _height as i32,
+                unsafe { sapp_width() } as i32,
+                unsafe { sapp_height() } as i32,
             ),
             Some(pass) => {
                 let pass = &self.passes[pass.0];

--- a/src/graphics/texture.rs
+++ b/src/graphics/texture.rs
@@ -236,6 +236,7 @@ impl Texture {
 
     pub fn resize(&mut self, ctx: &mut Context, width: u32, height: u32, bytes: Option<&[u8]>) {
         ctx.cache.store_texture_binding(0);
+        ctx.cache.bind_texture(0, self.texture);
 
         let (internal_format, format, pixel_type) = self.format.into();
 


### PR DESCRIPTION
Previously, calling `ShowCursor` on Windows would simply change the cursor's display counter, which doesn't match the behavior on other platforms.