### PR TITLE
Unbreak build on FreeBSD

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -24,7 +24,7 @@ log-impl = []
 [target.'cfg(windows)'.dependencies]
 sapp-windows = { path ="./native/sapp-windows", version = "=0.2.19" }
 
-[target.'cfg(target_os = "linux")'.dependencies]
+[target.'cfg(any(target_os = "linux", target_os = "dragonfly", target_os = "freebsd", target_os = "netbsd", target_os = "openbsd"))'.dependencies]
 sapp-linux = { path ="./native/sapp-linux", version = "=0.1.13", optional = true }
 
 sapp-kms = { path ="./native/sapp-kms", version = "=0.1.1", optional = true }
@@ -41,7 +41,7 @@ sapp-android = { path = "./native/sapp-android", version = "=0.1.10" }
 [target.'cfg(target_arch = "wasm32")'.dependencies]
 sapp-wasm = { path ="./native/sapp-wasm", version = "=0.1.26" }
 
-[target.'cfg(not(any(target_os="linux", target_os="macos", target_os="android", target_os="ios", target_arch="wasm32", windows)))'.dependencies]
+[target.'cfg(not(any(target_os="linux", target_os="dragonfly", target_os="freebsd", target_os="netbsd", target_os="openbsd", target_os="macos", target_os="android", target_os="ios", target_arch="wasm32", windows)))'.dependencies]
 sapp-dummy = { path ="./native/sapp-dummy", version = "=0.1.5" }
 
 [dev-dependencies]

--- a/native/sapp-linux/build.rs
+++ b/native/sapp-linux/build.rs
@@ -3,7 +3,12 @@ use std::env;
 fn main() {
     let target = env::var("TARGET").unwrap_or_else(|e| panic!("{}", e));
 
-    if target.contains("linux") == false {
+    if target.contains("linux") == false
+       && target.contains("dragonfly") == false
+       && target.contains("freebsd") == false
+       && target.contains("netbsd") == false
+       && target.contains("openbsd") == false
+    {
         panic!("sapp_linux support only linux target");
     }
 

--- a/src/clipboard.rs
+++ b/src/clipboard.rs
@@ -2,7 +2,13 @@
 
 use crate::Context;
 
-#[cfg(all(target_os = "linux", feature = "sapp-linux"))]
+#[cfg(all(feature = "sapp-linux", any(
+    target_os = "linux",
+    target_os = "dragonfly",
+    target_os = "freebsd",
+    target_os = "netbsd",
+    target_os = "openbsd",
+)))]
 mod linux_x11 {
     use crate::Context;
 
@@ -53,7 +59,13 @@ mod windows {
 }
 
 #[cfg(not(any(
-    all(target_os = "linux", feature = "sapp-linux"),
+    all(feature = "sapp-linux", any(
+        target_os = "linux",
+        target_os = "dragonfly",
+        target_os = "freebsd",
+        target_os = "netbsd",
+        target_os = "openbsd",
+    )),
     target_os = "windows",
     target_arch = "wasm32"
 )))]
@@ -68,12 +80,24 @@ mod dummy {
 }
 
 #[cfg(not(any(
-    all(target_os = "linux", feature = "sapp-linux"),
+    all(feature = "sapp-linux", any(
+        target_os = "linux",
+        target_os = "dragonfly",
+        target_os = "freebsd",
+        target_os = "netbsd",
+        target_os = "openbsd",
+    )),
     target_os = "windows",
     target_arch = "wasm32"
 )))]
 use dummy as clipboard;
-#[cfg(all(target_os = "linux", feature = "sapp-linux"))]
+#[cfg(all(feature = "sapp-linux", any(
+    target_os = "linux",
+    target_os = "dragonfly",
+    target_os = "freebsd",
+    target_os = "netbsd",
+    target_os = "openbsd",
+)))]
 use linux_x11 as clipboard;
 #[cfg(target_arch = "wasm32")]
 use wasm as clipboard;

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -8,6 +8,10 @@ pub use sapp_android;
 extern crate sapp_darwin as sapp;
 #[cfg(not(any(
     target_os = "linux",
