### PR TITLE
Support OpenGL 2.1 + OpenGL ES 2

### DIFF
--- a/src/graphics.rs
+++ b/src/graphics.rs
@@ -1110,6 +1110,9 @@ impl Context {
     /// + `base_element` specifies starting offset in `index_buffer`.
     /// + `num_elements` specifies length of the slice of `index_buffer` to draw.
     /// + `num_instances` specifies how many instances should be rendered.
+    ///
+    /// NOTE: num_instances > 1 might be not supported by the GPU (gl2.1 and gles2).
+    /// `features.instancing` check is required.
     pub fn draw(&self, base_element: i32, num_elements: i32, num_instances: i32) {
         assert!(
             self.cache.cur_pipeline.is_some(),

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -38,7 +38,9 @@ pub mod date {
 }
 
 impl Context {
-    pub(crate) fn as_mut(&mut self, display: &mut dyn NativeDisplay) -> &mut Context {
+    // Updates the display pointer inside the Context
+    // Context should always be passed to event handlers through "with_display"
+    pub(crate) fn with_display(&mut self, display: &mut dyn NativeDisplay) -> &mut Context {
         self.display = Some(display);
         self
     }

--- a/src/native/android.rs
+++ b/src/native/android.rs
@@ -225,7 +225,7 @@ impl MainThreadState {
                 self.display.screen_width = width as _;
                 self.display.screen_height = height as _;
                 self.event_handler.resize_event(
-                    self.context.as_mut(&mut self.display),
+                    self.context.with_display(&mut self.display),
                     width as _,
                     height as _,
                 );
@@ -237,7 +237,7 @@ impl MainThreadState {
                 y,
             } => {
                 self.event_handler.touch_event(
-                    self.context.as_mut(&mut self.display),
+                    self.context.with_display(&mut self.display),
                     phase,
                     touch_id,
                     x,
@@ -246,10 +246,10 @@ impl MainThreadState {
             }
             Message::Pause => self
                 .event_handler
-                .window_minimized_event(self.context.as_mut(&mut self.display)),
+                .window_minimized_event(self.context.with_display(&mut self.display)),
             Message::Resume => self
                 .event_handler
-                .window_restored_event(self.context.as_mut(&mut self.display)),
+                .window_restored_event(self.context.with_display(&mut self.display)),
             Message::Destroy => {
                 self.quit = true;
             }
@@ -258,11 +258,11 @@ impl MainThreadState {
 
     fn frame(&mut self) {
         self.event_handler
-            .update(self.context.as_mut(&mut self.display));
+            .update(self.context.with_display(&mut self.display));
 
         if self.surface.is_null() == false {
             self.event_handler
-                .draw(self.context.as_mut(&mut self.display));
+                .draw(self.context.with_display(&mut self.display));
 
             unsafe {
                 (self.libegl.eglSwapBuffers.unwrap())(self.egl_display, self.surface);
@@ -379,7 +379,7 @@ where
             screen_width,
             screen_height,
         };
-        let event_handler = f.0(context.as_mut(&mut display));
+        let event_handler = f.0(context.with_display(&mut display));
         let mut s = MainThreadState {
             libegl,
             egl_display,

--- a/src/native/android.rs
+++ b/src/native/android.rs
@@ -375,6 +375,8 @@ where
         }
 
         let mut context = GraphicsContext::new();
+        context.features.instancing = !gl::is_gl2();
+
         let mut display = AndroidDisplay {
             screen_width,
             screen_height,

--- a/src/native/egl.rs
+++ b/src/native/egl.rs
@@ -324,7 +324,7 @@ pub unsafe fn create_egl_context(
     if !exact_cfg_found {
         config = available_cfgs[0];
     }
-    let ctx_attributes = vec![EGL_CONTEXT_CLIENT_VERSION, 3, EGL_NONE];
+    let ctx_attributes = vec![EGL_CONTEXT_CLIENT_VERSION, 2, EGL_NONE];
     let context = (egl.eglCreateContext.unwrap())(
         display,
         config,

--- a/src/native/gl.rs
+++ b/src/native/gl.rs
@@ -630,3 +630,14 @@ gl_loader!(
     fn glFlush() -> (),
     fn glFinish() -> ()
 );
+
+// note that glGetString only works after first glSwapBuffer,
+// not just after context creation
+pub unsafe fn is_gl2() -> bool {
+    let version_string = glGetString(super::gl::GL_VERSION);
+    let version_string = std::ffi::CStr::from_ptr(version_string as _)
+        .to_str()
+        .unwrap();
+
+    version_string.starts_with("2") || version_string.starts_with("OpenGL ES 2")
+}

--- a/src/native/linux_wayland.rs
+++ b/src/native/linux_wayland.rs
@@ -86,7 +86,10 @@ struct WaylandPayload {
 impl WaylandPayload {
     pub fn context(&mut self) -> (&mut Context, &mut Option<Box<dyn EventHandler>>) {
         (
-            self.context.as_mut().unwrap().as_mut(&mut self.display),
+            self.context
+                .as_mut()
+                .unwrap()
+                .with_display(&mut self.display),
             &mut self.event_handler,
         )
     }

--- a/src/native/linux_x11.rs
+++ b/src/native/linux_x11.rs
@@ -9,6 +9,7 @@ mod x_cursor;
 mod xi_input;
 
 use crate::{
+    gl,
     event::EventHandler,
     graphics::GraphicsContext,
     native::{egl, NativeDisplayData},
@@ -703,7 +704,7 @@ where
         glx_context,
         conf.platform.swap_interval.unwrap_or(1),
     );
-    super::gl::load_gl_funcs(|proc| glx.libgl.get_procaddr(proc));
+    gl::load_gl_funcs(|proc| glx.libgl.get_procaddr(proc));
 
     display.show_window(window);
 
@@ -719,6 +720,8 @@ where
     display.data.screen_height = h;
 
     let mut context = GraphicsContext::new();
+
+    context.features.instancing = !gl::is_gl2();
 
     let mut data = (f.take().unwrap())(context.with_display(&mut display));
 
@@ -805,6 +808,8 @@ where
     (display.libx11.XFlush)(display.display);
 
     let mut context = GraphicsContext::new();
+
+    context.features.instancing = !gl::is_gl2();
 
     let (w, h) = display.query_window_size(window);
     display.data.screen_width = w;

--- a/src/native/linux_x11/glx.rs
+++ b/src/native/linux_x11/glx.rs
@@ -3,7 +3,7 @@
 use super::{libx11::*, X11Display};
 
 use crate::native::module;
-    
+
 pub type GLXContext = *mut ();
 pub type GLXFBConfig = *mut ();
 pub type GLXWindow = XID;
@@ -318,16 +318,11 @@ impl Glx {
         }
 
         // _sapp_x11_grab_error_handler(libx11);
-        let attribs: [libc::c_int; 10] = [
+        let attribs: [libc::c_int; 5] = [
             GLX_CONTEXT_MAJOR_VERSION_ARB,
-            3,
+            2,
             GLX_CONTEXT_MINOR_VERSION_ARB,
-            3,
-            GLX_CONTEXT_PROFILE_MASK_ARB,
-            GLX_CONTEXT_CORE_PROFILE_BIT_ARB,
-            GLX_CONTEXT_FLAGS_ARB,
-            GLX_CONTEXT_FORWARD_COMPATIBLE_BIT_ARB,
-            0,
+            1,
             0,
         ];
         let glx_ctx = self.extensions.glxCreateContextAttribsARB.unwrap()(

--- a/src/native/linux_x11/glx.rs
+++ b/src/native/linux_x11/glx.rs
@@ -318,11 +318,14 @@ impl Glx {
         }
 
         // _sapp_x11_grab_error_handler(libx11);
-        let attribs: [libc::c_int; 5] = [
+        let attribs: [libc::c_int; 8] = [
             GLX_CONTEXT_MAJOR_VERSION_ARB,
             2,
             GLX_CONTEXT_MINOR_VERSION_ARB,
             1,
+            GLX_CONTEXT_FLAGS_ARB,
+            GLX_CONTEXT_CORE_PROFILE_BIT_ARB,
+            0,
             0,
         ];
         let glx_ctx = self.extensions.glxCreateContextAttribsARB.unwrap()(

--- a/src/native/macos.rs
+++ b/src/native/macos.rs
@@ -140,7 +140,7 @@ impl WindowPayload {
         let a = self.context.as_mut()?;
         let event_handler = self.event_handler.as_deref_mut()?;
 
-        Some((a.as_mut(&mut self.display), event_handler))
+        Some((a.with_display(&mut self.display), event_handler))
     }
 }
 pub fn define_app_delegate() -> *const Class {
@@ -314,7 +314,7 @@ pub fn define_cocoa_view_class() -> *const Class {
             .context
             .as_mut()
             .unwrap()
-            .as_mut(&mut payload.display)));
+            .with_display(&mut payload.display)));
     }
 
     extern "C" fn timer_fired(this: &Object, _sel: Sel, _: ObjcId) {

--- a/src/native/wasm.rs
+++ b/src/native/wasm.rs
@@ -142,7 +142,7 @@ where
             dropped_files: Default::default(),
         };
         *g.borrow_mut() = Some(WasmGlobals {
-            event_handler: f(context.as_mut(&mut display)),
+            event_handler: f(context.with_display(&mut display)),
             context,
             display,
         });
@@ -271,10 +271,10 @@ pub extern "C" fn frame() {
     with(|globals| {
         globals
             .event_handler
-            .update(globals.context.as_mut(&mut globals.display));
+            .update(globals.context.with_display(&mut globals.display));
         globals
             .event_handler
-            .draw(globals.context.as_mut(&mut globals.display));
+            .draw(globals.context.with_display(&mut globals.display));
     });
 }
 
@@ -282,7 +282,7 @@ pub extern "C" fn frame() {
 pub extern "C" fn mouse_move(x: i32, y: i32) {
     with(|globals| {
         globals.event_handler.mouse_motion_event(
-            globals.context.as_mut(&mut globals.display),
+            globals.context.with_display(&mut globals.display),
             x as _,
             y as _,
         );
@@ -293,7 +293,7 @@ pub extern "C" fn mouse_move(x: i32, y: i32) {
 pub extern "C" fn raw_mouse_move(dx: i32, dy: i32) {
     with(|globals| {
         globals.event_handler.raw_mouse_motion(
-            globals.context.as_mut(&mut globals.display),
+            globals.context.with_display(&mut globals.display),
             dx as _,
             dy as _,
         );
@@ -306,7 +306,7 @@ pub extern "C" fn mouse_down(x: i32, y: i32, btn: i32) {
 
     with(|globals| {
         globals.event_handler.mouse_button_down_event(
-            globals.context.as_mut(&mut globals.display),
+            globals.context.with_display(&mut globals.display),
             btn,
             x as _,
             y as _,
@@ -320,7 +320,7 @@ pub extern "C" fn mouse_up(x: i32, y: i32, btn: i32) {
 
     with(|globals| {
         globals.event_handler.mouse_button_up_event(
-            globals.context.as_mut(&mut globals.display),
+            globals.context.with_display(&mut globals.display),
             btn,
             x as _,
             y as _,
@@ -332,7 +332,7 @@ pub extern "C" fn mouse_up(x: i32, y: i32, btn: i32) {
 pub extern "C" fn mouse_wheel(dx: i32, dy: i32) {
     with(|globals| {
         globals.event_handler.mouse_wheel_event(
-            globals.context.as_mut(&mut globals.display),
+            globals.context.with_display(&mut globals.display),
             dx as _,
             dy as _,
         );
@@ -346,7 +346,7 @@ pub extern "C" fn key_down(key: u32, modifiers: u32, repeat: bool) {
 
     with(|globals| {
         globals.event_handler.key_down_event(
-            globals.context.as_mut(&mut globals.display),
+            globals.context.with_display(&mut globals.display),
             key,
             mods,
             repeat,
@@ -359,7 +359,7 @@ pub extern "C" fn key_press(key: u32) {
     if let Some(key) = char::from_u32(key) {
         with(|globals| {
             globals.event_handler.char_event(
-                globals.context.as_mut(&mut globals.display),
+                globals.context.with_display(&mut globals.display),
                 key,
                 crate::KeyMods::default(),
                 false,
@@ -374,9 +374,11 @@ pub extern "C" fn key_up(key: u32, modifiers: u32) {
     let mods = keycodes::translate_mod(modifiers as _);
 
     with(|globals| {
-        globals
-            .event_handler
-            .key_up_event(globals.context.as_mut(&mut globals.display), key, mods);
+        globals.event_handler.key_up_event(
+            globals.context.with_display(&mut globals.display),
+            key,
+            mods,
+        );
     });
 }
 
@@ -387,7 +389,7 @@ pub extern "C" fn resize(width: i32, height: i32) {
         globals.display.screen_height = height as _;
 
         globals.event_handler.resize_event(
-            globals.context.as_mut(&mut globals.display),
+            globals.context.with_display(&mut globals.display),
             width as _,
             height as _,
         );
@@ -399,7 +401,7 @@ pub extern "C" fn touch(phase: u32, id: u32, x: f32, y: f32) {
     let phase = keycodes::translate_touch_phase(phase as _);
     with(|globals| {
         globals.event_handler.touch_event(
-            globals.context.as_mut(&mut globals.display),
+            globals.context.with_display(&mut globals.display),
             phase,
             id as _,
             x as _,
@@ -420,7 +422,7 @@ pub extern "C" fn on_files_dropped_finish() {
     with(|globals| {
         globals
             .event_handler
-            .files_dropped_event(globals.context.as_mut(&mut globals.display))
+            .files_dropped_event(globals.context.with_display(&mut globals.display))
     });
 }
 

--- a/src/native/windows.rs
+++ b/src/native/windows.rs
@@ -873,6 +873,7 @@ where
         super::gl::load_gl_funcs(|proc| display.get_proc_address(proc));
 
         let mut context = GraphicsContext::new();
+        context.features.instancing = !crate::gl::is_gl2();
 
         let event_handler = f(context.with_display(&mut display));
 

--- a/src/native/windows/wgl.rs
+++ b/src/native/windows/wgl.rs
@@ -396,12 +396,10 @@ impl Wgl {
         }
         let attrs = [
             WGL_CONTEXT_MAJOR_VERSION_ARB,
-            3,
+            2,
             WGL_CONTEXT_MINOR_VERSION_ARB,
-            3,
+            1,
             WGL_CONTEXT_FLAGS_ARB,
-            WGL_CONTEXT_FORWARD_COMPATIBLE_BIT_ARB,
-            WGL_CONTEXT_PROFILE_MASK_ARB,
             WGL_CONTEXT_CORE_PROFILE_BIT_ARB,
             0,
             0,


### PR DESCRIPTION
## Historical background: 

miniquad had one very old issue: https://github.com/not-fl3/miniquad/issues/176.  
miniquad promised that any code would work exactly the same way on any miniquad-supported platforms. In other words, it used to be the "lowest common denominator" between all the supported APIs.

After 0.3 miniquad changed the course. Now miniquad wants to be a reasonably minimal building block, allowing rendering on as many platforms as possible, with the least amount of platform-dependent hacks.

## Instanced rendering

A good example for the new approach is the instanced rendering. Technically, miniquad could make software emulation of an instanced draw calls(this PR actually used to have this implementation).  
This will keep the "same code draw the same things on all platforms promise". In practice, it doesn't really make sense - if GPU does not support instancing, software emulated instancing will be way too slow to be practical.  

## Solution 

Now we have a `Features` struct, accessible through `context.features()`. And certain API calls might have a note in the comments, like "this texture format might not work under webgl1 internet explorer, better check features.is_CERTAIN_FORMAT_supported if this is important". (this will fix https://github.com/not-fl3/miniquad/issues/166#issuecomment-758504280). 

In the case of instancing, its "features.instancing". Macroquad, for example, will draw simplified particle effects in case of no instancing support.
