### PR TITLE
General fixes with Clippy lints

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -49,7 +49,7 @@ impl Context {
         unsafe { &*self.display.unwrap() }
     }
 
-    pub fn display_mut(&self) -> &mut dyn NativeDisplay {
+    pub fn display_mut(&mut self) -> &mut dyn NativeDisplay {
         unsafe { &mut *self.display.unwrap() }
     }
 

--- a/src/native/linux_wayland.rs
+++ b/src/native/linux_wayland.rs
@@ -302,7 +302,7 @@ unsafe extern "C" fn xdg_toplevel_handle_configure(
             }
         }
         if let (mut context, Some(event_handler)) = payload.context() {
-            event_handler.resize_event(&mut context, width as _, height as _);
+            event_handler.resize_event(context, width as _, height as _);
         }
     }
 }

--- a/src/native/linux_wayland.rs
+++ b/src/native/linux_wayland.rs
@@ -491,15 +491,15 @@ where
         payload.display.data.screen_width = conf.window_width;
         payload.display.data.screen_height = conf.window_height;
 
-        let event_handler = (f.take().unwrap())(&mut payload.context().0);
+        let event_handler = (f.take().unwrap())(payload.context().0);
         payload.event_handler = Some(event_handler);
 
         while payload.display.closed == false {
             (payload.display.client.wl_display_dispatch_pending)(wdisplay);
 
-            let (mut context, event_handler) = payload.context();
-            event_handler.as_mut().unwrap().update(&mut context);
-            event_handler.as_mut().unwrap().draw(&mut context);
+            let (context, event_handler) = payload.context();
+            event_handler.as_mut().unwrap().update(context);
+            event_handler.as_mut().unwrap().draw(context);
 
             (libegl.eglSwapBuffers.unwrap())(egl_display, egl_surface);
         }

--- a/src/native/linux_wayland.rs
+++ b/src/native/linux_wayland.rs
@@ -273,7 +273,7 @@ unsafe extern "C" fn xdg_toplevel_handle_configure(
     width: i32,
     height: i32,
     _states: *mut wl_array,
-) -> () {
+) {
     assert!(!data.is_null());
 
     if width != 0 && height != 0 {

--- a/src/native/linux_wayland.rs
+++ b/src/native/linux_wayland.rs
@@ -301,7 +301,7 @@ unsafe extern "C" fn xdg_toplevel_handle_configure(
                 decorations.resize(&mut display.client, width, height);
             }
         }
-        if let (mut context, Some(event_handler)) = payload.context() {
+        if let (context, Some(event_handler)) = payload.context() {
             event_handler.resize_event(context, width as _, height as _);
         }
     }

--- a/src/native/linux_x11.rs
+++ b/src/native/linux_x11.rs
@@ -167,7 +167,7 @@ impl X11Display {
             if !db.is_null() {
                 let mut value = XrmValue {
                     size: 0,
-                    addr: 0 as *mut libc::c_char,
+                    addr: std::ptr::null_mut::<libc::c_char>(),
                 };
                 let mut type_ = std::ptr::null_mut();
                 if (self.libx11.XrmGetResource)(

--- a/src/native/linux_x11.rs
+++ b/src/native/linux_x11.rs
@@ -177,10 +177,10 @@ impl X11Display {
                     &mut type_,
                     &mut value,
                 ) != 0
+                    && !type_.is_null()
+                    && libc::strcmp(type_, b"String\x00".as_ptr() as _) == 0
                 {
-                    if !type_.is_null() && libc::strcmp(type_, b"String\x00".as_ptr() as _) == 0 {
-                        self.dpi_scale = libc::atof(value.addr as *const _) as f32 / 96.0;
-                    }
+                    self.dpi_scale = libc::atof(value.addr as *const _) as f32 / 96.0;
                 }
                 (self.libx11.XrmDestroyDatabase)(db);
             }


### PR DESCRIPTION
This is the start of some of the clippy lints I acted on.
Every lint I fixed is per-commit with a link attached (I think the best thing to do with this PR is a squash-merge).

The 2 first commits are clippy lints denoted as **errors**, all the other ones are warnings.

I didn't fix every single clippy lint, first because there are a lot of them, and second because I don't know your preferences regarding some of them (unnecessary `return` keywords for instance, maybe you prefer that in every situation).

![image](https://user-images.githubusercontent.com/13885008/191354449-2d7e7ade-5a18-41d0-9718-b8c9e7d347e7.png)

Let me know if there should be a `clippy.toml` file for that.