### PR TITLE
Handle and return non-success status codes when loading files on web

### DIFF
--- a/js/gl.js
+++ b/js/gl.js
@@ -1269,7 +1269,10 @@ var importObject = {
 
                     FS.loaded_files[file_id] = uInt8Array;
                     wasm_exports.file_loaded(file_id);
-                }
+                } else {
+		    FS.loaded_files[file_id] = null;
+		    wasm_exports.file_loaded(file_id);
+		}
             }
             xhr.onerror = function (e) {
                 FS.loaded_files[file_id] = null;

--- a/js/gl.js
+++ b/js/gl.js
@@ -171,6 +171,7 @@ function stringToUTF8(str, heap, outIdx, maxBytesToWrite) {
 }
 var FS = {
     loaded_files: [],
+    statuses: [],
     unique_id: 0
 };
 
@@ -1264,18 +1265,13 @@ var importObject = {
             xhr.open('GET', url, true);
             xhr.responseType = 'arraybuffer';
             xhr.onload = function (e) {
-                if (this.status == 200) {
-                    var uInt8Array = new Uint8Array(this.response);
-
-                    FS.loaded_files[file_id] = uInt8Array;
-                    wasm_exports.file_loaded(file_id);
-                } else {
-		    FS.loaded_files[file_id] = null;
-		    wasm_exports.file_loaded(file_id);
-		}
+                var uInt8Array = new Uint8Array(this.response);
+                FS.loaded_files[file_id] = uInt8Array;
+                FS.statuses[file_id] = this.status;
+                wasm_exports.file_loaded(file_id);
             }
             xhr.onerror = function (e) {
-                FS.loaded_files[file_id] = null;
+                FS.statuses[file_id] = 404;
                 wasm_exports.file_loaded(file_id);
             };
 
@@ -1283,13 +1279,13 @@ var importObject = {
 
             return file_id;
         },
-
         fs_get_buffer_size: function (file_id) {
-            if (FS.loaded_files[file_id] == null) {
-                return -1;
-            } else {
-                return FS.loaded_files[file_id].length;
-            }
+            return FS.loaded_files[file_id].length;
+        },
+        fs_take_status: function (file_id) {
+            var status = FS.statuses[file_id];
+            delete FS.statuses[file_id];
+            return status;
         },
         fs_take_buffer: function (file_id, ptr, max_length) {
             var file = FS.loaded_files[file_id];

--- a/src/native/wasm/fs.rs
+++ b/src/native/wasm/fs.rs
@@ -1,6 +1,7 @@
 extern "C" {
     pub fn fs_load_file(ptr: *const i8, len: u32) -> u32;
     pub fn fs_get_buffer_size(file_id: u32) -> i32;
+    pub fn fs_take_status(file_id: u32) -> i32;
     pub fn fs_take_buffer(file_id: u32, ptr: *mut u8, max_size: u32);
 }
 


### PR DESCRIPTION
Successor of #284 

- Add `WebAssetLoadingError(u16)` to `fs::Error` a la `AndroidAssetLoadingError`
- Call file loaded callback even on failure (fixes infinite hang when file fails to load)
- Throw `fs::Error::DownloadFailed` on 404 (file not found), otherwise throw `fs::Error::WebAssetLoadingError` with the status code
- Treat errors as a 404 (file not found) and also throw `fs::Error::DownloadFailed`

Everything is tested, but I'm leaving this as a draft because:
- This is a breaking change; should the gl.js version be bumped to `0.1.27`?
- This may return garbage if the server responds with an invalid status code (such as negative status codes or status codes over `i16::MAX`); I think this is fine, but do you want me to special-case this and throw `DownloadFailed`?