### PR TITLE
Remove <'a, 'b> from Context definition

### DIFF
--- a/src/graphics/texture.rs
+++ b/src/graphics/texture.rs
@@ -151,13 +151,13 @@ impl Texture {
 
         let (internal_format, format, pixel_type) = params.format.into();
 
-        ctx.a.cache.store_texture_binding(0);
+        ctx.cache.store_texture_binding(0);
 
         let mut texture: GLuint = 0;
 
         unsafe {
             glGenTextures(1, &mut texture as *mut _);
-            ctx.a.cache.bind_texture(0, texture);
+            ctx.cache.bind_texture(0, texture);
             glPixelStorei(GL_UNPACK_ALIGNMENT, 1); // miniquad always uses row alignment of 1
 
             if cfg!(not(target_arch = "wasm32")) {
@@ -192,7 +192,7 @@ impl Texture {
             glTexParameteri(GL_TEXTURE_2D, GL_TEXTURE_MIN_FILTER, params.filter as i32);
             glTexParameteri(GL_TEXTURE_2D, GL_TEXTURE_MAG_FILTER, params.filter as i32);
         }
-        ctx.a.cache.restore_texture_binding(0);
+        ctx.cache.restore_texture_binding(0);
 
         Texture {
             texture,
@@ -225,17 +225,17 @@ impl Texture {
     }
 
     pub fn set_filter(&self, ctx: &mut Context, filter: FilterMode) {
-        ctx.a.cache.store_texture_binding(0);
-        ctx.a.cache.bind_texture(0, self.texture);
+        ctx.cache.store_texture_binding(0);
+        ctx.cache.bind_texture(0, self.texture);
         unsafe {
             glTexParameteri(GL_TEXTURE_2D, GL_TEXTURE_MIN_FILTER, filter as i32);
             glTexParameteri(GL_TEXTURE_2D, GL_TEXTURE_MAG_FILTER, filter as i32);
         }
-        ctx.a.cache.restore_texture_binding(0);
+        ctx.cache.restore_texture_binding(0);
     }
 
     pub fn resize(&mut self, ctx: &mut Context, width: u32, height: u32, bytes: Option<&[u8]>) {
-        ctx.a.cache.store_texture_binding(0);
+        ctx.cache.store_texture_binding(0);
 
         let (internal_format, format, pixel_type) = self.format.into();
 
@@ -259,7 +259,7 @@ impl Texture {
             );
         }
 
-        ctx.a.cache.restore_texture_binding(0);
+        ctx.cache.restore_texture_binding(0);
     }
 
     /// Update whole texture content
@@ -290,8 +290,8 @@ impl Texture {
         assert!(x_offset + width <= self.width as _);
         assert!(y_offset + height <= self.height as _);
 
-        ctx.a.cache.store_texture_binding(0);
-        ctx.a.cache.bind_texture(0, self.texture);
+        ctx.cache.store_texture_binding(0);
+        ctx.cache.bind_texture(0, self.texture);
 
         let (_, format, pixel_type) = self.format.into();
 
@@ -323,7 +323,7 @@ impl Texture {
             );
         }
 
-        ctx.a.cache.restore_texture_binding(0);
+        ctx.cache.restore_texture_binding(0);
     }
 
     /// Read texture data into CPU memory

--- a/src/native/linux_wayland.rs
+++ b/src/native/linux_wayland.rs
@@ -84,12 +84,9 @@ struct WaylandPayload {
 }
 
 impl WaylandPayload {
-    pub fn context(&mut self) -> (Context<'_, '_>, &mut Option<Box<dyn EventHandler>>) {
+    pub fn context(&mut self) -> (&mut Context, &mut Option<Box<dyn EventHandler>>) {
         (
-            Context {
-                a: self.context.as_mut().unwrap(),
-                b: &mut self.display,
-            },
+            self.context.as_mut().unwrap().as_mut(&mut self.display),
             &mut self.event_handler,
         )
     }

--- a/src/native/windows.rs
+++ b/src/native/windows.rs
@@ -272,7 +272,7 @@ unsafe extern "system" fn win32_wndproc(
                 // if window should be closed and event handling is enabled, give user code
                 // a change to intervene via sapp_cancel_quit()
                 display.display_data.quit_requested = true;
-                event_handler.quit_requested_event(&mut Context::new(context, display));
+                event_handler.quit_requested_event(context.as_mut(display));
                 // if user code hasn't intervened, quit the app
                 if display.display_data.quit_requested {
                     display.display_data.quit_ordered = true;
@@ -310,9 +310,9 @@ unsafe extern "system" fn win32_wndproc(
             if iconified != display.iconified {
                 display.iconified = iconified;
                 if iconified {
-                    event_handler.window_minimized_event(&mut Context::new(context, display));
+                    event_handler.window_minimized_event(context.as_mut(display));
                 } else {
-                    event_handler.window_restored_event(&mut Context::new(context, display));
+                    event_handler.window_restored_event(context.as_mut(display));
                 }
             }
         }
@@ -329,7 +329,7 @@ unsafe extern "system" fn win32_wndproc(
             let mouse_x = display.mouse_x;
             let mouse_y = display.mouse_y;
             event_handler.mouse_button_down_event(
-                &mut Context::new(context, display),
+                context.as_mut(display),
                 MouseButton::Left,
                 mouse_x,
                 mouse_y,
@@ -339,7 +339,7 @@ unsafe extern "system" fn win32_wndproc(
             let mouse_x = display.mouse_x;
             let mouse_y = display.mouse_y;
             event_handler.mouse_button_down_event(
-                &mut Context::new(context, display),
+                context.as_mut(display),
                 MouseButton::Right,
                 mouse_x,
                 mouse_y,
@@ -349,7 +349,7 @@ unsafe extern "system" fn win32_wndproc(
             let mouse_x = display.mouse_x;
             let mouse_y = display.mouse_y;
             event_handler.mouse_button_down_event(
-                &mut Context::new(context, display),
+                context.as_mut(display),
                 MouseButton::Middle,
                 mouse_x,
                 mouse_y,
@@ -359,7 +359,7 @@ unsafe extern "system" fn win32_wndproc(
             let mouse_x = display.mouse_x;
             let mouse_y = display.mouse_y;
             event_handler.mouse_button_up_event(
-                &mut Context::new(context, display),
+                context.as_mut(display),
                 MouseButton::Left,
                 mouse_x,
                 mouse_y,
@@ -369,7 +369,7 @@ unsafe extern "system" fn win32_wndproc(
             let mouse_x = display.mouse_x;
             let mouse_y = display.mouse_y;
             event_handler.mouse_button_up_event(
-                &mut Context::new(context, display),
+                context.as_mut(display),
                 MouseButton::Right,
                 mouse_x,
                 mouse_y,
@@ -379,7 +379,7 @@ unsafe extern "system" fn win32_wndproc(
             let mouse_x = display.mouse_x;
             let mouse_y = display.mouse_y;
             event_handler.mouse_button_up_event(
-                &mut Context::new(context, display),
+                context.as_mut(display),
                 MouseButton::Middle,
                 mouse_x,
                 mouse_y,
@@ -409,7 +409,7 @@ unsafe extern "system" fn win32_wndproc(
             let mouse_x = display.mouse_x;
             let mouse_y = display.mouse_y;
 
-            event_handler.mouse_motion_event(&mut Context::new(context, display), mouse_x, mouse_y);
+            event_handler.mouse_motion_event(context.as_mut(display), mouse_x, mouse_y);
         }
 
         WM_MOVE if display.cursor_grabbed => {
@@ -436,11 +436,7 @@ unsafe extern "system" fn win32_wndproc(
 
             let dx = data.data.mouse().lLastX as f32 * display.mouse_scale;
             let dy = data.data.mouse().lLastY as f32 * display.mouse_scale;
-            event_handler.raw_mouse_motion(
-                &mut Context::new(context, display),
-                dx as f32,
-                dy as f32,
-            );
+            event_handler.raw_mouse_motion(context.as_mut(display), dx as f32, dy as f32);
 
             update_clip_rect(hwnd);
         }
@@ -455,7 +451,7 @@ unsafe extern "system" fn win32_wndproc(
         }
         WM_MOUSEWHEEL => {
             event_handler.mouse_wheel_event(
-                &mut Context::new(context, display),
+                context.as_mut(display),
                 0.0,
                 (HIWORD(wparam as _) as i16) as f32,
             );
@@ -463,7 +459,7 @@ unsafe extern "system" fn win32_wndproc(
 
         WM_MOUSEHWHEEL => {
             event_handler.mouse_wheel_event(
-                &mut Context::new(context, display),
+                context.as_mut(display),
                 (HIWORD(wparam as _) as i16) as f32,
                 0.0,
             );
@@ -474,12 +470,7 @@ unsafe extern "system" fn win32_wndproc(
             let mods = key_mods();
             if chr > 0 {
                 if let Some(chr) = std::char::from_u32(chr as u32) {
-                    event_handler.char_event(
-                        &mut Context::new(context, display),
-                        chr,
-                        mods,
-                        repeat,
-                    );
+                    event_handler.char_event(context.as_mut(display), chr, mods, repeat);
                 }
             }
         }
@@ -488,18 +479,13 @@ unsafe extern "system" fn win32_wndproc(
             let keycode = keycodes::translate_keycode(keycode);
             let mods = key_mods();
             let repeat = !!(lparam & 0x40000000) != 0;
-            event_handler.key_down_event(
-                &mut Context::new(context, display),
-                keycode,
-                mods,
-                repeat,
-            );
+            event_handler.key_down_event(context.as_mut(display), keycode, mods, repeat);
         }
         WM_KEYUP | WM_SYSKEYUP => {
             let keycode = HIWORD(lparam as _) as u32 & 0x1FF;
             let keycode = keycodes::translate_keycode(keycode);
             let mods = key_mods();
-            event_handler.key_up_event(&mut Context::new(context, display), keycode, mods);
+            event_handler.key_up_event(context.as_mut(display), keycode, mods);
         }
 
         _ => {}
@@ -888,7 +874,7 @@ where
 
         let mut context = GraphicsContext::new();
 
-        let event_handler = f(&mut Context::new(&mut context, &mut display));
+        let event_handler = f(context.as_mut(&mut display));
 
         let mut p = WindowPayload {
             display,
@@ -911,20 +897,15 @@ where
                     DispatchMessageW(&mut msg as *mut _ as _);
                 }
             }
-            p.event_handler
-                .update(&mut Context::new(&mut p.context, &mut p.display));
-            p.event_handler
-                .draw(&mut Context::new(&mut p.context, &mut p.display));
+            p.event_handler.update(p.context.as_mut(&mut p.display));
+            p.event_handler.draw(p.context.as_mut(&mut p.display));
             SwapBuffers(p.display.dc);
 
             if p.display.update_dimensions(wnd) {
                 let width = p.display.display_data.screen_width as _;
                 let height = p.display.display_data.screen_height as _;
-                p.event_handler.resize_event(
-                    &mut Context::new(&mut p.context, &mut p.display),
-                    width,
-                    height,
-                );
+                p.event_handler
+                    .resize_event(p.context.as_mut(&mut p.display), width, height);
             }
             if p.display.display_data.quit_requested {
                 PostMessageW(p.display.wnd, WM_CLOSE, 0, 0);


### PR DESCRIPTION
Pre `0.3` `EventHandler` looked like this:
```rust
pub trait EventHandler {
    fn update(&mut self, _ctx: &mut Context);
    ..
}
```

Post `0.3` looks exactly the same: 
```rust
pub trait EventHandler {
    fn update(&mut self, _ctx: &mut Context);
    ..
}
```

So I thought this is going work and no breaking change happened. What a mistake! 
I the new miniquad Context got a lifetime, so it was actually this:
`fn update<'a>(&'a mut self, _ctx: &'a Context<'a, 'a>)`

The new context was basically a tuple struct with two references. This allowed some nice type-safe things to happen.

The problem with lifetimes in the context - it is really painful to keep the reference to the context inside user code. Especially in the case of `&mut Context` -> `&mut dyn Any`. 

This PR removes the lifetimes. 

How it works:

Most backends have something like:
```rust
struct WindowPayload {
  context: GraphicsContext,
  display: NativeDisplayImplementation
}
```

When its time to call some EventHandler function, miniquad used to do basically this:
```rust
struct Context(&mut GraphicsContext, &mut dyn NativeDisplay);
```

```rust
event_handler.update(&mut Context::new(&mut payload.context, &mut payload.display));
```

display became a trait-object, memory/aliasing safety is doing well, a function called. 


After this PR miniquad is doing this:

```rust
event_handler.update(payload.context.as_mut(&mut payload.display));
```

I believe this is UB-free and safe enough until event-handler's calls are using `context.as_mut(&mut display)` and not `&mut context`. I would love to enforce `as_mut` call on compile time, but, unfortunately, it doesn't seem possible without either introducing some sort of a wrapper type around Context with a lifetime or dealing with raw pointers everywhere :( 