### PR TITLE
Flawless multi-touch support on Android

### DIFF
--- a/java/MainActivity.java
+++ b/java/MainActivity.java
@@ -95,6 +95,22 @@ class QuadSurface
             y = event.getY(0);
             QuadNative.surfaceOnTouch(id, 2, x, y);
             break;
+        case MotionEvent.ACTION_POINTER_UP: {
+            final int pointerIndex = event.getActionIndex();
+            id = event.getPointerId(pointerIndex);
+            x = event.getX(pointerIndex);
+            y = event.getY(pointerIndex);
+            QuadNative.surfaceOnTouch(id, 1, x, y);
+            break;
+        }
+        case MotionEvent.ACTION_POINTER_DOWN: {
+            final int pointerIndex = event.getActionIndex();
+            id = event.getPointerId(pointerIndex);
+            x = event.getX(pointerIndex);
+            y = event.getY(pointerIndex);
+            QuadNative.surfaceOnTouch(id, 2, x, y);
+            break;
+        }
         case MotionEvent.ACTION_CANCEL:
             for (i = 0; i < pointerCount; i++) {
                 id = event.getPointerId(i);

--- a/java/MainActivity.java
+++ b/java/MainActivity.java
@@ -94,6 +94,7 @@ class QuadSurface
             x = event.getX(0);
             y = event.getY(0);
             QuadNative.surfaceOnTouch(id, 2, x, y);
+            break;
         case MotionEvent.ACTION_CANCEL:
             for (i = 0; i < pointerCount; i++) {
                 id = event.getPointerId(i);

--- a/src/native/android.rs
+++ b/src/native/android.rs
@@ -108,7 +108,7 @@ impl NativeDisplay for AndroidDisplay {
         None
     }
     fn clipboard_set(&mut self, _data: &str) {}
-    fn show_keyboard(&mut self, _show: bool) {}
+    // fn show_keyboard(&mut self, _show: bool) {}
     fn as_any(&mut self) -> &mut dyn std::any::Any {
         self
     }


### PR DESCRIPTION
Multi-touch on Android currently doesn't work correctly. Once we start pressing multiple fingers, the states get confused and sometimes `Stationary` ghost touches can appear. I noticed that when trying the `touch` example of macroquad:
https://user-images.githubusercontent.com/13885008/187576490-878fa4ac-1575-4f46-a127-b59c09aaf6f9.mp4

I traced the problem all the day down to the Android `MainActivity` class of miniquad, which I discovered didn't handle some touch events that are essential for multi-touch: [`ACTION_POINTER_UP`](https://developer.android.com/reference/android/view/MotionEvent#ACTION_POINTER_UP) and [`ACTION_POINTER_DOWN`](https://developer.android.com/reference/android/view/MotionEvent#ACTION_POINTER_DOWN).
So after researching about all of this (since I don't know anything about Android development), I eventually managed to fix the bug entirely!

How to compile the `touch_blobs` example (it logs touches):
```sh
docker run --rm -v $(pwd)":/root/src" -w /root/src notfl3/cargo-apk cargo quad-apk build --example touch_blobs --features log-impl
```

Touch input is now flawless. Here's a demo.
https://youtu.be/mM3vQthcBc4

## Things to note about this demo

- at 0:25 you can see that it perfectly handles 2 fingers touching the screen at the same time, and releasing at the same time.
- following that, it has no problems with secondary pointers leaving early while others are still holding.
- following that again, it has no problems with fast finger spamming. Essential for rhythm games. ;)
- at 0:40 you can see that it perfectly handles 3 fingers.
- at 0:59 you can see that it sometimes perfectly handles 4 fingers, but for some reason produces `Cancelled` touch phases if you press 4 at the same time. This only happens when you have touch gestures enabled, which is why I switch into Game Focus Mode at 1:11.
- the rest of the video is just testing more crazy stuff with fingers like 8 at the same time, which is yet again flawless.

I have done some other minor modifications as well: put the shaders into a separate file and `include_str!` on them in both blob examples (though I don't know if it's desirable for this codebase), format the `MainActivity` class... if you want me to change any of that let me know.

Also, I couldn't compile for Android because there was `fn show_keyboard(&mut self, _show: bool) {}` in the `NativeDisplay` impl of `AndroidDisplay` in `android.rs` line 111... It wasn't used so I have commented it locally but not in this PR. Is this function a WIP, a misplacement...?