### PR TITLE
MacOS: trigger `mouse_motion_event` when dragging

### DIFF
--- a/src/native/macos.rs
+++ b/src/native/macos.rs
@@ -443,6 +443,18 @@ pub fn define_cocoa_view_class() -> *const Class {
             mouse_moved as extern "C" fn(&Object, Sel, ObjcId),
         );
         decl.add_method(
+            sel!(mouseDragged:),
+            mouse_moved as extern "C" fn(&Object, Sel, ObjcId),
+        );
+        decl.add_method(
+            sel!(rightMouseDragged:),
+            mouse_moved as extern "C" fn(&Object, Sel, ObjcId),
+        );
+        decl.add_method(
+            sel!(otherMouseDragged:),
+            mouse_moved as extern "C" fn(&Object, Sel, ObjcId),
+        );
+        decl.add_method(
             sel!(mouseDown:),
             mouse_down as extern "C" fn(&Object, Sel, ObjcId),
         );


### PR DESCRIPTION
Moving mouse around while holding a mouse button is a "dragging" event in MacOS that's distinct from regular `mouseMoved`. This maps dragging with any mouse button to regular mouse move to bring it to parity with how it works on other platforms. Dragging can still be handled in API by monitoring `mouse_button_down_event` and `mouse_button_up_event`.