### PR TITLE
Fix wasm file loading status handling

### DIFF
--- a/js/gl.js
+++ b/js/gl.js
@@ -1269,7 +1269,10 @@ var importObject = {
 
                     FS.loaded_files[file_id] = uInt8Array;
                     wasm_exports.file_loaded(file_id);
-                }
+                } else {
+		    FS.loaded_files[file_id] = null;
+		    wasm_exports.file_loaded(file_id);
+		}
             }
             xhr.onerror = function (e) {
                 FS.loaded_files[file_id] = null;


### PR DESCRIPTION
Previously, when the `XHRHttpRequest` was successfully completed with a non-200 status code, `file_loaded` was never fired, causing the game to hang. This just calls `file_loaded` in such cases with a `null` buffer so that an `Err` can be returned correctly.

@nobbele reports that even with this fix, there is a screen flicker issue when the the file loading fails with a 404. Noting here because I have no idea what could be causing that or how to fix it and have neither the time nor the expertise to investigate further :P