### PR TITLE
MacOS: Fix scrolling and window title

### DIFF
--- a/src/native/macos.rs
+++ b/src/native/macos.rs
@@ -371,14 +371,15 @@ pub fn define_cocoa_view_class() -> *const Class {
     extern "C" fn scroll_wheel(this: &Object, _sel: Sel, event: ObjcId) {
         let payload = get_window_payload(this);
         unsafe {
-            let mut dx: f32 = msg_send![event, scrollingDeltaX];
-            let mut dy: f32 = msg_send![event, scrollingDeltaY];
-            if msg_send![event, hasPreciseScrollingDeltas] {
-                dx *= 0.1;
-                dy *= 0.1;
+            let mut dx: f64 = msg_send![event, scrollingDeltaX];
+            let mut dy: f64 = msg_send![event, scrollingDeltaY];
+
+            if !msg_send![event, hasPreciseScrollingDeltas] {
+                dx *= 10.0;
+                dy *= 10.0;
             }
             if let (mut context, Some(event_handler)) = payload.context() {
-                event_handler.mouse_wheel_event(&mut context, dx, dy);
+                event_handler.mouse_wheel_event(&mut context, dx as f32, dy as f32);
             }
         }
     }
@@ -618,10 +619,6 @@ where
     let title = str_to_nsstring(&conf.window_title);
     //let () = msg_send![window, setReleasedWhenClosed: NO];
     let () = msg_send![window, setTitle: title];
-    let () = msg_send![
-        window,
-        setTitleVisibility: NSWindowTitleVisibility::NSWindowTitleHidden
-    ];
     let () = msg_send![window, center];
     let () = msg_send![window, setAcceptsMouseMovedEvents: YES];
 


### PR DESCRIPTION
This was tricky, I kept having `0` deltas for scrolling events and couldn't for the life of me figure out why for the life of me, so I ended up carefully reading every little bit of the docs and found out that [CGFloat is actually a 64bit floating point on 64bit systems](https://developer.apple.com/documentation/coregraphics/cgfloat), so we were effectively truncating it to the top 32 bits. This could use some `#[cfg]` flags, although I believe 32bit binaries are long dead in the Apple ecosystem (including iOS), am I wrong?

I reversed the multiplier so that instead of reducing the amount scrolled by a factor of 10 for precise scrolling, it's increased by a factor of 10 for non-precise scrolling, which makes the scrolling in native MacOS and Wasm behave identical.

Bonus: I was wondering why the title set in the config wasn't showing up, turns out we were always hiding it.

https://user-images.githubusercontent.com/1096222/171702813-7432f0c5-9925-4f07-bcc6-1578e54cf7e3.MOV