### PR TITLE
Fixes issue 280: wrong code in lib.rs in conf::LinuxBackend::WaylandWithX11Fallback

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -208,9 +208,9 @@ where
                 }
             }
             conf::LinuxBackend::WaylandWithX11Fallback => {
-                if native::linux_x11::run(&conf, f).is_none() {
+                if native::linux_wayland::run(&conf, f).is_none() {
                     println!("Failed to initialize through wayland! Trying X11 instead");
-                    native::linux_wayland::run(&conf, f);
+                    native::linux_x11::run(&conf, f);
                 }
             }
         }


### PR DESCRIPTION
This fixes the wrong code in the match arm conf::LinuxBackend::WaylandWithX11Fallback in lib.rs as described in issue #280 