### PR TITLE
Wasm  fix german "-" keycode

### DIFF
--- a/js/gl.js
+++ b/js/gl.js
@@ -438,7 +438,7 @@ function into_sapp_keycode(key_code) {
         case "Comma": return 44;
         case "Minus": return 45;
         case "Period": return 46;
-        case "Slash": return 47;
+        case "Slash": return 189;
         case "Digit0": return 48;
         case "Digit1": return 49;
         case "Digit2": return 50;

--- a/js/gl.js
+++ b/js/gl.js
@@ -434,7 +434,7 @@ function into_sapp_mousebutton(btn) {
 function into_sapp_keycode(key_code) {
     switch (key_code) {
         case "Space": return 32;
-        case "Quote": return 39;
+        case "Quote": return 222;
         case "Comma": return 44;
         case "Minus": return 45;
         case "Period": return 46;


### PR DESCRIPTION
It similiar problem as https://github.com/not-fl3/macroquad/issues/512. described in https://github.com/not-fl3/macroquad/issues/512#issuecomment-1318915843

Tested on German and US Layout