### PR TITLE
Implement clipboard for MacOS

### DIFF
--- a/src/native/macos.rs
+++ b/src/native/macos.rs
@@ -89,7 +89,15 @@ impl crate::native::NativeDisplay for MacosDisplay {
     fn clipboard_get(&mut self) -> Option<String> {
         None
     }
-    fn clipboard_set(&mut self, _data: &str) {}
+    fn clipboard_set(&mut self, data: &str) {
+        let str: ObjcId = str_to_nsstring(data);
+        unsafe {
+            let pasteboard: ObjcId = msg_send![class!(NSPasteboard), generalPasteboard];
+            let () = msg_send![pasteboard, clearContents];
+            let arr: ObjcId = msg_send![class!(NSArray), arrayWithObject: str];
+            let () = msg_send![pasteboard, writeObjects: arr];
+        }
+    }
     fn as_any(&mut self) -> &mut dyn std::any::Any {
         self
     }

--- a/src/native/macos.rs
+++ b/src/native/macos.rs
@@ -91,7 +91,10 @@ impl crate::native::NativeDisplay for MacosDisplay {
             let pasteboard: ObjcId = msg_send![class!(NSPasteboard), generalPasteboard];
             let content: ObjcId = msg_send![pasteboard, stringForType: NSStringPboardType];
             let string = nsstring_to_string(content);
-            (!string.is_empty()).then(|| string)
+            if string.is_empty() {
+                return None;
+            }
+            Some(string)
         }
     }
     fn clipboard_set(&mut self, data: &str) {

--- a/src/native/macos.rs
+++ b/src/native/macos.rs
@@ -87,7 +87,12 @@ impl crate::native::NativeDisplay for MacosDisplay {
         }
     }
     fn clipboard_get(&mut self) -> Option<String> {
-        None
+        unsafe {
+            let pasteboard: ObjcId = msg_send![class!(NSPasteboard), generalPasteboard];
+            let content: ObjcId = msg_send![pasteboard, stringForType: NSStringPboardType];
+            let string = nsstring_to_string(content);
+            (!string.is_empty()).then(|| string)
+        }
     }
     fn clipboard_set(&mut self, data: &str) {
         let str: ObjcId = str_to_nsstring(data);


### PR DESCRIPTION
A naive implementation of clipboard_set and clipboard_get for MacOS. Tested on MacOS 12.6.

Fixes #172