+    target_os = "dragonfly",
+    target_os = "freebsd",
+    target_os = "netbsd",
+    target_os = "openbsd",
     target_os = "macos",
     target_os = "ios",
     target_os = "android",
@@ -17,9 +21,21 @@ extern crate sapp_darwin as sapp;
 extern crate sapp_dummy as sapp;
 #[cfg(target_os = "ios")]
 extern crate sapp_ios as sapp;
-#[cfg(all(target_os = "linux", feature = "kms"))]
+#[cfg(all(feature = "kms", any(
+    target_os = "linux",
+    target_os = "dragonfly",
+    target_os = "freebsd",
+    target_os = "netbsd",
+    target_os = "openbsd",
+)))]
 extern crate sapp_kms as sapp;
-#[cfg(all(target_os = "linux", not(feature = "kms")))]
+#[cfg(all(not(feature = "kms"), any(
+    target_os = "linux",
+    target_os = "dragonfly",
+    target_os = "freebsd",
+    target_os = "netbsd",
+    target_os = "openbsd",
+)))]
 extern crate sapp_linux as sapp;
 
 #[cfg(target_arch = "wasm32")]
@@ -140,7 +156,13 @@ impl Context {
     pub fn set_mouse_cursor(&self, _cursor_icon: CursorIcon) {
         #[cfg(any(
             target_arch = "wasm32",
-            all(target_os = "linux", not(feature = "kms")),
+            all(not(feature = "kms"), any(
+                target_os = "linux",
+                target_os = "dragonfly",
+                target_os = "freebsd",
+                target_os = "netbsd",
+                target_os = "openbsd",
+            )),
             windows,
         ))]
         unsafe {
@@ -166,6 +188,10 @@ impl Context {
     pub fn set_window_size(&self, new_width: u32, new_height: u32) {
         #[cfg(not(any(
             target_os = "linux",
+            target_os = "dragonfly",
+            target_os = "freebsd",
+            target_os = "netbsd",
+            target_os = "openbsd",
             target_os = "macos",
             target_os = "ios",
             target_os = "android",
@@ -188,7 +214,15 @@ impl Context {
 
     #[allow(unused_variables)]
     pub fn set_fullscreen(&self, fullscreen: bool) {
-        #[cfg(not(any(target_os = "linux", target_os = "ios", target_os = "android",)))]
+        #[cfg(not(any(
+            target_os = "linux",
+            target_os = "dragonfly",
+            target_os = "freebsd",
+            target_os = "netbsd",
+            target_os = "openbsd",
+            target_os = "ios",
+            target_os = "android",
+	)))]
         unsafe {
             sapp::sapp_set_fullscreen(fullscreen);
         }


### PR DESCRIPTION
OpenGL on X11 is supported on every Unix. KMS/X11 requires **modern** Unix e.g., Linux, BSD, Solaris. Wayland is also supported on DragonFly and FreeBSD, so #152 can be extended to those or match X11. Runtime tested under Xwayland via [FishFight](https://github.com/fishfight/FishFight) ([package](https://www.freshports.org/games/fishfight)).

### Before
```rust
$ cargo build
[...]
error[E0433]: failed to resolve: use of undeclared crate or module `gl`
   --> src/graphics/texture.rs:336:27
    |
336 |             glGetIntegerv(gl::GL_DRAW_FRAMEBUFFER_BINDING, &mut binded_fbo);
    |                           ^^ use of undeclared crate or module `gl`

error[E0433]: failed to resolve: use of undeclared crate or module `gl`
   --> src/graphics/texture.rs:338:31
    |
338 |             glBindFramebuffer(gl::GL_FRAMEBUFFER, fbo);
    |                               ^^ use of undeclared crate or module `gl`

error[E0433]: failed to resolve: use of undeclared crate or module `gl`
   --> src/graphics/texture.rs:340:17
    |
340 |                 gl::GL_FRAMEBUFFER,
    |                 ^^ use of undeclared crate or module `gl`

error[E0433]: failed to resolve: use of undeclared crate or module `gl`
   --> src/graphics/texture.rs:341:17
    |
341 |                 gl::GL_COLOR_ATTACHMENT0,
    |                 ^^ use of undeclared crate or module `gl`

error[E0433]: failed to resolve: use of undeclared crate or module `gl`
   --> src/graphics/texture.rs:342:17
    |
342 |                 gl::GL_TEXTURE_2D,
    |                 ^^ use of undeclared crate or module `gl`

error[E0433]: failed to resolve: use of undeclared crate or module `gl`
   --> src/graphics/texture.rs:357:31
    |
357 |             glBindFramebuffer(gl::GL_FRAMEBUFFER, binded_fbo as _);
    |                               ^^ use of undeclared crate or module `gl`

error[E0425]: cannot find function `sapp_is_fullscreen` in crate `sapp`
   --> src/lib.rs:174:22
    |
174 |             if sapp::sapp_is_fullscreen() {
    |                      ^^^^^^^^^^^^^^^^^^ not found in `sapp`

error[E0425]: cannot find function `sapp_set_window_size` in crate `sapp`
   --> src/lib.rs:180:19
    |
180 |             sapp::sapp_set_window_size(new_width, new_height);
    |                   ^^^^^^^^^^^^^^^^^^^^ not found in `sapp`

error[E0425]: cannot find function `sapp_set_fullscreen` in crate `sapp`
   --> src/lib.rs:193:19
    |
193 |             sapp::sapp_set_fullscreen(fullscreen);
    |                   ^^^^^^^^^^^^^^^^^^^ not found in `sapp`

error[E0603]: module `gl` is private
  --> src/lib.rs:43:15
   |
43 | pub use sapp::gl;
   |               ^^ private module
   |
note: the module `gl` is defined here
  --> /tmp/miniquad/native/sapp-dummy/src/lib.rs:14:1
   |
14 | mod gl;
   | ^^^^^^^

error[E0609]: no field `window_resizable` on type `sapp_desc`
   --> src/lib.rs:434:14
    |
434 |         desc.window_resizable = conf.window_resizable as _;
    |              ^^^^^^^^^^^^^^^^ unknown field
    |
    = note: available fields are: `init_cb`, `frame_cb`, `cleanup_cb`, `event_cb`, `fail_cb` ... and 22 others
```
### After
```rust
$ cargo test
[...]
warning: field is never read: `offset`
   --> src/graphics.rs:319:5
    |
319 |     offset: usize,
    |     ^^^^^^^^^^^^^
    |
    = note: `#[warn(dead_code)]` on by default

warning: field is never read: `size`
   --> src/graphics.rs:320:5
    |
320 |     size: usize,
    |     ^^^^^^^^^^^

warning: `miniquad` (lib) generated 2 warnings
warning: `miniquad` (lib test) generated 2 warnings (2 duplicates)
    Finished test [unoptimized + debuginfo] target(s) in 3.61s
     Running unittests (target/debug/deps/miniquad-c706136e193f73a0)

running 0 tests

test result: ok. 0 passed; 0 failed; 0 ignored; 0 measured; 0 filtered out; finished in 0.00s

   Doc-tests miniquad

running 11 tests
test src/conf.rs - conf (line 19) ... ignored
test src/graphics.rs - graphics::Buffer::immutable (line 1693) ... ignored
test src/lib.rs - start (line 374) - compile ... ok
test src/lib.rs - start (line 388) - compile ... ok
test src/graphics.rs - graphics::BlendState (line 337) ... ok
test src/graphics.rs - graphics::PipelineParams::alpha_blend (line 1449) ... ok
test src/graphics.rs - graphics::PipelineParams::color_blend (line 1433) ... ok
test src/graphics.rs - graphics::ElapsedQuery (line 1834) ... ok
test src/graphics.rs - graphics::ElapsedQuery (line 1846) ... ok
test src/graphics.rs - graphics::ElapsedQuery (line 1859) ... ok
test src/graphics.rs - graphics::ElapsedQuery (line 1826) ... ok

test result: ok. 9 passed; 0 failed; 2 ignored; 0 measured; 0 filtered out; finished in 0.13s
```
