### PR TITLE
Fix mouse buttons in Wasm

### DIFF
--- a/src/graphics.rs
+++ b/src/graphics.rs
@@ -1231,10 +1231,10 @@ pub fn load_shader(shader_type: GLenum, source: &str) -> Result<GLuint, ShaderEr
             assert!(max_length >= 1);
             let mut error_message =
                 std::string::String::from_utf8_lossy(&error_message[0..max_length as usize - 1])
-                    .to_string();
+                    .into_owned();
 
             // On Wasm + Chrome, for unknown reason, string with zero-terminator is returned. On Firefox there is no zero-terminators in JavaScript string.
-            if error_message.chars().last() == Some('\0') {
+            if error_message.ends_with('\0') {
                 error_message.pop();
             }
 

--- a/src/native/wasm/keycodes.rs
+++ b/src/native/wasm/keycodes.rs
@@ -6,9 +6,9 @@ use crate::event::{KeyCode, KeyMods, MouseButton, TouchPhase};
 
 pub fn translate_mouse_button(button: i32) -> MouseButton {
     match button {
-        1 => return MouseButton::Left,
+        0 => return MouseButton::Left,
+        1 => return MouseButton::Right,
         2 => return MouseButton::Middle,
-        3 => return MouseButton::Right,
         _ => return MouseButton::Unknown,
     };
 }


### PR DESCRIPTION
JS still thinks we are in sapp land:

```rust
pub const sapp_mousebutton_SAPP_MOUSEBUTTON_MIDDLE: sapp_mousebutton = 2;
pub const sapp_mousebutton_SAPP_MOUSEBUTTON_RIGHT: sapp_mousebutton = 1;
pub const sapp_mousebutton_SAPP_MOUSEBUTTON_LEFT: sapp_mousebutton = 0;
pub const sapp_mousebutton_SAPP_MOUSEBUTTON_INVALID: sapp_mousebutton = -1;
```

Current code in Rust is:
https://github.com/not-fl3/miniquad/blob/5fe44e7146b88c34c0ae04cae62f003d8992e247/src/native/wasm/keycodes.rs#L7-L14

Bonus: minor thing I just spotted at random (`into_owned` avoids allocating if `Cow` was already owned).