### PR TITLE
Fix swizzle for alpha textures and GLES 2, fix #335

### DIFF
--- a/src/graphics/texture.rs
+++ b/src/graphics/texture.rs
@@ -198,14 +198,16 @@ impl Texture {
             #[cfg(not(target_arch = "wasm32"))]
             match params.format {
                 // on non-WASM alpha value is stored in red channel
-                // swizzle red -> alpha
+                // swizzle red -> alpha, zero red
                 TextureFormat::Alpha if !ctx.features().alpha_texture => {
                     glTexParameteri(GL_TEXTURE_2D, GL_TEXTURE_SWIZZLE_A, GL_RED as _);
+                    glTexParameteri(GL_TEXTURE_2D, GL_TEXTURE_SWIZZLE_R, GL_ZERO as _);
                 }
                 // on non-WASM luminance is stored in red channel, alpha is stored in green channel
-                // keep red, swizzle green -> alpha
+                // keep red, swizzle green -> alpha, zero green
                 TextureFormat::LuminanceAlpha if !ctx.features().alpha_texture => {
                     glTexParameteri(GL_TEXTURE_2D, GL_TEXTURE_SWIZZLE_A, GL_GREEN as _);
+                    glTexParameteri(GL_TEXTURE_2D, GL_TEXTURE_SWIZZLE_G, GL_ZERO as _);
                 }
                 _ => {}
             }

--- a/src/graphics/texture.rs
+++ b/src/graphics/texture.rs
@@ -385,14 +385,16 @@ impl Texture {
             // if not WASM
             match format {
                 // on non-WASM alpha value is stored in red channel
-                // swizzle red -> alpha
+                // swizzle red -> alpha, zero red
                 TextureFormat::Alpha => {
-                    glTexParameteri(GL_TEXTURE_2D, GL_TEXTURE_SWIZZLE_A, GL_RED as _)
+                    glTexParameteri(GL_TEXTURE_2D, GL_TEXTURE_SWIZZLE_A, GL_RED as _);
+                    glTexParameteri(GL_TEXTURE_2D, GL_TEXTURE_SWIZZLE_R, GL_ZERO as _);
                 }
                 // on non-WASM luminance is stored in red channel, alpha is stored in green channel
-                // keep red, swizzle green -> alpha
+                // keep red, swizzle green -> alpha, zero green
                 TextureFormat::LuminanceAlpha => {
-                    glTexParameteri(GL_TEXTURE_2D, GL_TEXTURE_SWIZZLE_A, GL_GREEN as _)
+                    glTexParameteri(GL_TEXTURE_2D, GL_TEXTURE_SWIZZLE_A, GL_GREEN as _);
+                    glTexParameteri(GL_TEXTURE_2D, GL_TEXTURE_SWIZZLE_G, GL_ZERO as _);
                 }
                 _ => {}
             }


### PR DESCRIPTION
#334 missed to add the runtime check for alpha_texture feature when applying swizzle parameters.
This would break Alpha and LuminanceAlpha textures on GLES 2. (WebGL is fine, GL 3 is fine)

Also zeroing the red or green color component, when they are mapped to alpha to not get fooled as described in #335.