### PR TITLE
Fix keycode mapping for umlauts

### DIFF
--- a/js/gl.js
+++ b/js/gl.js
@@ -434,7 +434,7 @@ function into_sapp_mousebutton(btn) {
 function into_sapp_keycode(key_code) {
     switch (key_code) {
         case "Space": return 32;
-        case "Quote": return 39;
+        case "Quote": return 222;
         case "Comma": return 44;
         case "Minus": return 45;
         case "Period": return 46;


### PR DESCRIPTION
Fixes the behaviour described in https://github.com/not-fl3/macroquad/issues/512

Pressing `ä` fires now the `char_event` with `ä` instead of `\'` as `character` parameter.