### PR TITLE
Fix a typo in gl.js

### DIFF
--- a/js/gl.js
+++ b/js/gl.js
@@ -630,7 +630,7 @@ var importObject = {
             gl.clearColor(r, g, b, a);
         },
         glClearStencil: function (s) {
-            gl.clearColorStencil(s);
+            gl.clearStencil(s);
         },
         glColorMask: function (red, green, blue, alpha) {
             gl.colorMask(red, green, blue, alpha);


### PR DESCRIPTION
This typo causes unavailability of glClearStencil