### PR TITLE
MacOS: Activate app on startup

### DIFF
--- a/src/native/macos.rs
+++ b/src/native/macos.rs
@@ -588,6 +588,7 @@ where
         setActivationPolicy: NSApplicationActivationPolicy::NSApplicationActivationPolicyRegular
             as i64
     ];
+    let () = msg_send![ns_app, activateIgnoringOtherApps: YES];
 
     let window_masks = NSWindowStyleMask::NSTitledWindowMask as u64
         | NSWindowStyleMask::NSClosableWindowMask as u64


### PR DESCRIPTION
Forces the app to the foreground so the window shows up after `cargo run` without having to click it in the task bar.

This should be the last one of these micro PRs for MacOS for a while I hope.