### PR TITLE
Full fullscreen on Android

### DIFF
--- a/java/MainActivity.java
+++ b/java/MainActivity.java
@@ -10,6 +10,7 @@ import android.util.Log;
 import android.view.View;
 import android.view.Surface;
 import android.view.Window;
+import android.view.WindowManager.LayoutParams;
 import android.view.SurfaceView;
 import android.view.SurfaceHolder;
 import android.view.MotionEvent;
@@ -203,6 +204,8 @@ public class MainActivity extends Activity {
                     View decorView = getWindow().getDecorView();
 
                     if (fullscreen) {
+                        getWindow().setFlags(LayoutParams.FLAG_LAYOUT_NO_LIMITS, LayoutParams.FLAG_LAYOUT_NO_LIMITS);
+                        getWindow().getAttributes().layoutInDisplayCutoutMode = LayoutParams.LAYOUT_IN_DISPLAY_CUTOUT_MODE_SHORT_EDGES;
                         int uiOptions = View.SYSTEM_UI_FLAG_HIDE_NAVIGATION | View.SYSTEM_UI_FLAG_FULLSCREEN | View.SYSTEM_UI_FLAG_IMMERSIVE_STICKY;
                         decorView.setSystemUiVisibility(uiOptions);
                     }


### PR DESCRIPTION
This PR makes the app truly fullscreen on Android. It covers the entire area of the phone including the upper band that could be partially hidden on phones with wider screens.

One thing I'm not sure is if this should be toggleable separately from the `fullscreen` setting in Miniquad. Would some people want their fullscreen to not cover the partially hidden part of the screen on wider phones? I don't know.

## Before
(notice the black band on the left, where stuff like the front camera could be.)
![image](https://user-images.githubusercontent.com/13885008/188313262-c7ec8c9e-1d5f-491f-8efd-4a4eb7d6358f.png)

## After
![image](https://user-images.githubusercontent.com/13885008/188313270-3fbe2073-692d-49df-9321-a38876e7dbd6.png)

