### PR TITLE
Bump dependencies and Rust edition

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -1,3 +1,0 @@
-{
-    "rust-analyzer.cargo.target": "arm-linux-androideabi"
-}

--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -1,0 +1,3 @@
+{
+    "rust-analyzer.cargo.target": "arm-linux-androideabi"
+}

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -28,7 +28,6 @@ winapi = { version = "0.3", features = ["wingdi", "winuser", "libloaderapi", "wi
 [target.'cfg(target_os = "android")'.dependencies]
 libc = "0.2"
 ndk-sys = "0.4"
-jni-sys = "0.3"
 
 [target.'cfg(any(target_os = "macos", target_os = "ios"))'.dependencies]
 objc = "0.2"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -28,6 +28,7 @@ winapi = { version = "0.3", features = ["wingdi", "winuser", "libloaderapi", "wi
 [target.'cfg(target_os = "android")'.dependencies]
 libc = "0.2"
 ndk-sys = "0.4"
+jni-sys = "0.3"
 
 [target.'cfg(any(target_os = "macos", target_os = "ios"))'.dependencies]
 objc = "0.2"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -33,6 +33,6 @@ ndk-sys = "0.2"
 objc = "0.2"
 
 [dev-dependencies]
-glam = {version = "0.14", features = ["scalar-math"] }
+glam = { version = "0.22" }
 quad-rand = "0.1"
 

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -27,7 +27,7 @@ winapi = { version = "0.3", features = ["wingdi", "winuser", "libloaderapi", "wi
 
 [target.'cfg(target_os = "android")'.dependencies]
 libc = "0.2"
-ndk-sys = "0.4"
+ndk-sys = "0.2"
 
 [target.'cfg(any(target_os = "macos", target_os = "ios"))'.dependencies]
 objc = "0.2"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -27,7 +27,7 @@ winapi = { version = "0.3", features = ["wingdi", "winuser", "libloaderapi", "wi
 
 [target.'cfg(target_os = "android")'.dependencies]
 libc = "0.2"
-ndk-sys = "0.2"
+ndk-sys = "0.4"
 
 [target.'cfg(any(target_os = "macos", target_os = "ios"))'.dependencies]
 objc = "0.2"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -2,7 +2,7 @@
 name = "miniquad"
 version = "0.3.15"
 authors = ["not-fl3 <not.fl3@gmail.com>"]
-edition = "2018"
+edition = "2021"
 license = "MIT/Apache-2.0"
 homepage = "https://github.com/not-fl3/miniquad"
 repository = "https://github.com/not-fl3/miniquad"

--- a/examples/offscreen.rs
+++ b/examples/offscreen.rs
@@ -1,6 +1,6 @@
 use miniquad::*;
 
-use glam::{vec3, Mat4};
+use glam::{vec3, Mat4, EulerRot};
 
 struct Stage {
     display_pipeline: Pipeline,
@@ -172,7 +172,7 @@ impl EventHandler for Stage {
 
         self.rx += 0.01;
         self.ry += 0.03;
-        let model = Mat4::from_rotation_ypr(self.rx, self.ry, 0.);
+        let model = Mat4::from_euler(EulerRot::YXZ, self.rx, self.ry, 0.);
 
         let vs_params = display_shader::Uniforms {
             mvp: view_proj * model,

--- a/examples/post_processing.rs
+++ b/examples/post_processing.rs
@@ -1,6 +1,6 @@
 use miniquad::*;
 
-use glam::{vec3, Mat4};
+use glam::{vec3, Mat4, EulerRot};
 
 struct Stage {
     post_processing_pipeline: Pipeline,
@@ -209,7 +209,7 @@ impl EventHandler for Stage {
 
         self.rx += 0.01;
         self.ry += 0.03;
-        let model = Mat4::from_rotation_ypr(self.rx, self.ry, 0.);
+        let model = Mat4::from_euler(EulerRot::YXZ, self.rx, self.ry, 0.);
 
         let (w, h) = ctx.screen_size();
         // the offscreen pass, rendering an rotating, untextured cube into a render target image

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -179,7 +179,7 @@ pub enum CursorIcon {
 /// Start miniquad.
 pub fn start<F>(conf: conf::Conf, f: F)
 where
-    F: 'static + FnOnce(&mut Context) -> Box<dyn EventHandler> + Send,
+    F: 'static + FnOnce(&mut Context) -> Box<dyn EventHandler>,
 {
     #[cfg(target_os = "linux")]
     {

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -179,7 +179,7 @@ pub enum CursorIcon {
 /// Start miniquad.
 pub fn start<F>(conf: conf::Conf, f: F)
 where
-    F: 'static + FnOnce(&mut Context) -> Box<dyn EventHandler>,
+    F: 'static + FnOnce(&mut Context) -> Box<dyn EventHandler> + Send,
 {
     #[cfg(target_os = "linux")]
     {

--- a/src/native/android.rs
+++ b/src/native/android.rs
@@ -132,7 +132,7 @@ impl NativeDisplay for AndroidDisplay {
 
 pub unsafe fn console_debug(msg: *const ::std::os::raw::c_char) {
     ndk_sys::__android_log_write(
-        ndk_sys::android_LogPriority_ANDROID_LOG_DEBUG as _,
+        ndk_sys::android_LogPriority::ANDROID_LOG_DEBUG.0 as _,
         b"SAPP\0".as_ptr() as _,
         msg,
     );
@@ -140,7 +140,7 @@ pub unsafe fn console_debug(msg: *const ::std::os::raw::c_char) {
 
 pub unsafe fn console_info(msg: *const ::std::os::raw::c_char) {
     ndk_sys::__android_log_write(
-        ndk_sys::android_LogPriority_ANDROID_LOG_INFO as _,
+        ndk_sys::android_LogPriority::ANDROID_LOG_INFO.0 as _,
         b"SAPP\0".as_ptr() as _,
         msg,
     );
@@ -148,7 +148,7 @@ pub unsafe fn console_info(msg: *const ::std::os::raw::c_char) {
 
 pub unsafe fn console_warn(msg: *const ::std::os::raw::c_char) {
     ndk_sys::__android_log_write(
-        ndk_sys::android_LogPriority_ANDROID_LOG_WARN as _,
+        ndk_sys::android_LogPriority::ANDROID_LOG_WARN.0 as _,
         b"SAPP\0".as_ptr() as _,
         msg,
     );
@@ -156,7 +156,7 @@ pub unsafe fn console_warn(msg: *const ::std::os::raw::c_char) {
 
 pub unsafe fn console_error(msg: *const ::std::os::raw::c_char) {
     ndk_sys::__android_log_write(
-        ndk_sys::android_LogPriority_ANDROID_LOG_ERROR as _,
+        ndk_sys::android_LogPriority::ANDROID_LOG_ERROR.0 as _,
         b"SAPP\0".as_ptr() as _,
         msg,
     );

--- a/src/native/android.rs
+++ b/src/native/android.rs
@@ -344,7 +344,7 @@ impl MainThreadState {
 /// TODO: (this should be a GH issue)
 /// TODO: for reference - grep for "pthread_setspecific" in SDL2 sources, SDL fixed it!
 pub unsafe fn attach_jni_env() -> *mut jni_sys::JNIEnv {
-    let env: *mut jni_sys::JNIEnv = std::ptr::null_mut();
+    let mut env: *mut jni_sys::JNIEnv = std::ptr::null_mut();
     let attach_current_thread = (**VM).AttachCurrentThread.unwrap();
 
     let res = attach_current_thread(VM, &mut (env as *mut _), std::ptr::null_mut());
@@ -355,7 +355,7 @@ pub unsafe fn attach_jni_env() -> *mut jni_sys::JNIEnv {
 
 pub unsafe fn run<F>(conf: crate::conf::Conf, f: F)
 where
-    F: 'static + FnOnce(&mut crate::Context) -> Box<dyn EventHandler> + Send,
+    F: 'static + FnOnce(&mut crate::Context) -> Box<dyn EventHandler>,
 {
     {
         use std::ffi::CString;

--- a/src/native/android.rs
+++ b/src/native/android.rs
@@ -355,7 +355,7 @@ pub unsafe fn attach_jni_env() -> *mut ndk_sys::JNIEnv {
 
 pub unsafe fn run<F>(conf: crate::conf::Conf, f: F)
 where
-    F: 'static + FnOnce(&mut crate::Context) -> Box<dyn EventHandler>,
+    F: 'static + FnOnce(&mut crate::Context) -> Box<dyn EventHandler> + Send,
 {
     {
         use std::ffi::CString;

--- a/src/native/android.rs
+++ b/src/native/android.rs
@@ -132,7 +132,7 @@ impl NativeDisplay for AndroidDisplay {
 
 pub unsafe fn console_debug(msg: *const ::std::os::raw::c_char) {
     ndk_sys::__android_log_write(
-        ndk_sys::android_LogPriority::ANDROID_LOG_DEBUG.0 as _,
+        ndk_sys::android_LogPriority_ANDROID_LOG_DEBUG as _,
         b"SAPP\0".as_ptr() as _,
         msg,
     );
@@ -140,7 +140,7 @@ pub unsafe fn console_debug(msg: *const ::std::os::raw::c_char) {
 
 pub unsafe fn console_info(msg: *const ::std::os::raw::c_char) {
     ndk_sys::__android_log_write(
-        ndk_sys::android_LogPriority::ANDROID_LOG_INFO.0 as _,
+        ndk_sys::android_LogPriority_ANDROID_LOG_INFO as _,
         b"SAPP\0".as_ptr() as _,
         msg,
     );
@@ -148,7 +148,7 @@ pub unsafe fn console_info(msg: *const ::std::os::raw::c_char) {
 
 pub unsafe fn console_warn(msg: *const ::std::os::raw::c_char) {
     ndk_sys::__android_log_write(
-        ndk_sys::android_LogPriority::ANDROID_LOG_WARN.0 as _,
+        ndk_sys::android_LogPriority_ANDROID_LOG_WARN as _,
         b"SAPP\0".as_ptr() as _,
         msg,
     );
@@ -156,7 +156,7 @@ pub unsafe fn console_warn(msg: *const ::std::os::raw::c_char) {
 
 pub unsafe fn console_error(msg: *const ::std::os::raw::c_char) {
     ndk_sys::__android_log_write(
-        ndk_sys::android_LogPriority::ANDROID_LOG_ERROR.0 as _,
+        ndk_sys::android_LogPriority_ANDROID_LOG_ERROR as _,
         b"SAPP\0".as_ptr() as _,
         msg,
     );

--- a/src/native/android.rs
+++ b/src/native/android.rs
@@ -344,7 +344,7 @@ impl MainThreadState {
 /// TODO: (this should be a GH issue)
 /// TODO: for reference - grep for "pthread_setspecific" in SDL2 sources, SDL fixed it!
 pub unsafe fn attach_jni_env() -> *mut jni_sys::JNIEnv {
-    let mut env: *mut jni_sys::JNIEnv = std::ptr::null_mut();
+    let env: *mut jni_sys::JNIEnv = std::ptr::null_mut();
     let attach_current_thread = (**VM).AttachCurrentThread.unwrap();
 
     let res = attach_current_thread(VM, &mut (env as *mut _), std::ptr::null_mut());
@@ -355,7 +355,7 @@ pub unsafe fn attach_jni_env() -> *mut jni_sys::JNIEnv {
 
 pub unsafe fn run<F>(conf: crate::conf::Conf, f: F)
 where
-    F: 'static + FnOnce(&mut crate::Context) -> Box<dyn EventHandler>,
+    F: 'static + FnOnce(&mut crate::Context) -> Box<dyn EventHandler> + Send,
 {
     {
         use std::ffi::CString;

--- a/src/native/android.rs
+++ b/src/native/android.rs
@@ -17,12 +17,12 @@ pub mod ndk_utils;
 
 #[no_mangle]
 pub unsafe extern "C" fn JNI_OnLoad(
-    vm: *mut jni_sys::JavaVM,
+    vm: *mut ndk_sys::JavaVM,
     _: std::ffi::c_void,
-) -> jni_sys::jint {
+) -> ndk_sys::jint {
     VM = vm as *mut _ as _;
 
-    jni_sys::JNI_VERSION_1_6 as _
+    ndk_sys::JNI_VERSION_1_6 as _
 }
 
 extern "C" {
@@ -82,8 +82,8 @@ fn send_message(message: Message) {
     })
 }
 
-static mut ACTIVITY: jni_sys::jobject = std::ptr::null_mut();
-static mut VM: *mut jni_sys::JavaVM = std::ptr::null_mut();
+static mut ACTIVITY: ndk_sys::jobject = std::ptr::null_mut();
+static mut VM: *mut ndk_sys::JavaVM = std::ptr::null_mut();
 
 struct AndroidDisplay {
     screen_width: f32,
@@ -343,11 +343,11 @@ impl MainThreadState {
 /// TODO: Figure how to get into the thread destructor to correctly call Detach
 /// TODO: (this should be a GH issue)
 /// TODO: for reference - grep for "pthread_setspecific" in SDL2 sources, SDL fixed it!
-pub unsafe fn attach_jni_env() -> *mut jni_sys::JNIEnv {
-    let mut env: *mut jni_sys::JNIEnv = std::ptr::null_mut();
+pub unsafe fn attach_jni_env() -> *mut ndk_sys::JNIEnv {
+    let mut env: *mut ndk_sys::JNIEnv = std::ptr::null_mut();
     let attach_current_thread = (**VM).AttachCurrentThread.unwrap();
 
-    let res = attach_current_thread(VM, &mut (env as *mut _), std::ptr::null_mut());
+    let res = attach_current_thread(VM, &mut env, std::ptr::null_mut());
     assert!(res == 0);
 
     env
@@ -482,7 +482,7 @@ extern "C" fn jni_on_load(vm: *mut std::ffi::c_void) {
     }
 }
 
-unsafe fn create_native_window(surface: jni_sys::jobject) -> *mut ndk_sys::ANativeWindow {
+unsafe fn create_native_window(surface: ndk_sys::jobject) -> *mut ndk_sys::ANativeWindow {
     let env = attach_jni_env();
 
     ndk_sys::ANativeWindow_fromSurface(env, surface)
@@ -490,9 +490,9 @@ unsafe fn create_native_window(surface: jni_sys::jobject) -> *mut ndk_sys::ANati
 
 #[no_mangle]
 pub unsafe extern "C" fn Java_quad_1native_QuadNative_activityOnCreate(
-    _: *mut jni_sys::JNIEnv,
-    _: jni_sys::jobject,
-    activity: jni_sys::jobject,
+    _: *mut ndk_sys::JNIEnv,
+    _: ndk_sys::jobject,
+    activity: ndk_sys::jobject,
 ) {
     let env = attach_jni_env();
     ACTIVITY = (**env).NewGlobalRef.unwrap()(env, activity);
@@ -501,33 +501,33 @@ pub unsafe extern "C" fn Java_quad_1native_QuadNative_activityOnCreate(
 
 #[no_mangle]
 unsafe extern "C" fn Java_quad_1native_QuadNative_activityOnResume(
-    _: *mut jni_sys::JNIEnv,
-    _: jni_sys::jobject,
+    _: *mut ndk_sys::JNIEnv,
+    _: ndk_sys::jobject,
 ) {
     send_message(Message::Resume);
 }
 
 #[no_mangle]
 unsafe extern "C" fn Java_quad_1native_QuadNative_activityOnPause(
-    _: *mut jni_sys::JNIEnv,
-    _: jni_sys::jobject,
+    _: *mut ndk_sys::JNIEnv,
+    _: ndk_sys::jobject,
 ) {
     send_message(Message::Pause);
 }
 
 #[no_mangle]
 unsafe extern "C" fn Java_quad_1native_QuadNative_activityOnDestroy(
-    _: *mut jni_sys::JNIEnv,
-    _: jni_sys::jobject,
+    _: *mut ndk_sys::JNIEnv,
+    _: ndk_sys::jobject,
 ) {
     send_message(Message::Destroy);
 }
 
 #[no_mangle]
 extern "C" fn Java_quad_1native_QuadNative_surfaceOnSurfaceCreated(
-    _: *mut jni_sys::JNIEnv,
-    _: jni_sys::jobject,
-    surface: jni_sys::jobject,
+    _: *mut ndk_sys::JNIEnv,
+    _: ndk_sys::jobject,
+    surface: ndk_sys::jobject,
 ) {
     let window = unsafe { create_native_window(surface) };
     send_message(Message::SurfaceCreated { window });
@@ -535,19 +535,19 @@ extern "C" fn Java_quad_1native_QuadNative_surfaceOnSurfaceCreated(
 
 #[no_mangle]
 extern "C" fn Java_quad_1native_QuadNative_surfaceOnSurfaceDestroyed(
-    _: *mut jni_sys::JNIEnv,
-    _: jni_sys::jobject,
+    _: *mut ndk_sys::JNIEnv,
+    _: ndk_sys::jobject,
 ) {
     send_message(Message::SurfaceDestroyed);
 }
 
 #[no_mangle]
 extern "C" fn Java_quad_1native_QuadNative_surfaceOnSurfaceChanged(
-    _: *mut jni_sys::JNIEnv,
-    _: jni_sys::jobject,
-    surface: jni_sys::jobject,
-    width: jni_sys::jint,
-    height: jni_sys::jint,
+    _: *mut ndk_sys::JNIEnv,
+    _: ndk_sys::jobject,
+    surface: ndk_sys::jobject,
+    width: ndk_sys::jint,
+    height: ndk_sys::jint,
 ) {
     let window = unsafe { create_native_window(surface) };
 
@@ -560,12 +560,12 @@ extern "C" fn Java_quad_1native_QuadNative_surfaceOnSurfaceChanged(
 
 #[no_mangle]
 extern "C" fn Java_quad_1native_QuadNative_surfaceOnTouch(
-    _: *mut jni_sys::JNIEnv,
-    _: jni_sys::jobject,
-    touch_id: jni_sys::jint,
-    action: jni_sys::jint,
-    x: jni_sys::jfloat,
-    y: jni_sys::jfloat,
+    _: *mut ndk_sys::JNIEnv,
+    _: ndk_sys::jobject,
+    touch_id: ndk_sys::jint,
+    action: ndk_sys::jint,
+    x: ndk_sys::jfloat,
+    y: ndk_sys::jfloat,
 ) {
     let phase = match action {
         0 => TouchPhase::Moved,
@@ -585,9 +585,9 @@ extern "C" fn Java_quad_1native_QuadNative_surfaceOnTouch(
 
 #[no_mangle]
 extern "C" fn Java_quad_1native_QuadNative_surfaceOnKeyDown(
-    _: *mut jni_sys::JNIEnv,
-    _: jni_sys::jobject,
-    keycode: jni_sys::jint,
+    _: *mut ndk_sys::JNIEnv,
+    _: ndk_sys::jobject,
+    keycode: ndk_sys::jint,
 ) {
     let keycode = keycodes::translate_keycode(keycode as _);
 
@@ -596,9 +596,9 @@ extern "C" fn Java_quad_1native_QuadNative_surfaceOnKeyDown(
 
 #[no_mangle]
 extern "C" fn Java_quad_1native_QuadNative_surfaceOnKeyUp(
-    _: *mut jni_sys::JNIEnv,
-    _: jni_sys::jobject,
-    keycode: jni_sys::jint,
+    _: *mut ndk_sys::JNIEnv,
+    _: ndk_sys::jobject,
+    keycode: ndk_sys::jint,
 ) {
     let keycode = keycodes::translate_keycode(keycode as _);
 
@@ -607,16 +607,16 @@ extern "C" fn Java_quad_1native_QuadNative_surfaceOnKeyUp(
 
 #[no_mangle]
 extern "C" fn Java_quad_1native_QuadNative_surfaceOnCharacter(
-    _: *mut jni_sys::JNIEnv,
-    _: jni_sys::jobject,
-    character: jni_sys::jint,
+    _: *mut ndk_sys::JNIEnv,
+    _: ndk_sys::jobject,
+    character: ndk_sys::jint,
 ) {
     send_message(Message::Character {
         character: character as u32,
     });
 }
 
-unsafe fn set_full_screen(env: *mut jni_sys::JNIEnv, fullscreen: bool) {
+unsafe fn set_full_screen(env: *mut ndk_sys::JNIEnv, fullscreen: bool) {
     ndk_utils::call_void_method!(env, ACTIVITY, "setFullScreen", "(Z)V", fullscreen as i32);
 }
 
@@ -632,8 +632,8 @@ pub struct android_asset {
 // For some reason it is missing fron ndk_sys binding
 extern "C" {
     pub fn AAssetManager_fromJava(
-        env: *mut jni_sys::JNIEnv,
-        assetManager: jni_sys::jobject,
+        env: *mut ndk_sys::JNIEnv,
+        assetManager: ndk_sys::jobject,
     ) -> *mut ndk_sys::AAssetManager;
 }
 


### PR DESCRIPTION
This PR lets miniquad use the latest versions of all dependencies and the latest Rust edition.
On my Linux machine, the compile times haven't really been affected, so it shouldn't cause any additional problems.

`glam` doesn't need to have any additional features, and now also has a bunch more QOL functions that miniquad examples could use a bit everywhere, such as doing some `Vec2 / f32` operations, though it's probably better to keep that for a separate PR.

As for `ndk-sys` going from 0.2 to 0.4, I have tested it on my phone and examples just crash on startup. I don't know what to do nor why it happens despite the logs, so I'm not bumping it.

Otherwise, all other dependencies are up-to-date on their major version.