### PR TITLE
Add GL_TRIANGLE_STRIP and GL_LINE_STRIP to PrimitiveType Enum

### DIFF
--- a/src/graphics.rs
+++ b/src/graphics.rs
@@ -1407,14 +1407,18 @@ impl From<CompareFunc> for GLenum {
 #[derive(Debug, PartialEq, Clone, Copy)]
 pub enum PrimitiveType {
     Triangles,
+    TriangleStrip,
     Lines,
+    LineStrip,
 }
 
 impl From<PrimitiveType> for GLenum {
     fn from(primitive_type: PrimitiveType) -> Self {
         match primitive_type {
             PrimitiveType::Triangles => GL_TRIANGLES,
+            PrimitiveType::TriangleStrip => GL_TRIANGLE_STRIP,
             PrimitiveType::Lines => GL_LINES,
+            PrimitiveType::LineStrip => GL_LINE_STRIP,
         }
     }
 }


### PR DESCRIPTION
Add missing OpenGL primitive types

Explaining what they do:
https://learnopengl.com/Advanced-OpenGL/Geometry-Shader

They appear to be defined since OpenGL 2
https://docs.gl/gl2/glDrawElements
so I think they are available on all supported platforms.