### PR TITLE
Put example shaders in separate files

### DIFF
--- a/examples/blobs.rs
+++ b/examples/blobs.rs
@@ -134,79 +134,8 @@ fn main() {
 mod shader {
     use miniquad::*;
 
-    pub const VERTEX: &str = r#"#version 100
-    attribute vec2 pos;
-    attribute vec2 uv;
-
-    uniform vec2 offset;
-
-    varying highp vec2 texcoord;
-
-    void main() {
-        gl_Position = vec4(pos + offset, 0, 1);
-        texcoord = uv;
-    }"#;
-
-    pub const FRAGMENT: &str = r#"#version 100
-    precision highp float;
-
-    varying vec2 texcoord;
-
-    uniform float time;
-    uniform int blobs_count;
-    uniform vec2 blobs_positions[32];
-
-    float k = 20.0;
-    float field = 0.0;
-    vec2 coord;
-        
-    void circle ( float r , vec3 col , vec2 offset) {
-        vec2 pos = coord.xy;
-        vec2 c = offset;
-        float d = distance ( pos , c );
-        field += ( k * r ) / ( d*d );
-    }
-        
-    vec3 band ( float shade, float low, float high, vec3 col1, vec3 col2 ) {
-        if ( (shade >= low) && (shade <= high) ) {
-            float delta = (shade - low) / (high - low);
-            vec3 colDiff = col2 - col1;
-            return col1 + (delta * colDiff);
-        }
-        else
-            return vec3(0.0,0.0,0.0);
-    }
-    
-    vec3 gradient ( float shade ) {
-        vec3 colour = vec3( (sin(time/2.0)*0.25)+0.25,0.0,(cos(time/2.0)*0.25)+0.25);
-        
-        vec3 col1 = vec3(0.01, 0.0, 1.0-0.01);
-        vec3 col2 = vec3(1.0-0.01, 0.0, 0.01);
-        vec3 col3 = vec3(0.02, 1.0-0.02, 0.02);
-        vec3 col4 = vec3((0.01+0.02)/2.0, (0.01+0.02)/2.0, 1.0 - (0.01+0.02)/2.0);
-        vec3 col5 = vec3(0.02, 0.02, 0.02);
-        
-        colour += band ( shade, 0.0, 0.3, colour, col1 );
-        colour += band ( shade, 0.3, 0.6, col1, col2 );
-        colour += band ( shade, 0.6, 0.8, col2, col3 );
-        colour += band ( shade, 0.8, 0.9, col3, col4 );
-        colour += band ( shade, 0.9, 1.0, col4, col5 );
-        
-        return colour;
-    }
-    
-    void main() {
-        coord = texcoord;
-        
-        for (int i = 0; i < 32; i++) {
-            if (i >= blobs_count) { break; } // workaround for webgl error: Loop index cannot be compared with non-constant expression
-            circle(.03 , vec3(0.7 ,0.2, 0.8), blobs_positions[i]);
-        }
-        
-        float shade = min ( 1.0, max ( field/256.0, 0.0 ) );
-        
-        gl_FragColor = vec4( gradient(shade), 1.0 );
-    }"#;
+    pub const VERTEX: &str = include_str!("shaders/vertex-uv.glsl");
+    pub const FRAGMENT: &str = include_str!("shaders/blobs-fragment.glsl");
 
     pub fn meta() -> ShaderMeta {
         ShaderMeta {

--- a/examples/instancing.rs
+++ b/examples/instancing.rs
@@ -150,29 +150,8 @@ fn main() {
 mod shader {
     use miniquad::*;
 
-    pub const VERTEX: &str = r#"#version 100
-    attribute vec3 pos;
-    attribute vec4 color0;
-    attribute vec3 inst_pos;
-
-    varying lowp vec4 color;
-
-    uniform mat4 mvp;
-
-    void main() {
-        vec4 pos = vec4(pos + inst_pos, 1.0);
-        gl_Position = mvp * pos;
-        color = color0;
-    }
-    "#;
-
-    pub const FRAGMENT: &str = r#"#version 100
-    varying lowp vec4 color;
-
-    void main() {
-        gl_FragColor = color;
-    }
-    "#;
+    pub const VERTEX: &str = include_str!("shaders/instancing-vertex.glsl");
+    pub const FRAGMENT: &str = include_str!("shaders/fragment-color.glsl");
 
     pub fn meta() -> ShaderMeta {
         ShaderMeta {

--- a/examples/offscreen.rs
+++ b/examples/offscreen.rs
@@ -214,33 +214,8 @@ fn main() {
 mod display_shader {
     use miniquad::*;
 
-    pub const VERTEX: &str = r#"#version 100
-    attribute vec4 pos;
-    attribute vec4 color0;
-    attribute vec2 uv0;
-
-    varying lowp vec4 color;
-    varying lowp vec2 uv;
-
-    uniform mat4 mvp;
-
-    void main() {
-        gl_Position = mvp * pos;
-        color = color0;
-        uv = uv0;
-    }
-    "#;
-
-    pub const FRAGMENT: &str = r#"#version 100
-    varying lowp vec4 color;
-    varying lowp vec2 uv;
-
-    uniform sampler2D tex;
-
-    void main() {
-        gl_FragColor = color * texture2D(tex, uv);
-    }
-    "#;
+    pub const VERTEX: &str = include_str!("shaders/offscreen-vertex.glsl");
+    pub const FRAGMENT: &str = include_str!("shaders/offscreen-fragment.glsl");
 
     pub fn meta() -> ShaderMeta {
         ShaderMeta {

--- a/examples/post_processing.rs
+++ b/examples/post_processing.rs
@@ -207,8 +207,8 @@ impl EventHandler for Stage {
         );
         let view_proj = proj * view;
 
-        self.rx += 0.01;
-        self.ry += 0.03;
+        self.rx += 0.002;
+        self.ry += 0.005;
         let model = Mat4::from_rotation_ypr(self.rx, self.ry, 0.);
 
         let (w, h) = ctx.screen_size();
@@ -249,42 +249,8 @@ fn main() {
 mod post_processing_shader {
     use miniquad::*;
 
-    pub const VERTEX: &str = r#"#version 100
-    attribute vec2 pos;
-    attribute vec2 uv;
-
-    varying lowp vec2 texcoord;
-
-    void main() {
-        gl_Position = vec4(pos, 0, 1);
-        texcoord = uv;
-    }
-    "#;
-
-    pub const FRAGMENT: &str = r#"#version 100
-    precision lowp float;
-
-    varying vec2 texcoord;
-
-    uniform sampler2D tex;
-    uniform vec2 resolution;
-
-
-
-    // Source: https://github.com/Jam3/glsl-fast-gaussian-blur/blob/master/5.glsl
-    vec4 blur5(sampler2D image, vec2 uv, vec2 resolution, vec2 direction) {
-        vec4 color = vec4(0.0);
-        vec2 off1 = vec2(1.3333333333333333) * direction;
-        color += texture2D(image, uv) * 0.29411764705882354;
-        color += texture2D(image, uv + (off1 / resolution)) * 0.35294117647058826;
-        color += texture2D(image, uv - (off1 / resolution)) * 0.35294117647058826;
-        return color;
-    }
-
-    void main() {
-        gl_FragColor = blur5(tex, texcoord, resolution, vec2(3.0));
-    }
-    "#;
+    pub const VERTEX: &str = include_str!("shaders/post_processing-vertex.glsl");
+    pub const FRAGMENT: &str = include_str!("shaders/post_processing-fragment.glsl");
 
     pub fn meta() -> ShaderMeta {
         ShaderMeta {
@@ -304,28 +270,8 @@ mod post_processing_shader {
 mod offscreen_shader {
     use miniquad::*;
 
-    pub const VERTEX: &str = r#"#version 100
-    attribute vec4 pos;
-    attribute vec4 color0;
-
-    varying lowp vec4 color;
-
-    uniform mat4 mvp;
-
-    void main() {
-        gl_Position = mvp * pos;
-        color = color0;
-    }
-    "#;
-
-    pub const FRAGMENT: &str = r#"#version 100
-
-    varying lowp vec4 color;
-
-    void main() {
-        gl_FragColor = color;
-    }
-    "#;
+    pub const VERTEX: &str = include_str!("shaders/post_processing-offscreenvertex.glsl");
+    pub const FRAGMENT: &str = include_str!("shaders/fragment-color.glsl");
 
     pub fn meta() -> ShaderMeta {
         ShaderMeta {

--- a/examples/quad.rs
+++ b/examples/quad.rs
@@ -94,27 +94,8 @@ fn main() {
 mod shader {
     use miniquad::*;
 
-    pub const VERTEX: &str = r#"#version 100
-    attribute vec2 pos;
-    attribute vec2 uv;
-
-    uniform vec2 offset;
-
-    varying lowp vec2 texcoord;
-
-    void main() {
-        gl_Position = vec4(pos + offset, 0, 1);
-        texcoord = uv;
-    }"#;
-
-    pub const FRAGMENT: &str = r#"#version 100
-    varying lowp vec2 texcoord;
-
-    uniform sampler2D tex;
-
-    void main() {
-        gl_FragColor = texture2D(tex, texcoord);
-    }"#;
+    pub const VERTEX: &str = include_str!("shaders/vertex-uv.glsl");
+    pub const FRAGMENT: &str = include_str!("shaders/quad-fragment.glsl");
 
     pub fn meta() -> ShaderMeta {
         ShaderMeta {

--- a/examples/shaders/blobs-fragment.glsl
+++ b/examples/shaders/blobs-fragment.glsl
@@ -1,0 +1,60 @@
+#version 100
+precision highp float;
+
+varying vec2 texcoord;
+
+uniform float time;
+uniform int blobs_count;
+uniform vec2 blobs_positions[32];
+
+float k = 20.0;
+float field = 0.0;
+vec2 coord;
+    
+void circle ( float r , vec3 col , vec2 offset) {
+    vec2 pos = coord.xy;
+    vec2 c = offset;
+    float d = distance ( pos , c );
+    field += ( k * r ) / ( d*d );
+}
+    
+vec3 band ( float shade, float low, float high, vec3 col1, vec3 col2 ) {
+    if ( (shade >= low) && (shade <= high) ) {
+        float delta = (shade - low) / (high - low);
+        vec3 colDiff = col2 - col1;
+        return col1 + (delta * colDiff);
+    }
+    else
+        return vec3(0.0,0.0,0.0);
+}
+
+vec3 gradient ( float shade ) {
+    vec3 colour = vec3( (sin(time/2.0)*0.25)+0.25,0.0,(cos(time/2.0)*0.25)+0.25);
+    
+    vec3 col1 = vec3(0.01, 0.0, 1.0-0.01);
+    vec3 col2 = vec3(1.0-0.01, 0.0, 0.01);
+    vec3 col3 = vec3(0.02, 1.0-0.02, 0.02);
+    vec3 col4 = vec3((0.01+0.02)/2.0, (0.01+0.02)/2.0, 1.0 - (0.01+0.02)/2.0);
+    vec3 col5 = vec3(0.02, 0.02, 0.02);
+    
+    colour += band ( shade, 0.0, 0.3, colour, col1 );
+    colour += band ( shade, 0.3, 0.6, col1, col2 );
+    colour += band ( shade, 0.6, 0.8, col2, col3 );
+    colour += band ( shade, 0.8, 0.9, col3, col4 );
+    colour += band ( shade, 0.9, 1.0, col4, col5 );
+    
+    return colour;
+}
+
+void main() {
+    coord = texcoord;
+    
+    for (int i = 0; i < 32; i++) {
+        if (i >= blobs_count) { break; } // workaround for webgl error: Loop index cannot be compared with non-constant expression
+        circle(.03 , vec3(0.7 ,0.2, 0.8), blobs_positions[i]);
+    }
+    
+    float shade = min ( 1.0, max ( field/256.0, 0.0 ) );
+    
+    gl_FragColor = vec4( gradient(shade), 1.0 );
+}

--- a/examples/shaders/fragment-color.glsl
+++ b/examples/shaders/fragment-color.glsl
@@ -1,0 +1,6 @@
+#version 100
+varying lowp vec4 color;
+
+void main() {
+    gl_FragColor = color;
+}

--- a/examples/shaders/instancing-vertex.glsl
+++ b/examples/shaders/instancing-vertex.glsl
@@ -1,0 +1,14 @@
+#version 100
+attribute vec3 pos;
+attribute vec4 color0;
+attribute vec3 inst_pos;
+
+varying lowp vec4 color;
+
+uniform mat4 mvp;
+
+void main() {
+    vec4 pos = vec4(pos + inst_pos, 1.0);
+    gl_Position = mvp * pos;
+    color = color0;
+}

--- a/examples/shaders/offscreen-fragment.glsl
+++ b/examples/shaders/offscreen-fragment.glsl
@@ -1,0 +1,9 @@
+#version 100
+varying lowp vec4 color;
+varying lowp vec2 uv;
+
+uniform sampler2D tex;
+
+void main() {
+    gl_FragColor = color * texture2D(tex, uv);
+}

--- a/examples/shaders/offscreen-vertex.glsl
+++ b/examples/shaders/offscreen-vertex.glsl
@@ -1,0 +1,15 @@
+#version 100
+attribute vec4 pos;
+attribute vec4 color0;
+attribute vec2 uv0;
+
+varying lowp vec4 color;
+varying lowp vec2 uv;
+
+uniform mat4 mvp;
+
+void main() {
+    gl_Position = mvp * pos;
+    color = color0;
+    uv = uv0;
+}

--- a/examples/shaders/post_processing-fragment.glsl
+++ b/examples/shaders/post_processing-fragment.glsl
@@ -1,0 +1,23 @@
+#version 100
+precision lowp float;
+
+varying vec2 texcoord;
+
+uniform sampler2D tex;
+uniform vec2 resolution;
+
+
+
+// Source: https://github.com/Jam3/glsl-fast-gaussian-blur/blob/master/5.glsl
+vec4 blur5(sampler2D image, vec2 uv, vec2 resolution, vec2 direction) {
+    vec4 color = vec4(0.0);
+    vec2 off1 = vec2(1.3333333333333333) * direction;
+    color += texture2D(image, uv) * 0.29411764705882354;
+    color += texture2D(image, uv + (off1 / resolution)) * 0.35294117647058826;
+    color += texture2D(image, uv - (off1 / resolution)) * 0.35294117647058826;
+    return color;
+}
+
+void main() {
+    gl_FragColor = blur5(tex, texcoord, resolution, vec2(3.0));
+}

--- a/examples/shaders/post_processing-offscreenvertex.glsl
+++ b/examples/shaders/post_processing-offscreenvertex.glsl
@@ -1,0 +1,12 @@
+#version 100
+attribute vec4 pos;
+attribute vec4 color0;
+
+varying lowp vec4 color;
+
+uniform mat4 mvp;
+
+void main() {
+    gl_Position = mvp * pos;
+    color = color0;
+}

--- a/examples/shaders/post_processing-vertex.glsl
+++ b/examples/shaders/post_processing-vertex.glsl
@@ -1,0 +1,10 @@
+#version 100
+attribute vec2 pos;
+attribute vec2 uv;
+
+varying lowp vec2 texcoord;
+
+void main() {
+    gl_Position = vec4(pos, 0, 1);
+    texcoord = uv;
+}

--- a/examples/shaders/quad-fragment.glsl
+++ b/examples/shaders/quad-fragment.glsl
@@ -1,0 +1,8 @@
+#version 100
+varying lowp vec2 texcoord;
+
+uniform sampler2D tex;
+
+void main() {
+    gl_FragColor = texture2D(tex, texcoord);
+}

--- a/examples/shaders/vertex-uv.glsl
+++ b/examples/shaders/vertex-uv.glsl
@@ -1,0 +1,12 @@
+#version 100
+attribute vec2 pos;
+attribute vec2 uv;
+
+uniform vec2 offset;
+
+varying highp vec2 texcoord;
+
+void main() {
+    gl_Position = vec4(pos + offset, 0, 1);
+    texcoord = uv;
+}


### PR DESCRIPTION
This PR just takes the raw shader strings of the examples and puts them in separate files.
The `include_str!` macro makes sure that the file exists at compile time.

Some shaders were exactly the same so I tried to give them a sensible name so that they get reused.
Let me know what you think!