### PR TITLE
File drag & drop support for Windows, Linux and WASM

### DIFF
--- a/native/sapp-linux/src/clipboard.rs
+++ b/native/sapp-linux/src/clipboard.rs
@@ -13,19 +13,6 @@ const AnyPropertyType: libc::c_long = 0 as libc::c_long;
 
 type Time = libc::c_ulong;
 
-extern "C" {
-    pub fn XConvertSelection(
-        _: *mut Display,
-        _: Atom,
-        _: Atom,
-        _: Atom,
-        _: Window,
-        _: Time,
-    ) -> libc::c_int;
-
-    pub fn XSetSelectionOwner(_: *mut Display, _: Atom, _: Window, _: Time) -> libc::c_int;
-}
-
 pub unsafe fn get_clipboard(
     mut bufname: *const libc::c_char,
     mut fmtname: *const libc::c_char,

--- a/native/sapp-linux/src/x.rs
+++ b/native/sapp-linux/src/x.rs
@@ -10,7 +10,7 @@ pub use X_h::{
     FocusChangeMask, GrabModeAsync, InputOutput, IsViewable, KeyCode, KeyPressMask, KeyReleaseMask,
     KeySym, KeymapStateMask, LeaveWindowMask, Mod1Mask, Mod4Mask, Pixmap, PointerMotionHintMask,
     PointerMotionMask, PropModeReplace, PropertyChangeMask, PropertyNewValue, ShiftMask,
-    StaticGravity, StructureNotifyMask, Success, VisibilityChangeMask, Window, XID,
+    StaticGravity, StructureNotifyMask, Success, VisibilityChangeMask, Window, XID, Time
 };
 pub use Xlib_h::{
     ClientMessageData, Display, Screen, Visual, XChangeProperty, XClientMessageEvent,
@@ -991,5 +991,21 @@ extern "C" {
         _: libc::c_int,
         _: libc::c_long,
         _: *mut XEvent,
+    ) -> libc::c_int;
+
+    pub fn XConvertSelection(
+        _: *mut Display,
+        _: Atom,
+        _: Atom,
+        _: Atom,
+        _: Window,
+        _: Time,
+    ) -> libc::c_int;
+
+    pub fn XSetSelectionOwner(
+        _: *mut Display,
+        _: Atom,
+        _: Window,
+        _: Time
     ) -> libc::c_int;
 }

--- a/native/sapp-wasm/js/gl.js
+++ b/native/sapp-wasm/js/gl.js
@@ -1233,6 +1233,8 @@ var importObject = {
             window.ondrop = async function(e) {
                 e.preventDefault();
 
+                wasm_exports.on_files_dropped_start();
+
                 for (let file of e.dataTransfer.files) {
                     const nameLen = file.name.length;
                     const nameVec = wasm_exports.allocate_vec_u8(nameLen);
@@ -1247,6 +1249,8 @@ var importObject = {
 
                     wasm_exports.on_file_dropped(nameVec, nameLen, fileVec, fileLen);
                 }
+
+                wasm_exports.on_files_dropped_finish();
             };
 
             window.requestAnimationFrame(animation);

--- a/native/sapp-wasm/js/gl.js
+++ b/native/sapp-wasm/js/gl.js
@@ -1226,6 +1226,29 @@ var importObject = {
                 }
             });
 
+            window.ondragover = function(e) {
+                e.preventDefault();
+            };
+
+            window.ondrop = async function(e) {
+                e.preventDefault();
+
+                for (let file of e.dataTransfer.files) {
+                    const nameLen = file.name.length;
+                    const nameVec = wasm_exports.allocate_vec_u8(nameLen);
+                    const nameHeap = new Uint8Array(wasm_memory.buffer, nameVec, nameLen);
+                    stringToUTF8(file.name, nameHeap, 0, nameLen);
+
+                    const fileBuf = await file.arrayBuffer();
+                    const fileLen = fileBuf.byteLength;
+                    const fileVec = wasm_exports.allocate_vec_u8(fileLen);
+                    const fileHeap = new Uint8Array(wasm_memory.buffer, fileVec, fileLen);
+                    fileHeap.set(new Uint8Array(fileBuf), 0);
+
+                    wasm_exports.on_file_dropped(nameVec, nameLen, fileVec, fileLen);
+                }
+            };
+
             window.requestAnimationFrame(animation);
         },
 

