### PR TITLE
Fix handling of repeated keycodes in linux_x11.

### DIFF
--- a/src/native/linux_x11.rs
+++ b/src/native/linux_x11.rs
@@ -486,7 +486,7 @@ impl X11Display {
             3 => {
                 let keycode = (*event).xkey.keycode;
                 let key = self.translate_key(keycode as _);
-                self.repeated_keycodes[(keycode & 0xffe) as usize] = false;
+                self.repeated_keycodes[(keycode & 0xff) as usize] = false;
                 if key != crate::event::KeyCode::Unknown {
                     let mods = self.translate_mod((*event).xkey.state as libc::c_int);
                     event_handler.key_up_event(context.as_mut(&mut *self), key, mods);


### PR DESCRIPTION
A typo prevented keys to be properly considered released for the purpose of the repeat flag.
This caused only the very first key press of a key to be reported as non-repeated, e.g.
breaking macroquad's is_key_pressed on Linux.