--- a/native/sapp-wasm/src/lib.rs
+++ b/native/sapp-wasm/src/lib.rs
@@ -243,7 +243,7 @@ pub struct sapp_event {
     pub window_height: ::std::os::raw::c_int,
     pub framebuffer_width: ::std::os::raw::c_int,
     pub framebuffer_height: ::std::os::raw::c_int,
-    pub file_path: Option<[u16; 4096]>,
+    pub file_path: Option<[u8; 4096]>,
     pub file_path_length: usize,
     pub file_buf: *mut u8,
     pub file_buf_length: usize,
@@ -582,13 +582,13 @@ pub extern "C" fn touch(event_type: u32, id: u32, x: f32, y: f32) {
 
 #[no_mangle]
 pub extern "C" fn on_file_dropped(name: *mut u8, name_len: usize, bytes: *mut u8, bytes_len: usize) {
-    let name_utf16 = unsafe {
-        String::from_raw_parts(name, name_len, name_len).encode_utf16().collect::<Vec<_>>()
+    let name = unsafe {
+        String::from_raw_parts(name, name_len, name_len)
     };
 
     let mut name_array = [0; 4096];
-    let actual_len = name_array.len().min(name_utf16.len());
-    name_array[0..actual_len].copy_from_slice(&name_utf16[0..actual_len]);
+    let actual_len = name_array.len().min(name.len());
+    name_array[0..actual_len].copy_from_slice((&name[0..actual_len]).as_bytes());
 
     let mut event: sapp_event = unsafe { std::mem::zeroed() };
 

--- a/native/sapp-windows/Cargo.toml
+++ b/native/sapp-windows/Cargo.toml
@@ -12,4 +12,4 @@ homepage = "https://github.com/not-fl3/miniquad"
 include = ["src/", "Cargo.toml", "LICENSE-MIT", "LICENSE-APACHE", "README.md"]
 
 [dependencies]
-winapi = { version = "0.3", features = ["wingdi", "winuser", "libloaderapi", "windef", "shellscalingapi", "errhandlingapi", "windowsx", "winbase", "hidusage"] }
+winapi = { version = "0.3", features = ["wingdi", "winuser", "libloaderapi", "windef", "shellscalingapi", "errhandlingapi", "windowsx", "winbase", "hidusage", "shellapi"] }

--- a/native/sapp-windows/src/lib.rs
+++ b/native/sapp-windows/src/lib.rs
@@ -950,7 +950,7 @@ unsafe extern "system" fn win32_wndproc(
                     let path_len =
                         DragQueryFileW(hdrop, i, path.as_mut_ptr(), MAX_PATH as u32) as usize;
                     if path_len > 0 {
-                        paths.push(PathBuf::from(OsString::from_wide(&path)));
+                        paths.push(PathBuf::from(OsString::from_wide(&path[..path_len])));
                     }
                 }
 

--- a/src/dnd.rs
+++ b/src/dnd.rs
@@ -1,0 +1,39 @@
+//! File drag & drop abstraction
+
+#[cfg(target_arch = "wasm32")]
+pub use sapp_wasm::{
+    dropped_file_count,
+    dropped_file_bytes,
+    dropped_file_path
+};
+
+#[cfg(target_os = "windows")]
+pub use sapp_windows::{
+    dropped_file_count,
+    dropped_file_bytes,
+    dropped_file_path
+};
+
+#[cfg(target_os = "linux")]
+pub use sapp_linux::{
+    dropped_file_count,
+    dropped_file_bytes,
+    dropped_file_path
+};
+
+#[cfg(not(any(target_arch = "wasm32", target_os = "windows", target_os = "linux")))]
+mod dummy {
+    pub fn dropped_file_count() -> usize {
+        0
+    }
+
+    pub fn dropped_file_bytes(index: usize) -> Option<Vec<u8>> {
+        None
+    }
+
+    pub fn dropped_file_path(index: usize) -> Option<std::path::PathBuf> {
+        None
+    }
+}
+#[cfg(not(any(target_arch = "wasm32", target_os = "windows", target_os = "linux")))]
+pub use dummy::*;

--- a/src/event.rs
+++ b/src/event.rs
@@ -471,5 +471,6 @@ pub trait EventHandlerFree {
     /// If the event is ignored, the application will quit as usual.
     fn quit_requested_event(&mut self) {}
 
+    /// A file has been dropped over the application.
     fn file_dropped_event(&mut self, _path: Option<PathBuf>, _bytes: Option<Vec<u8>>) {}
 }

--- a/src/event.rs
+++ b/src/event.rs
@@ -1,5 +1,4 @@
 use crate::Context;
-use std::path::PathBuf;
 
 use crate::sapp::{self, sapp_keycode, sapp_mousebutton};
 
@@ -412,13 +411,11 @@ pub trait EventHandler {
     fn quit_requested_event(&mut self, _ctx: &mut Context) {}
 
     /// A file has been dropped over the application.
-    fn file_dropped_event(
-        &mut self,
-        _ctx: &mut Context,
-        _path: Option<PathBuf>,
-        _bytes: Option<Vec<u8>>,
-    ) {
-    }
+    /// Applications can request the number of dropped files with
+    /// miniquad::dnd::dropped_file_count, path of an individual file with
+    /// miniquad::dnd::dropped_file_path, and for wasm targets the file bytes
+    /// can be requested with miniquad::dnd::dropped_file_bytes.
+    fn files_dropped_event(&mut self, _ctx: &mut Context) {}
 }
 
 /// A trait defining event callbacks.
@@ -472,5 +469,9 @@ pub trait EventHandlerFree {
     fn quit_requested_event(&mut self) {}
 
     /// A file has been dropped over the application.
-    fn file_dropped_event(&mut self, _path: Option<PathBuf>, _bytes: Option<Vec<u8>>) {}
+    /// Applications can request the number of dropped files with
+    /// miniquad::dnd::dropped_file_count, path of an individual file with
+    /// miniquad::dnd::dropped_file_path, and for wasm targets the file bytes
+    /// can be requested with miniquad::dnd::dropped_file_bytes.
+    fn files_dropped_event(&mut self) {}
 }

--- a/src/event.rs
+++ b/src/event.rs
@@ -1,4 +1,5 @@
 use crate::Context;
+use std::path::PathBuf;
 
 use crate::sapp::{self, sapp_keycode, sapp_mousebutton};
 
@@ -409,6 +410,15 @@ pub trait EventHandler {
     /// ctx.cancel_quit() to cancel the quit.
     /// If the event is ignored, the application will quit as usual.
     fn quit_requested_event(&mut self, _ctx: &mut Context) {}
+
+    /// A file has been dropped over the application.
+    fn file_dropped_event(
+        &mut self,
+        _ctx: &mut Context,
+        _path: Option<PathBuf>,
+        _bytes: Option<Vec<u8>>,
+    ) {
+    }
 }
 
 /// A trait defining event callbacks.
@@ -460,4 +470,6 @@ pub trait EventHandlerFree {
     /// ctx.cancel_quit() to cancel the quit.
     /// If the event is ignored, the application will quit as usual.
     fn quit_requested_event(&mut self) {}
+
+    fn file_dropped_event(&mut self, _path: Option<PathBuf>, _bytes: Option<Vec<u8>>) {}
 }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -402,6 +402,7 @@ extern "C" fn event(event: *const sapp::sapp_event, user_data: *mut ::std::os::r
         sapp::sapp_event_type_SAPP_EVENTTYPE_SUSPENDED => {
             event_call!(data, window_minimized_event);
         }
+        #[cfg(any(target_os = "windows", target_os = "linux", target_arch = "wasm32"))]
         sapp::sapp_event_type_SAPP_EVENTTYPE_FILE_DROPPED => {
             let path = event.file_path.map(|path| {
                 #[cfg(target_os = "windows")]
@@ -411,7 +412,7 @@ extern "C" fn event(event: *const sapp::sapp_event, user_data: *mut ::std::os::r
                 }
 
                 #[cfg(not(target_os = "windows"))]
-                PathBuf::from(String::from_utf16_lossy(&path[0..event.file_path_length]))
+                PathBuf::from(String::from_utf8_lossy(&path[0..event.file_path_length]).as_ref())
             });
 
             let bytes = if event.file_buf_length > 0 {

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -48,6 +48,7 @@ pub mod conf;
 mod event;
 pub mod fs;
 pub mod graphics;
+pub mod dnd;
 
 #[cfg(feature = "log-impl")]
 pub mod log;
@@ -59,7 +60,6 @@ pub use graphics::*;
 pub use sapp::gl;
 
 use std::ffi::CString;
-use std::path::PathBuf;
 
 #[rustfmt::skip]
 mod default_icon;
@@ -403,31 +403,8 @@ extern "C" fn event(event: *const sapp::sapp_event, user_data: *mut ::std::os::r
             event_call!(data, window_minimized_event);
         }
         #[cfg(any(target_os = "windows", target_os = "linux", target_arch = "wasm32"))]
-        sapp::sapp_event_type_SAPP_EVENTTYPE_FILE_DROPPED => {
-            let path = event.file_path.map(|path| {
-                #[cfg(target_os = "windows")]
-                {
-                    use std::os::windows::ffi::OsStringExt;
-                    PathBuf::from(std::ffi::OsString::from_wide(&path[0..event.file_path_length]))
-                }
-
-                #[cfg(not(target_os = "windows"))]
-                PathBuf::from(String::from_utf8_lossy(&path[0..event.file_path_length]).as_ref())
-            });
-
-            let bytes = if event.file_buf_length > 0 {
-                Some(unsafe {
-                    Vec::from_raw_parts(
-                        event.file_buf,
-                        event.file_buf_length,
-                        event.file_buf_length,
-                    )
-                })
-            } else {
-                None
-            };
-
-            event_call!(data, file_dropped_event, path, bytes);
+        sapp::sapp_event_type_SAPP_EVENTTYPE_FILES_DROPPED => {
+            event_call!(data, files_dropped_event);
         }
         _ => {}
     }


### PR DESCRIPTION
Miniquad can now handle dropped files on Windows, Linux and WASM.

A file path on Windows may be at most 260 characters long (16 bits each). On Mac it is 1024 bytes and on Linux it is 4096 bytes. Is it okay to have a 4096 bytes long array in sapp_event? If PathBuf is used, the event can no longer be `Copy`.

In browsers you cannot read a file from the filesystem with a path, so the file bytes are read immediately in the file drop event. In native applications the file reading can be left to the client.