### PR TITLE
Metal backend

### DIFF
--- a/examples/blobs.rs
+++ b/examples/blobs.rs
@@ -141,7 +141,7 @@ impl EventHandler for Stage {
 
 fn main() {
     let mut conf = conf::Conf::default();
-    let metal = true; //std::env::args().nth(1).as_deref() == Some("metal");
+    let metal = std::env::args().nth(1).as_deref() == Some("metal");
     conf.platform.apple_gfx_api = if metal {
         conf::AppleGfxApi::Metal
     } else {

--- a/examples/blobs.rs
+++ b/examples/blobs.rs
@@ -33,10 +33,11 @@ impl Stage {
             Vertex { pos : Vec2 { x: -1.0, y:  1.0 }, uv: Vec2 { x: 0., y: 1. } },
         ];
         let vertex_buffer =
-            ctx.new_buffer_immutable(BufferType::VertexBuffer, Arg::slice(&vertices));
+            ctx.new_buffer_immutable(BufferType::VertexBuffer, BufferSource::slice(&vertices));
 
         let indices: [u16; 6] = [0, 1, 2, 0, 2, 3];
-        let index_buffer = ctx.new_buffer_immutable(BufferType::IndexBuffer, Arg::slice(&indices));
+        let index_buffer =
+            ctx.new_buffer_immutable(BufferType::IndexBuffer, BufferSource::slice(&indices));
 
         let bindings = Bindings {
             vertex_buffers: vec![vertex_buffer],
@@ -129,7 +130,8 @@ impl EventHandler for Stage {
         self.ctx.begin_default_pass(Default::default());
         self.ctx.apply_pipeline(&self.pipeline);
         self.ctx.apply_bindings(&self.bindings);
-        self.ctx.apply_uniforms(Arg::val(&self.uniforms));
+        self.ctx
+            .apply_uniforms(UniformsSource::table(&self.uniforms));
         self.ctx.draw(0, 6, 1);
         self.ctx.end_render_pass();
 

--- a/examples/blobs.rs
+++ b/examples/blobs.rs
@@ -18,10 +18,13 @@ struct Stage {
     last_frame: f64,
     uniforms: shader::Uniforms,
     blobs_velocities: [(f32, f32); 32],
+    ctx: Box<dyn RenderingBackend>,
 }
 
 impl Stage {
-    pub fn new(ctx: &mut Context) -> Stage {
+    pub fn new() -> Stage {
+        let mut ctx: Box<dyn RenderingBackend> = window::new_rendering_backend();
+
         #[rustfmt::skip]
         let vertices: [Vertex; 4] = [
             Vertex { pos : Vec2 { x: -1.0, y: -1.0 }, uv: Vec2 { x: 0., y: 0. } },
@@ -29,10 +32,11 @@ impl Stage {
             Vertex { pos : Vec2 { x:  1.0, y:  1.0 }, uv: Vec2 { x: 1., y: 1. } },
             Vertex { pos : Vec2 { x: -1.0, y:  1.0 }, uv: Vec2 { x: 0., y: 1. } },
         ];
-        let vertex_buffer = Buffer::immutable(ctx, BufferType::VertexBuffer, &vertices);
+        let vertex_buffer =
+            ctx.new_buffer_immutable(BufferType::VertexBuffer, Arg::slice(&vertices));
 
         let indices: [u16; 6] = [0, 1, 2, 0, 2, 3];
-        let index_buffer = Buffer::immutable(ctx, BufferType::IndexBuffer, &indices);
+        let index_buffer = ctx.new_buffer_immutable(BufferType::IndexBuffer, Arg::slice(&indices));
 
         let bindings = Bindings {
             vertex_buffers: vec![vertex_buffer],
@@ -40,14 +44,22 @@ impl Stage {
             images: vec![],
         };
 
-        let shader = Shader::new(ctx, shader::VERTEX, shader::FRAGMENT, shader::meta()).unwrap();
+        let shader = ctx
+            .new_shader(
+                ShaderSource {
+                    glsl_vertex: Some(shader::VERTEX),
+                    glsl_fragment: Some(shader::FRAGMENT),
+                    metal_shader: Some(shader::METAL),
+                },
+                shader::meta(),
+            )
+            .unwrap();
 
-        let pipeline = Pipeline::new(
-            ctx,
+        let pipeline = ctx.new_pipeline(
             &[BufferLayout::default()],
             &[
-                VertexAttribute::new("pos", VertexFormat::Float2),
-                VertexAttribute::new("uv", VertexFormat::Float2),
+                VertexAttribute::new("in_pos", VertexFormat::Float2),
+                VertexAttribute::new("in_uv", VertexFormat::Float2),
             ],
             shader,
         );
@@ -67,12 +79,13 @@ impl Stage {
             uniforms,
             blobs_velocities: [(0., 0.); 32],
             last_frame: time,
+            ctx,
         }
     }
 }
 
 impl EventHandler for Stage {
-    fn update(&mut self, _ctx: &mut Context) {
+    fn update(&mut self) {
         let time = miniquad::date::now();
         let delta = (time - self.last_frame) as f32;
         self.last_frame = time;
@@ -90,18 +103,18 @@ impl EventHandler for Stage {
         }
     }
 
-    fn mouse_motion_event(&mut self, ctx: &mut Context, x: f32, y: f32) {
-        let (w, h) = ctx.screen_size();
+    fn mouse_motion_event(&mut self, x: f32, y: f32) {
+        let (w, h) = window::screen_size();
         let (x, y) = (x / w, 1. - y / h);
         self.uniforms.blobs_positions[0] = (x, y);
     }
 
-    fn mouse_button_down_event(&mut self, ctx: &mut Context, _button: MouseButton, x: f32, y: f32) {
+    fn mouse_button_down_event(&mut self, _button: MouseButton, x: f32, y: f32) {
         if self.uniforms.blobs_count >= 32 {
             return;
         }
 
-        let (w, h) = ctx.screen_size();
+        let (w, h) = window::screen_size();
         let (x, y) = (x / w, 1. - y / h);
         let (dx, dy) = (quad_rand::gen_range(-1., 1.), quad_rand::gen_range(-1., 1.));
 
@@ -110,24 +123,30 @@ impl EventHandler for Stage {
         self.uniforms.blobs_count += 1;
     }
 
-    fn draw(&mut self, ctx: &mut Context) {
+    fn draw(&mut self) {
         self.uniforms.time = (miniquad::date::now() - self.start_time) as f32;
 
-        ctx.begin_default_pass(Default::default());
-        ctx.apply_pipeline(&self.pipeline);
-        ctx.apply_bindings(&self.bindings);
-        ctx.apply_uniforms(&self.uniforms);
-        ctx.draw(0, 6, 1);
-        ctx.end_render_pass();
+        self.ctx.begin_default_pass(Default::default());
+        self.ctx.apply_pipeline(&self.pipeline);
+        self.ctx.apply_bindings(&self.bindings);
+        self.ctx.apply_uniforms(Arg::val(&self.uniforms));
+        self.ctx.draw(0, 6, 1);
+        self.ctx.end_render_pass();
 
-        ctx.commit_frame();
+        self.ctx.commit_frame();
     }
 }
 
 fn main() {
-    miniquad::start(conf::Conf::default(), |mut ctx| {
-        Box::new(Stage::new(&mut ctx))
-    });
+    let mut conf = conf::Conf::default();
+    let metal = true; //std::env::args().nth(1).as_deref() == Some("metal");
+    conf.platform.apple_gfx_api = if metal {
+        conf::AppleGfxApi::Metal
+    } else {
+        conf::AppleGfxApi::OpenGl
+    };
+
+    miniquad::start(conf, move || Box::new(Stage::new()));
 }
 
 // based on: https://www.shadertoy.com/view/XsS3DV
@@ -135,22 +154,20 @@ mod shader {
     use miniquad::*;
 
     pub const VERTEX: &str = r#"#version 100
-    attribute vec2 pos;
-    attribute vec2 uv;
+    attribute vec2 in_pos;
+    attribute vec2 in_uv;
 
-    uniform vec2 offset;
-
-    varying highp vec2 texcoord;
+    varying highp vec2 uv;
 
     void main() {
-        gl_Position = vec4(pos + offset, 0, 1);
-        texcoord = uv;
+        gl_Position = vec4(in_pos, 0, 1);
+        uv = in_uv;
     }"#;
 
     pub const FRAGMENT: &str = r#"#version 100
     precision highp float;
 
-    varying vec2 texcoord;
+    varying vec2 uv;
 
     uniform float time;
     uniform int blobs_count;
@@ -196,7 +213,7 @@ mod shader {
     }
     
     void main() {
-        coord = texcoord;
+        coord = uv;
         
         for (int i = 0; i < 32; i++) {
             if (i >= blobs_count) { break; } // workaround for webgl error: Loop index cannot be compared with non-constant expression
@@ -206,6 +223,91 @@ mod shader {
         float shade = min ( 1.0, max ( field/256.0, 0.0 ) );
         
         gl_FragColor = vec4( gradient(shade), 1.0 );
+    }"#;
+
+    pub const METAL: &str = r#"
+    #include <metal_stdlib>
+
+    using namespace metal;
+
+    struct Uniforms
+    {
+        float time;
+        int16_t blobs_count;
+        float2 blobs[32];
+    };
+
+    struct Vertex
+    {
+        float2 in_pos   [[attribute(0)]];
+        float2 in_uv    [[attribute(1)]];
+    };
+
+    struct RasterizerData
+    {
+        float4 position [[position]];
+        float2 uv       [[user(locn0)]];
+    };
+
+    vertex RasterizerData vertexShader(
+      Vertex v [[stage_in]])
+    {
+        RasterizerData out;
+
+        out.position = float4(v.in_pos.xy, 0.0, 1.0);
+        out.uv = v.in_uv;
+
+        return out;
+    }
+
+    constant float k = 20.0;
+        
+    float circle(float2 coord, float r , float3 col , float2 offset) {
+        float2 pos = coord.xy;
+        float2 c = offset;
+        float d = distance ( pos , c );
+        return ( k * r ) / ( d*d );
+    }
+        
+    float3 band ( float shade, float low, float high, float3 col1, float3 col2 ) {
+        if ( (shade >= low) && (shade <= high) ) {
+            float delta = (shade - low) / (high - low);
+            float3 colDiff = col2 - col1;
+            return col1 + (delta * colDiff);
+        }
+        else
+            return float3(0.0,0.0,0.0);
+    }
+    
+    float3 gradient (float shade, float time) {
+        float3 colour = float3( (sin(time/2.0)*0.25)+0.25,0.0,(cos(time/2.0)*0.25)+0.25);
+        
+        float3 col1 = float3(0.01, 0.0, 1.0-0.01);
+        float3 col2 = float3(1.0-0.01, 0.0, 0.01);
+        float3 col3 = float3(0.02, 1.0-0.02, 0.02);
+        float3 col4 = float3((0.01+0.02)/2.0, (0.01+0.02)/2.0, 1.0 - (0.01+0.02)/2.0);
+        float3 col5 = float3(0.02, 0.02, 0.02);
+        
+        colour += band ( shade, 0.0, 0.3, colour, col1 );
+        colour += band ( shade, 0.3, 0.6, col1, col2 );
+        colour += band ( shade, 0.6, 0.8, col2, col3 );
+        colour += band ( shade, 0.8, 0.9, col3, col4 );
+        colour += band ( shade, 0.9, 1.0, col4, col5 );
+        
+        return colour;
+    }
+
+    fragment float4 fragmentShader(RasterizerData in [[stage_in]], constant Uniforms& uniforms [[buffer(0)]])
+    {
+        float field = 0.0;
+        for (int i = 0; i < 32; i++) {
+            if (i >= uniforms.blobs_count) { break; } // workaround for webgl error: Loop index cannot be compared with non-constant expression
+            field += circle(in.uv, .03 , float3(0.7 ,0.2, 0.8), uniforms.blobs[i]);
+        }
+        
+        float shade = min ( 1.0, max(field/256.0, 0.0 ) );
+        
+        return float4(gradient(shade, uniforms.time), 1.0 );
     }"#;
 
     pub fn meta() -> ShaderMeta {

--- a/examples/instancing.rs
+++ b/examples/instancing.rs
@@ -33,14 +33,15 @@ impl Stage {
         ];
         // vertex buffer for static geometry
         let geometry_vertex_buffer =
-            ctx.new_buffer_immutable(BufferType::VertexBuffer, Arg::slice(&vertices));
+            ctx.new_buffer_immutable(BufferType::VertexBuffer, BufferSource::slice(&vertices));
 
         #[rustfmt::skip]
         let indices: &[u16] = &[
             0, 1, 2,    0, 2, 3,    0, 3, 4,    0, 4, 1,
             5, 1, 2,    5, 2, 3,    5, 3, 4,    5, 4, 1
         ];
-        let index_buffer = ctx.new_buffer_immutable(BufferType::IndexBuffer, Arg::slice(&indices));
+        let index_buffer =
+            ctx.new_buffer_immutable(BufferType::IndexBuffer, BufferSource::slice(&indices));
 
         // empty, dynamic instance-data vertex buffer
         let positions_vertex_buffer = ctx.new_buffer_stream(
@@ -127,7 +128,7 @@ impl EventHandler for Stage {
         assert_eq!(std::mem::size_of::<Vec3>(), 12);
 
         self.ctx
-            .buffer_update(self.bindings.vertex_buffers[1], Arg::slice(&self.pos[..]));
+            .buffer_update(self.bindings.vertex_buffers[1], BufferSource::slice(&self.pos[..]));
 
         // model-view-projection matrix
         let (width, height) = window::screen_size();
@@ -147,7 +148,7 @@ impl EventHandler for Stage {
 
         self.ctx.apply_pipeline(&self.pipeline);
         self.ctx.apply_bindings(&self.bindings);
-        self.ctx.apply_uniforms(Arg::val(&shader::Uniforms { mvp }));
+        self.ctx.apply_uniforms(UniformsSource::table(&shader::Uniforms { mvp }));
         self.ctx.draw(0, 24, self.pos.len() as i32);
         self.ctx.end_render_pass();
 

--- a/examples/mouse_cursor.rs
+++ b/examples/mouse_cursor.rs
@@ -3,14 +3,14 @@ use miniquad::*;
 struct Stage {}
 
 impl EventHandler for Stage {
-    fn update(&mut self, _ctx: &mut Context) {}
+    fn update(&mut self) {}
 
-    fn draw(&mut self, _ctx: &mut Context) {}
+    fn draw(&mut self) {}
 
-    fn char_event(&mut self, ctx: &mut Context, character: char, _: KeyMods, _: bool) {
+    fn char_event(&mut self, character: char, _: KeyMods, _: bool) {
         match character {
-            'z' => ctx.show_mouse(false),
-            'x' => ctx.show_mouse(true),
+            'z' => window::show_mouse(false),
+            'x' => window::show_mouse(true),
             _ => (),
         }
 
@@ -29,10 +29,10 @@ impl EventHandler for Stage {
             'w' => CursorIcon::NWSEResize,
             _ => return,
         };
-        ctx.set_mouse_cursor(icon);
+        window::set_mouse_cursor(icon);
     }
 }
 
 fn main() {
-    miniquad::start(conf::Conf::default(), |_ctx| Box::new(Stage {}));
+    miniquad::start(conf::Conf::default(), || Box::new(Stage {}));
 }

--- a/examples/offscreen.rs
+++ b/examples/offscreen.rs
@@ -14,12 +14,8 @@ struct Stage {
 }
 
 impl Stage {
-    pub fn new(metal: bool) -> Stage {
-        let mut ctx: Box<dyn RenderingBackend> = if metal {
-            Box::new(MetalContext::new())
-        } else {
-            Box::new(GlContext::new())
-        };
+    pub fn new() -> Stage {
+        let mut ctx: Box<dyn RenderingBackend> = window::new_rendering_backend();
 
         let color_img = ctx.new_render_texture(TextureParams {
             width: 256,
@@ -169,7 +165,7 @@ impl EventHandler for Stage {
     fn update(&mut self) {}
 
     fn draw(&mut self) {
-        let (width, height) = screen_size();
+        let (width, height) = window::screen_size();
         let proj = Mat4::perspective_rh_gl(60.0f32.to_radians(), width / height, 0.01, 10.0);
         let view = Mat4::look_at_rh(
             vec3(0.0, 1.5, 3.0),
@@ -185,7 +181,6 @@ impl EventHandler for Stage {
         let vs_params = display_shader::Uniforms {
             mvp: view_proj * model,
         };
-
 
         // the offscreen pass, rendering an rotating, untextured cube into a render target image
         self.ctx.begin_pass(
@@ -215,13 +210,13 @@ impl EventHandler for Stage {
 fn main() {
     let mut conf = conf::Conf::default();
     let metal = std::env::args().nth(1).as_deref() == Some("metal");
-    conf.platform.macos_gfx_api = if metal {
-        conf::MacosGfxApi::Metal
+    conf.platform.apple_gfx_api = if metal {
+        conf::AppleGfxApi::Metal
     } else {
-        conf::MacosGfxApi::OpenGl
+        conf::AppleGfxApi::OpenGl
     };
 
-    miniquad::start(conf, move || Box::new(Stage::new(metal)));
+    miniquad::start(conf, move || Box::new(Stage::new()));
 }
 
 mod display_shader {

--- a/examples/offscreen.rs
+++ b/examples/offscreen.rs
@@ -71,7 +71,7 @@ impl Stage {
         ];
 
         let vertex_buffer =
-            ctx.new_buffer_immutable(BufferType::VertexBuffer, Arg::slice(&vertices));
+            ctx.new_buffer_immutable(BufferType::VertexBuffer, BufferSource::slice(&vertices));
 
         #[rustfmt::skip]
         let indices: &[u16] = &[
@@ -83,7 +83,8 @@ impl Stage {
             22, 21, 20,  23, 22, 20
         ];
 
-        let index_buffer = ctx.new_buffer_immutable(BufferType::IndexBuffer, Arg::slice(&indices));
+        let index_buffer =
+            ctx.new_buffer_immutable(BufferType::IndexBuffer, BufferSource::slice(&indices));
 
         let offscreen_bind = Bindings {
             vertex_buffers: vec![vertex_buffer.clone()],
@@ -193,7 +194,7 @@ impl EventHandler for Stage {
         );
         self.ctx.apply_pipeline(&self.offscreen_pipeline);
         self.ctx.apply_bindings(&self.offscreen_bind);
-        self.ctx.apply_uniforms(Arg::val(&vs_params));
+        self.ctx.apply_uniforms(UniformsSource::table(&vs_params));
         self.ctx.draw(0, 36, 1);
         self.ctx.end_render_pass();
 
@@ -203,7 +204,7 @@ impl EventHandler for Stage {
             .begin_default_pass(PassAction::clear_color(0.0, 0., 0.45, 1.));
         self.ctx.apply_pipeline(&self.display_pipeline);
         self.ctx.apply_bindings(&self.display_bind);
-        self.ctx.apply_uniforms(Arg::val(&vs_params));
+        self.ctx.apply_uniforms(UniformsSource::table(&vs_params));
         self.ctx.draw(0, 36, 1);
         self.ctx.end_render_pass();
 

--- a/examples/quad.rs
+++ b/examples/quad.rs
@@ -34,10 +34,11 @@ impl Stage {
             Vertex { pos : Vec2 { x: -0.5, y:  0.5 }, uv: Vec2 { x: 0., y: 1. } },
         ];
         let vertex_buffer =
-            ctx.new_buffer_immutable(BufferType::VertexBuffer, Arg::slice(&vertices));
+            ctx.new_buffer_immutable(BufferType::VertexBuffer, BufferSource::slice(&vertices));
 
         let indices: [u16; 6] = [0, 1, 2, 0, 2, 3];
-        let index_buffer = ctx.new_buffer_immutable(BufferType::IndexBuffer, Arg::slice(&indices));
+        let index_buffer =
+            ctx.new_buffer_immutable(BufferType::IndexBuffer, BufferSource::slice(&indices));
 
         let pixels: [u8; 4 * 4 * 4] = [
             0xFF, 0xFF, 0xFF, 0xFF, 0xFF, 0x00, 0x00, 0xFF, 0xFF, 0xFF, 0xFF, 0xFF, 0xFF, 0x00,
@@ -95,9 +96,10 @@ impl EventHandler for Stage {
         for i in 0..10 {
             let t = t + i as f64 * 0.3;
 
-            self.ctx.apply_uniforms(Arg::val(&shader::Uniforms {
-                offset: (t.sin() as f32 * 0.5, (t * 3.).cos() as f32 * 0.5),
-            }));
+            self.ctx
+                .apply_uniforms(UniformsSource::table(&shader::Uniforms {
+                    offset: (t.sin() as f32 * 0.5, (t * 3.).cos() as f32 * 0.5),
+                }));
             self.ctx.draw(0, 6, 1);
         }
         self.ctx.end_render_pass();

--- a/examples/quad.rs
+++ b/examples/quad.rs
@@ -19,12 +19,8 @@ struct Stage {
 }
 
 impl Stage {
-    pub fn new(metal: bool) -> Stage {
-        let mut ctx: Box<dyn RenderingBackend> = if metal {
-            Box::new(MetalContext::new())
-        } else {
-            Box::new(GlContext::new())
-        };
+    pub fn new() -> Stage {
+        let mut ctx: Box<dyn RenderingBackend> = window::new_rendering_backend();
 
         #[rustfmt::skip]
         let vertices: [Vertex; 4] = [
@@ -111,13 +107,13 @@ impl EventHandler for Stage {
 fn main() {
     let mut conf = conf::Conf::default();
     let metal = std::env::args().nth(1).as_deref() == Some("metal");
-    conf.platform.macos_gfx_api = if metal {
-        conf::MacosGfxApi::Metal
+    conf.platform.apple_gfx_api = if metal {
+        conf::AppleGfxApi::Metal
     } else {
-        conf::MacosGfxApi::OpenGl
+        conf::AppleGfxApi::OpenGl
     };
 
-    miniquad::start(conf, move || Box::new(Stage::new(metal)));
+    miniquad::start(conf, move || Box::new(Stage::new()));
 }
 
 mod shader {

--- a/examples/triangle.rs
+++ b/examples/triangle.rs
@@ -13,12 +13,8 @@ struct Stage {
 }
 
 impl Stage {
-    pub fn new(metal: bool) -> Stage {
-        let mut ctx: Box<dyn RenderingBackend> = if metal {
-            Box::new(MetalContext::new())
-        } else {
-            Box::new(GlContext::new())
-        };
+    pub fn new() -> Stage {
+        let mut ctx: Box<dyn RenderingBackend> = window::new_rendering_backend();
 
         #[rustfmt::skip]
         let vertices: [Vertex; 3] = [
@@ -85,13 +81,13 @@ impl EventHandler for Stage {
 fn main() {
     let mut conf = conf::Conf::default();
     let metal = std::env::args().nth(1).as_deref() == Some("metal");
-    conf.platform.macos_gfx_api = if metal {
-        conf::MacosGfxApi::Metal
+    conf.platform.apple_gfx_api = if metal {
+        conf::AppleGfxApi::Metal
     } else {
-        conf::MacosGfxApi::OpenGl
+        conf::AppleGfxApi::OpenGl
     };
 
-    miniquad::start(conf, move || Box::new(Stage::new(metal)));
+    miniquad::start(conf, move || Box::new(Stage::new()));
 }
 
 mod shader {

--- a/examples/triangle.rs
+++ b/examples/triangle.rs
@@ -27,10 +27,11 @@ impl Stage {
             Vertex { pos : [  0.0,  0.5 ], color: [0., 0., 1., 1.] },
         ];
         let vertex_buffer =
-            ctx.new_buffer_immutable(BufferType::VertexBuffer, Arg::slice(&vertices));
+            ctx.new_buffer_immutable(BufferType::VertexBuffer, BufferSource::slice(&vertices));
 
         let indices: [u16; 3] = [0, 1, 2];
-        let index_buffer = ctx.new_buffer_immutable(BufferType::IndexBuffer, Arg::slice(&indices));
+        let index_buffer =
+            ctx.new_buffer_immutable(BufferType::IndexBuffer, BufferSource::slice(&indices));
 
         let bindings = Bindings {
             vertex_buffers: vec![vertex_buffer],

--- a/examples/window_conf.rs
+++ b/examples/window_conf.rs
@@ -1,11 +1,13 @@
 use miniquad::*;
 
-struct Stage {}
+struct Stage {
+    ctx: GlContext,
+}
 impl EventHandler for Stage {
-    fn update(&mut self, _ctx: &mut Context) {}
+    fn update(&mut self) {}
 
-    fn draw(&mut self, ctx: &mut Context) {
-        ctx.clear(Some((0., 1., 0., 1.)), None, None);
+    fn draw(&mut self) {
+        self.ctx.clear(Some((0., 1., 0., 1.)), None, None);
     }
 }
 
@@ -18,6 +20,10 @@ fn main() {
             fullscreen: true,
             ..Default::default()
         },
-        |_ctx| Box::new(Stage {}),
+        || {
+            Box::new(Stage {
+                ctx: GlContext::new(),
+            })
+        },
     );
 }

--- a/src/conf.rs
+++ b/src/conf.rs
@@ -62,6 +62,12 @@ pub enum LinuxBackend {
     WaylandWithX11Fallback,
 }
 
+#[derive(Debug, PartialEq, Clone, Copy)]
+pub enum AppleGfxApi {
+    OpenGl,
+    Metal,
+}
+
 /// Platform specific settings.
 #[derive(Debug)]
 pub struct Platform {
@@ -77,6 +83,13 @@ pub struct Platform {
     ///
     /// Defaults to X11Only. Wayland implementation is way too unstable right now.
     pub linux_backend: LinuxBackend,
+
+    /// Which rendering context to create, Metal or OpenGL.
+    /// Miniquad always links with Metal.framework (assuming it is always present)
+    /// but it links with OpenGL dynamically and only if required.
+    ///
+    /// Defaults to AppleGfxApi::GL for legacy reasons.
+    pub apple_gfx_api: AppleGfxApi,
 
     /// On some platform it is possible to ask the OS for a specific swap interval.
     /// Note that this is highly platform and implementation dependent,
@@ -98,6 +111,7 @@ impl Default for Platform {
             linux_x11_gl: LinuxX11Gl::GLXWithEGLFallback,
             swap_interval: None,
             linux_backend: LinuxBackend::X11Only,
+            apple_gfx_api: AppleGfxApi::OpenGl,
             framebuffer_alpha: false,
         }
     }

--- a/src/event.rs
+++ b/src/event.rs
@@ -1,5 +1,3 @@
-use crate::Context;
-
 #[derive(Debug, Copy, Clone, PartialEq, Hash, Eq)]
 pub enum MouseButton {
     Right,
@@ -165,87 +163,59 @@ pub trait EventHandler {
     /// When the app is in background, Android destroys the rendering surface,
     /// while app is still alive and can do some usefull calculations.
     /// Note that in this case drawing from update may lead to crashes.
-    fn update(&mut self, _ctx: &mut Context);
-    fn draw(&mut self, _ctx: &mut Context);
-    fn resize_event(&mut self, _ctx: &mut Context, _width: f32, _height: f32) {}
-    fn mouse_motion_event(&mut self, _ctx: &mut Context, _x: f32, _y: f32) {}
-    fn mouse_wheel_event(&mut self, _ctx: &mut Context, _x: f32, _y: f32) {}
-    fn mouse_button_down_event(
-        &mut self,
-        _ctx: &mut Context,
-        _button: MouseButton,
-        _x: f32,
-        _y: f32,
-    ) {
-    }
-    fn mouse_button_up_event(
-        &mut self,
-        _ctx: &mut Context,
-        _button: MouseButton,
-        _x: f32,
-        _y: f32,
-    ) {
-    }
+    fn update(&mut self);
+    fn draw(&mut self);
+    fn resize_event(&mut self, _width: f32, _height: f32) {}
+    fn mouse_motion_event(&mut self, _x: f32, _y: f32) {}
+    fn mouse_wheel_event(&mut self, _x: f32, _y: f32) {}
+    fn mouse_button_down_event(&mut self, _button: MouseButton, _x: f32, _y: f32) {}
+    fn mouse_button_up_event(&mut self, _button: MouseButton, _x: f32, _y: f32) {}
 
-    fn char_event(
-        &mut self,
-        _ctx: &mut Context,
-        _character: char,
-        _keymods: KeyMods,
-        _repeat: bool,
-    ) {
-    }
+    fn char_event(&mut self, _character: char, _keymods: KeyMods, _repeat: bool) {}
 
-    fn key_down_event(
-        &mut self,
-        _ctx: &mut Context,
-        _keycode: KeyCode,
-        _keymods: KeyMods,
-        _repeat: bool,
-    ) {
-    }
+    fn key_down_event(&mut self, _keycode: KeyCode, _keymods: KeyMods, _repeat: bool) {}
 
-    fn key_up_event(&mut self, _ctx: &mut Context, _keycode: KeyCode, _keymods: KeyMods) {}
+    fn key_up_event(&mut self, _keycode: KeyCode, _keymods: KeyMods) {}
 
     /// Default implementation emulates mouse clicks
-    fn touch_event(&mut self, ctx: &mut Context, phase: TouchPhase, _id: u64, x: f32, y: f32) {
+    fn touch_event(&mut self, phase: TouchPhase, _id: u64, x: f32, y: f32) {
         if phase == TouchPhase::Started {
-            self.mouse_button_down_event(ctx, MouseButton::Left, x, y);
+            self.mouse_button_down_event(MouseButton::Left, x, y);
         }
 
         if phase == TouchPhase::Ended {
-            self.mouse_button_up_event(ctx, MouseButton::Left, x, y);
+            self.mouse_button_up_event(MouseButton::Left, x, y);
         }
 
         if phase == TouchPhase::Moved {
-            self.mouse_motion_event(ctx, x, y);
+            self.mouse_motion_event(x, y);
         }
     }
 
     /// Represents raw hardware mouse motion event
     /// Note that these events are delivered regardless of input focus and not in pixels, but in
     /// hardware units instead. And those units may be different from pixels depending on the target platform
-    fn raw_mouse_motion(&mut self, _ctx: &mut Context, _dx: f32, _dy: f32) {}
+    fn raw_mouse_motion(&mut self, _dx: f32, _dy: f32) {}
 
     /// Window has been minimized
     /// Right now is only implemented on Android, and is called on a Pause ndk callback
-    fn window_minimized_event(&mut self, _ctx: &mut Context) {}
+    fn window_minimized_event(&mut self) {}
 
     /// Window has been restored
     /// Right now is only implemented on Android, and is called on a Resume ndk callback
-    fn window_restored_event(&mut self, _ctx: &mut Context) {}
+    fn window_restored_event(&mut self) {}
 
     /// This event is sent when the userclicks the window's close button
     /// or application code calls the ctx.request_quit() function. The event
     /// handler callback code can handle this event by calling
     /// ctx.cancel_quit() to cancel the quit.
     /// If the event is ignored, the application will quit as usual.
-    fn quit_requested_event(&mut self, _ctx: &mut Context) {}
+    fn quit_requested_event(&mut self) {}
 
     /// A file has been dropped over the application.
     /// Applications can request the number of dropped files with
     /// `ctx.dropped_file_count()`, path of an individual file with
     /// `ctx.dropped_file_path()`, and for wasm targets the file bytes
     /// can be requested with `ctx.dropped_file_bytes()`.
-    fn files_dropped_event(&mut self, _ctx: &mut Context) {}
+    fn files_dropped_event(&mut self) {}
 }

--- a/src/graphics.rs
+++ b/src/graphics.rs
@@ -8,7 +8,13 @@ use std::{error::Error, fmt::Display};
 
 mod gl;
 
+#[cfg(target_vendor = "apple")]
+mod metal;
+
 pub use gl::GlContext;
+
+#[cfg(target_vendor = "apple")]
+pub use metal::MetalContext;
 
 #[derive(Clone, Copy, Debug)]
 pub enum UniformType {

--- a/src/graphics.rs
+++ b/src/graphics.rs
@@ -1065,10 +1065,11 @@ pub trait RenderingBackend {
         //TODO
         //assert_eq!(texture.size(width, height), bytes.len());
 
-        self.update_texture_part(texture, 0 as _, 0 as _, width as _, height as _, bytes)
+        self.texture_update_part(texture, 0 as _, 0 as _, width as _, height as _, bytes)
     }
-
-    fn update_texture_part(
+    fn texture_set_filter(&mut self, texture: TextureId, filter: FilterMode);
+    fn texture_set_wrap(&mut self, texture: TextureId, wrap: TextureWrap);
+    fn texture_update_part(
         &mut self,
         texture: TextureId,
         x_offset: i32,

--- a/src/graphics.rs
+++ b/src/graphics.rs
@@ -1069,6 +1069,8 @@ pub trait RenderingBackend {
     }
     fn texture_set_filter(&mut self, texture: TextureId, filter: FilterMode);
     fn texture_set_wrap(&mut self, texture: TextureId, wrap: TextureWrap);
+    fn texture_resize(&mut self, texture: TextureId, width: u32, height: u32, bytes: Option<&[u8]>);
+    fn texture_read_pixels(&mut self, texture: TextureId, bytes: &mut [u8]);
     fn texture_update_part(
         &mut self,
         texture: TextureId,

--- a/src/graphics/gl.rs
+++ b/src/graphics/gl.rs
@@ -744,17 +744,17 @@ impl RenderingBackend for GlContext {
     /// ];
     /// let buffer = ctx.new_buffer_immutable(BufferType::VertexBuffer, &vertices);
     /// ```
-    fn new_buffer_immutable(&mut self, buffer_type: BufferType, data: Arg) -> BufferId {
-        debug_assert!(data.is_slice);
+    fn new_buffer_immutable(&mut self, buffer_type: BufferType, data: BufferSource) -> BufferId {
+        debug_assert!(data.0.is_slice);
         let index_type = if buffer_type == BufferType::IndexBuffer {
-            Some(IndexType::for_type_size(data.element_size))
+            Some(IndexType::for_type_size(data.0.element_size))
         } else {
             None
         };
 
         let gl_target = gl_buffer_target(&buffer_type);
         let gl_usage = gl_usage(&Usage::Immutable);
-        let size = data.size;
+        let size = data.0.size;
         let mut gl_buf: u32 = 0;
 
         unsafe {
@@ -762,7 +762,7 @@ impl RenderingBackend for GlContext {
             self.cache.store_buffer_binding(gl_target);
             self.cache.bind_buffer(gl_target, gl_buf, index_type);
             glBufferData(gl_target, size as _, std::ptr::null() as *const _, gl_usage);
-            glBufferSubData(gl_target, 0, size as _, data.ptr as _);
+            glBufferSubData(gl_target, 0, size as _, data.0.ptr as _);
             self.cache.restore_buffer_binding(gl_target);
         }
 
@@ -828,15 +828,15 @@ impl RenderingBackend for GlContext {
         BufferId(self.buffers.len() - 1)
     }
 
-    fn buffer_update(&mut self, buffer: BufferId, data: Arg) {
-        debug_assert!(data.is_slice);
+    fn buffer_update(&mut self, buffer: BufferId, data: BufferSource) {
+        debug_assert!(data.0.is_slice);
         let buffer = &self.buffers[buffer.0];
         if buffer.buffer_type == BufferType::IndexBuffer {
             assert!(buffer.index_type.is_some());
-            assert!(buffer.index_type.unwrap() == IndexType::for_type_size(data.element_size));
+            assert!(buffer.index_type.unwrap() == IndexType::for_type_size(data.0.element_size));
         };
 
-        let size = data.size;
+        let size = data.0.size;
 
         assert!(size <= buffer.size);
 
@@ -844,7 +844,7 @@ impl RenderingBackend for GlContext {
         self.cache.store_buffer_binding(gl_target);
         self.cache
             .bind_buffer(gl_target, buffer.gl_buf, buffer.index_type);
-        unsafe { glBufferSubData(gl_target, 0, size as _, data.ptr as _) };
+        unsafe { glBufferSubData(gl_target, 0, size as _, data.0.ptr as _) };
         self.cache.restore_buffer_binding(gl_target);
     }
 

--- a/src/graphics/gl.rs
+++ b/src/graphics/gl.rs
@@ -1,0 +1,1243 @@
+use std::ffi::CString;
+
+mod cache;
+
+use cache::*;
+
+use crate::{native::gl::*, window};
+
+use super::*;
+
+#[derive(Clone, Copy, Debug)]
+pub struct Buffer {
+    gl_buf: GLuint,
+    buffer_type: BufferType,
+    size: usize,
+    index_type: Option<IndexType>,
+}
+
+#[derive(Debug)]
+struct ShaderUniform {
+    gl_loc: UniformLocation,
+    uniform_type: UniformType,
+    array_count: i32,
+}
+
+struct ShaderInternal {
+    program: GLuint,
+    images: Vec<ShaderImage>,
+    uniforms: Vec<ShaderUniform>,
+}
+
+#[derive(Clone, Copy, Debug, PartialEq, Hash)]
+struct Texture {
+    texture: GLuint,
+    width: u32,
+    height: u32,
+    format: TextureFormat,
+}
+
+/// Converts from TextureFormat to (internal_format, format, pixel_type)
+impl From<TextureFormat> for (GLenum, GLenum, GLenum) {
+    fn from(format: TextureFormat) -> Self {
+        match format {
+            TextureFormat::RGB8 => (GL_RGB, GL_RGB, GL_UNSIGNED_BYTE),
+            TextureFormat::RGBA8 => (GL_RGBA, GL_RGBA, GL_UNSIGNED_BYTE),
+            TextureFormat::Depth => (GL_DEPTH_COMPONENT, GL_DEPTH_COMPONENT, GL_UNSIGNED_SHORT),
+            #[cfg(target_arch = "wasm32")]
+            TextureFormat::Alpha => (GL_ALPHA, GL_ALPHA, GL_UNSIGNED_BYTE),
+            #[cfg(not(target_arch = "wasm32"))]
+            TextureFormat::Alpha => (GL_R8, GL_RED, GL_UNSIGNED_BYTE), // texture updates will swizzle Red -> Alpha to match WASM
+        }
+    }
+}
+
+impl Texture {
+    pub fn new(
+        ctx: &mut GlContext,
+        _access: TextureAccess,
+        bytes: Option<&[u8]>,
+        params: TextureParams,
+    ) -> Texture {
+        if let Some(bytes_data) = bytes {
+            assert_eq!(
+                params.format.size(params.width, params.height) as usize,
+                bytes_data.len()
+            );
+        }
+
+        let (internal_format, format, pixel_type) = params.format.into();
+
+        ctx.cache.store_texture_binding(0);
+
+        let mut texture: GLuint = 0;
+
+        unsafe {
+            glGenTextures(1, &mut texture as *mut _);
+            ctx.cache.bind_texture(0, texture);
+            glPixelStorei(GL_UNPACK_ALIGNMENT, 1); // miniquad always uses row alignment of 1
+
+            if cfg!(not(target_arch = "wasm32")) {
+                // if not WASM
+                if params.format == TextureFormat::Alpha {
+                    // if alpha miniquad texture, the value on non-WASM is stored in red channel
+                    // swizzle red -> alpha
+                    glTexParameteri(GL_TEXTURE_2D, GL_TEXTURE_SWIZZLE_A, GL_RED as _);
+                } else {
+                    // keep alpha -> alpha
+                    glTexParameteri(GL_TEXTURE_2D, GL_TEXTURE_SWIZZLE_A, GL_ALPHA as _);
+                }
+            }
+
+            glTexImage2D(
+                GL_TEXTURE_2D,
+                0,
+                internal_format as i32,
+                params.width as i32,
+                params.height as i32,
+                0,
+                format,
+                pixel_type,
+                match bytes {
+                    Some(bytes) => bytes.as_ptr() as *const _,
+                    Option::None => std::ptr::null(),
+                },
+            );
+
+            // TODO: filter as i32 doesn't work anymore
+            glTexParameteri(GL_TEXTURE_2D, GL_TEXTURE_WRAP_S, params.wrap as i32);
+            glTexParameteri(GL_TEXTURE_2D, GL_TEXTURE_WRAP_T, params.wrap as i32);
+            glTexParameteri(GL_TEXTURE_2D, GL_TEXTURE_MIN_FILTER, GL_LINEAR as i32);
+            glTexParameteri(GL_TEXTURE_2D, GL_TEXTURE_MAG_FILTER, GL_LINEAR as i32);
+        }
+        ctx.cache.restore_texture_binding(0);
+
+        Texture {
+            texture,
+            width: params.width,
+            height: params.height,
+            format: params.format,
+        }
+    }
+
+    /// Delete GPU texture, leaving handle unmodified.
+    ///
+    /// More high-level code on top of miniquad probably is going to call this in Drop implementation of some
+    /// more RAII buffer object.
+    ///
+    /// There is no protection against using deleted textures later. However its not an UB in OpenGl and thats why
+    /// this function is not marked as unsafe
+    pub fn delete(&self) {
+        unsafe {
+            glDeleteTextures(1, &self.texture as *const _);
+        }
+    }
+
+    pub fn set_filter(&self, ctx: &mut GlContext, filter: FilterMode) {
+        ctx.cache.store_texture_binding(0);
+        ctx.cache.bind_texture(0, self.texture);
+        unsafe {
+            glTexParameteri(GL_TEXTURE_2D, GL_TEXTURE_MIN_FILTER, filter as i32);
+            glTexParameteri(GL_TEXTURE_2D, GL_TEXTURE_MAG_FILTER, filter as i32);
+        }
+        ctx.cache.restore_texture_binding(0);
+    }
+
+    pub fn set_wrap(&self, ctx: &mut GlContext, wrap: TextureWrap) {
+        ctx.cache.store_texture_binding(0);
+        ctx.cache.bind_texture(0, self.texture);
+        unsafe {
+            glTexParameteri(GL_TEXTURE_2D, GL_TEXTURE_WRAP_S, wrap as i32);
+            glTexParameteri(GL_TEXTURE_2D, GL_TEXTURE_WRAP_T, wrap as i32);
+        }
+        ctx.cache.restore_texture_binding(0);
+    }
+
+    pub fn resize(&mut self, ctx: &mut GlContext, width: u32, height: u32, bytes: Option<&[u8]>) {
+        ctx.cache.store_texture_binding(0);
+
+        let (internal_format, format, pixel_type) = self.format.into();
+
+        self.width = width;
+        self.height = height;
+
+        unsafe {
+            glTexImage2D(
+                GL_TEXTURE_2D,
+                0,
+                internal_format as i32,
+                self.width as i32,
+                self.height as i32,
+                0,
+                format,
+                pixel_type,
+                match bytes {
+                    Some(bytes) => bytes.as_ptr() as *const _,
+                    Option::None => std::ptr::null(),
+                },
+            );
+        }
+
+        ctx.cache.restore_texture_binding(0);
+    }
+
+    pub fn update_texture_part(
+        &self,
+        ctx: &mut GlContext,
+        x_offset: i32,
+        y_offset: i32,
+        width: i32,
+        height: i32,
+        bytes: &[u8],
+    ) {
+        assert_eq!(self.size(width as _, height as _), bytes.len());
+        assert!(x_offset + width <= self.width as _);
+        assert!(y_offset + height <= self.height as _);
+
+        ctx.cache.store_texture_binding(0);
+        ctx.cache.bind_texture(0, self.texture);
+
+        let (_, format, pixel_type) = self.format.into();
+
+        unsafe {
+            glPixelStorei(GL_UNPACK_ALIGNMENT, 1); // miniquad always uses row alignment of 1
+
+            if cfg!(not(target_arch = "wasm32")) {
+                // if not WASM
+                if self.format == TextureFormat::Alpha {
+                    // if alpha miniquad texture, the value on non-WASM is stored in red channel
+                    // swizzle red -> alpha
+                    glTexParameteri(GL_TEXTURE_2D, GL_TEXTURE_SWIZZLE_A, GL_RED as _);
+                } else {
+                    // keep alpha -> alpha
+                    glTexParameteri(GL_TEXTURE_2D, GL_TEXTURE_SWIZZLE_A, GL_ALPHA as _);
+                }
+            }
+
+            glTexSubImage2D(
+                GL_TEXTURE_2D,
+                0,
+                x_offset as _,
+                y_offset as _,
+                width as _,
+                height as _,
+                format,
+                pixel_type,
+                bytes.as_ptr() as *const _,
+            );
+        }
+
+        ctx.cache.restore_texture_binding(0);
+    }
+
+    /// Read texture data into CPU memory
+    pub fn read_pixels(&self, bytes: &mut [u8]) {
+        let (_, format, pixel_type) = self.format.into();
+
+        let mut fbo = 0;
+        unsafe {
+            let mut binded_fbo: i32 = 0;
+            glGetIntegerv(gl::GL_DRAW_FRAMEBUFFER_BINDING, &mut binded_fbo);
+            glGenFramebuffers(1, &mut fbo);
+            glBindFramebuffer(gl::GL_FRAMEBUFFER, fbo);
+            glFramebufferTexture2D(
+                gl::GL_FRAMEBUFFER,
+                gl::GL_COLOR_ATTACHMENT0,
+                gl::GL_TEXTURE_2D,
+                self.texture,
+                0,
+            );
+
+            glReadPixels(
+                0,
+                0,
+                self.width as _,
+                self.height as _,
+                format,
+                pixel_type,
+                bytes.as_mut_ptr() as _,
+            );
+
+            glBindFramebuffer(gl::GL_FRAMEBUFFER, binded_fbo as _);
+            glDeleteFramebuffers(1, &fbo);
+        }
+    }
+
+    #[inline]
+    fn size(&self, width: u32, height: u32) -> usize {
+        self.format.size(width, height) as usize
+    }
+}
+
+pub(crate) struct PipelineInternal {
+    layout: Vec<Option<VertexAttributeInternal>>,
+    shader: ShaderId,
+    params: PipelineParams,
+}
+
+type UniformLocation = Option<GLint>;
+
+pub struct ShaderImage {
+    gl_loc: UniformLocation,
+}
+
+fn get_uniform_location(program: GLuint, name: &str) -> Option<i32> {
+    let cname = CString::new(name).unwrap_or_else(|e| panic!("{}", e));
+    let location = unsafe { glGetUniformLocation(program, cname.as_ptr()) };
+
+    if location == -1 {
+        return None;
+    }
+
+    Some(location)
+}
+
+pub(crate) struct RenderPassInternal {
+    gl_fb: GLuint,
+    texture: TextureId,
+    depth_texture: Option<TextureId>,
+}
+
+pub struct GlContext {
+    shaders: Vec<ShaderInternal>,
+    pipelines: Vec<PipelineInternal>,
+    passes: Vec<RenderPassInternal>,
+    buffers: Vec<Buffer>,
+    textures: Vec<Texture>,
+    default_framebuffer: GLuint,
+    pub(crate) cache: GlCache,
+
+    pub(crate) features: Features,
+}
+
+impl GlContext {
+    pub fn new() -> GlContext {
+        unsafe {
+            let mut default_framebuffer: GLuint = 0;
+            glGetIntegerv(
+                GL_FRAMEBUFFER_BINDING,
+                &mut default_framebuffer as *mut _ as *mut _,
+            );
+            let mut vao = 0;
+
+            glGenVertexArrays(1, &mut vao as *mut _);
+            glBindVertexArray(vao);
+            GlContext {
+                default_framebuffer,
+                shaders: vec![],
+                pipelines: vec![],
+                passes: vec![],
+                buffers: vec![],
+                textures: vec![],
+                features: Features {
+                    instancing: !crate::native::gl::is_gl2(),
+                    ..Default::default()
+                },
+                cache: GlCache {
+                    stored_index_buffer: 0,
+                    stored_index_type: None,
+                    stored_vertex_buffer: 0,
+                    index_buffer: 0,
+                    index_type: None,
+                    vertex_buffer: 0,
+                    cur_pipeline: None,
+                    color_blend: None,
+                    alpha_blend: None,
+                    stencil: None,
+                    color_write: (true, true, true, true),
+                    cull_face: CullFace::Nothing,
+                    stored_texture: 0,
+                    textures: [0; MAX_SHADERSTAGE_IMAGES],
+                    attributes: [None; MAX_VERTEX_ATTRIBUTES],
+                },
+            }
+        }
+    }
+
+    pub fn features(&self) -> &Features {
+        &self.features
+    }
+}
+
+fn load_shader_internal(
+    vertex_shader: &str,
+    fragment_shader: &str,
+    meta: ShaderMeta,
+) -> Result<ShaderInternal, ShaderError> {
+    unsafe {
+        let vertex_shader = load_shader(GL_VERTEX_SHADER, vertex_shader)?;
+        let fragment_shader = load_shader(GL_FRAGMENT_SHADER, fragment_shader)?;
+
+        let program = glCreateProgram();
+        glAttachShader(program, vertex_shader);
+        glAttachShader(program, fragment_shader);
+        glLinkProgram(program);
+
+        let mut link_status = 0;
+        glGetProgramiv(program, GL_LINK_STATUS, &mut link_status as *mut _);
+        if link_status == 0 {
+            let mut max_length: i32 = 0;
+            glGetProgramiv(program, GL_INFO_LOG_LENGTH, &mut max_length as *mut _);
+
+            let mut error_message = vec![0u8; max_length as usize + 1];
+            glGetProgramInfoLog(
+                program,
+                max_length,
+                &mut max_length as *mut _,
+                error_message.as_mut_ptr() as *mut _,
+            );
+            assert!(max_length >= 1);
+            let error_message =
+                std::string::String::from_utf8_lossy(&error_message[0..max_length as usize - 1]);
+            return Err(ShaderError::LinkError(error_message.to_string()));
+        }
+
+        glUseProgram(program);
+
+        #[rustfmt::skip]
+        let images = meta.images.iter().map(|name| ShaderImage {
+            gl_loc: get_uniform_location(program, name),
+        }).collect();
+
+        #[rustfmt::skip]
+        let uniforms = meta.uniforms.uniforms.iter().scan(0, |offset, uniform| {
+            let res = ShaderUniform {
+                gl_loc: get_uniform_location(program, &uniform.name),
+                uniform_type: uniform.uniform_type,
+                array_count: uniform.array_count as _,
+            };
+            *offset += uniform.uniform_type.size() * uniform.array_count;
+            Some(res)
+        }).collect();
+
+        Ok(ShaderInternal {
+            program,
+            images,
+            uniforms,
+        })
+    }
+}
+
+pub fn load_shader(shader_type: GLenum, source: &str) -> Result<GLuint, ShaderError> {
+    unsafe {
+        let shader = glCreateShader(shader_type);
+        assert!(shader != 0);
+
+        let cstring = CString::new(source)?;
+        let csource = [cstring];
+        glShaderSource(shader, 1, csource.as_ptr() as *const _, std::ptr::null());
+        glCompileShader(shader);
+
+        let mut is_compiled = 0;
+        glGetShaderiv(shader, GL_COMPILE_STATUS, &mut is_compiled as *mut _);
+        if is_compiled == 0 {
+            let mut max_length: i32 = 0;
+            glGetShaderiv(shader, GL_INFO_LOG_LENGTH, &mut max_length as *mut _);
+
+            let mut error_message = vec![0u8; max_length as usize + 1];
+            glGetShaderInfoLog(
+                shader,
+                max_length,
+                &mut max_length as *mut _,
+                error_message.as_mut_ptr() as *mut _,
+            );
+
+            assert!(max_length >= 1);
+            let mut error_message =
+                std::string::String::from_utf8_lossy(&error_message[0..max_length as usize - 1])
+                    .into_owned();
+
+            // On Wasm + Chrome, for unknown reason, string with zero-terminator is returned. On Firefox there is no zero-terminators in JavaScript string.
+            if error_message.ends_with('\0') {
+                error_message.pop();
+            }
+
+            return Err(ShaderError::CompilationError {
+                shader_type: match shader_type {
+                    GL_VERTEX_SHADER => ShaderType::Vertex,
+                    GL_FRAGMENT_SHADER => ShaderType::Fragment,
+                    _ => unreachable!(),
+                },
+                error_message,
+            });
+        }
+
+        Ok(shader)
+    }
+}
+
+impl RenderingBackend for GlContext {
+    fn new_shader(
+        &mut self,
+        shader: ShaderSource,
+        meta: ShaderMeta,
+    ) -> Result<ShaderId, ShaderError> {
+        let shader = load_shader_internal(
+            shader.glsl_vertex.unwrap(),
+            shader.glsl_fragment.unwrap(),
+            meta,
+        )?;
+        self.shaders.push(shader);
+        Ok(ShaderId(self.shaders.len() - 1))
+    }
+
+    fn new_texture(
+        &mut self,
+        access: TextureAccess,
+        bytes: Option<&[u8]>,
+        params: TextureParams,
+    ) -> TextureId {
+        let texture = Texture::new(self, access, bytes, params);
+        self.textures.push(texture);
+        TextureId(self.textures.len() - 1)
+    }
+    fn update_texture_part(
+        &mut self,
+        texture: TextureId,
+        x_offset: i32,
+        y_offset: i32,
+        width: i32,
+        height: i32,
+        bytes: &[u8],
+    ) {
+        let t = self.textures[texture.0];
+        t.update_texture_part(self, x_offset, y_offset, width, height, bytes);
+    }
+    fn texture_size(&self, texture: TextureId) -> (u32, u32) {
+        let texture = self.textures[texture.0];
+        (texture.width as _, texture.height as _)
+    }
+    fn new_render_pass(
+        &mut self,
+        color_img: TextureId,
+        depth_img: Option<TextureId>,
+    ) -> RenderPass {
+        let mut gl_fb = 0;
+
+        unsafe {
+            glGenFramebuffers(1, &mut gl_fb as *mut _);
+            glBindFramebuffer(GL_FRAMEBUFFER, gl_fb);
+            glFramebufferTexture2D(
+                GL_FRAMEBUFFER,
+                GL_COLOR_ATTACHMENT0,
+                GL_TEXTURE_2D,
+                self.textures[color_img.0].texture,
+                0,
+            );
+            if let Some(depth_img) = depth_img {
+                glFramebufferTexture2D(
+                    GL_FRAMEBUFFER,
+                    GL_DEPTH_ATTACHMENT,
+                    GL_TEXTURE_2D,
+                    self.textures[depth_img.0].texture,
+                    0,
+                );
+            }
+            glBindFramebuffer(GL_FRAMEBUFFER, self.default_framebuffer);
+        }
+        let pass = RenderPassInternal {
+            gl_fb,
+            texture: color_img,
+            depth_texture: depth_img,
+        };
+
+        self.passes.push(pass);
+
+        RenderPass(self.passes.len() - 1)
+    }
+    fn render_pass_texture(&self, render_pass: RenderPass) -> TextureId {
+        self.passes[render_pass.0].texture
+    }
+    fn delete_render_pass(&mut self, render_pass: RenderPass) {
+        let render_pass = &mut self.passes[render_pass.0];
+
+        unsafe { glDeleteFramebuffers(1, &mut render_pass.gl_fb as *mut _) }
+
+        self.textures[render_pass.texture.0].delete();
+        if let Some(depth_texture) = render_pass.depth_texture {
+            self.textures[depth_texture.0].delete();
+        }
+    }
+
+    fn new_pipeline(
+        &mut self,
+        buffer_layout: &[BufferLayout],
+        attributes: &[VertexAttribute],
+        shader: ShaderId,
+    ) -> Pipeline {
+        self.new_pipeline_with_params(buffer_layout, attributes, shader, Default::default())
+    }
+
+    fn new_pipeline_with_params(
+        &mut self,
+        buffer_layout: &[BufferLayout],
+        attributes: &[VertexAttribute],
+        shader: ShaderId,
+        params: PipelineParams,
+    ) -> Pipeline {
+        #[derive(Clone, Copy, Default)]
+        struct BufferCacheData {
+            stride: i32,
+            offset: i64,
+        }
+
+        let mut buffer_cache: Vec<BufferCacheData> =
+            vec![BufferCacheData::default(); buffer_layout.len()];
+
+        for VertexAttribute {
+            format,
+            buffer_index,
+            ..
+        } in attributes
+        {
+            let layout = buffer_layout.get(*buffer_index).unwrap_or_else(|| panic!());
+            let mut cache = buffer_cache
+                .get_mut(*buffer_index)
+                .unwrap_or_else(|| panic!());
+
+            if layout.stride == 0 {
+                cache.stride += format.size_bytes();
+            } else {
+                cache.stride = layout.stride;
+            }
+            // WebGL 1 limitation
+            assert!(cache.stride <= 255);
+        }
+
+        let program = self.shaders[shader.0].program;
+
+        let attributes_len = attributes
+            .iter()
+            .map(|layout| match layout.format {
+                VertexFormat::Mat4 => 4,
+                _ => 1,
+            })
+            .sum();
+
+        let mut vertex_layout: Vec<Option<VertexAttributeInternal>> = vec![None; attributes_len];
+
+        for VertexAttribute {
+            name,
+            format,
+            buffer_index,
+        } in attributes
+        {
+            let mut buffer_data = &mut buffer_cache
+                .get_mut(*buffer_index)
+                .unwrap_or_else(|| panic!());
+            let layout = buffer_layout.get(*buffer_index).unwrap_or_else(|| panic!());
+
+            let cname = CString::new(*name).unwrap_or_else(|e| panic!("{}", e));
+            let attr_loc = unsafe { glGetAttribLocation(program, cname.as_ptr() as *const _) };
+            let attr_loc = if attr_loc == -1 { None } else { Some(attr_loc) };
+            let divisor = if layout.step_func == VertexStep::PerVertex {
+                0
+            } else {
+                layout.step_rate
+            };
+
+            let mut attributes_count: usize = 1;
+            let mut format = *format;
+
+            if format == VertexFormat::Mat4 {
+                format = VertexFormat::Float4;
+                attributes_count = 4;
+            }
+            for i in 0..attributes_count {
+                if let Some(attr_loc) = attr_loc {
+                    let attr_loc = attr_loc as GLuint + i as GLuint;
+
+                    let attr = VertexAttributeInternal {
+                        attr_loc,
+                        size: format.components(),
+                        type_: format.type_(),
+                        offset: buffer_data.offset,
+                        stride: buffer_data.stride,
+                        buffer_index: *buffer_index,
+                        divisor,
+                    };
+
+                    assert!(
+                        attr_loc < vertex_layout.len() as u32,
+                        "attribute: {} outside of allocated attributes array len: {}",
+                        name,
+                        vertex_layout.len()
+                    );
+                    vertex_layout[attr_loc as usize] = Some(attr);
+                }
+                buffer_data.offset += format.size_bytes() as i64
+            }
+        }
+
+        let pipeline = PipelineInternal {
+            layout: vertex_layout,
+            shader,
+            params,
+        };
+
+        self.pipelines.push(pipeline);
+        Pipeline(self.pipelines.len() - 1)
+    }
+
+    fn pipeline_set_blend(&mut self, pipeline: &Pipeline, color_blend: Option<BlendState>) {
+        let mut pipeline = &mut self.pipelines[pipeline.0];
+        pipeline.params.color_blend = color_blend;
+    }
+
+    fn apply_pipeline(&mut self, pipeline: &Pipeline) {
+        self.cache.cur_pipeline = Some(*pipeline);
+
+        {
+            let pipeline = &self.pipelines[pipeline.0];
+            let shader = &mut self.shaders[pipeline.shader.0];
+            unsafe {
+                glUseProgram(shader.program);
+            }
+
+            unsafe {
+                glEnable(GL_SCISSOR_TEST);
+            }
+
+            if pipeline.params.depth_write {
+                unsafe {
+                    glEnable(GL_DEPTH_TEST);
+                    glDepthFunc(pipeline.params.depth_test.into())
+                }
+            } else {
+                unsafe {
+                    glDisable(GL_DEPTH_TEST);
+                }
+            }
+
+            match pipeline.params.front_face_order {
+                FrontFaceOrder::Clockwise => unsafe {
+                    glFrontFace(GL_CW);
+                },
+                FrontFaceOrder::CounterClockwise => unsafe {
+                    glFrontFace(GL_CCW);
+                },
+            }
+        }
+
+        self.set_cull_face(self.pipelines[pipeline.0].params.cull_face);
+        self.set_blend(
+            self.pipelines[pipeline.0].params.color_blend,
+            self.pipelines[pipeline.0].params.alpha_blend,
+        );
+
+        self.set_stencil(self.pipelines[pipeline.0].params.stencil_test);
+        self.set_color_write(self.pipelines[pipeline.0].params.color_write);
+    }
+
+    /// Create an immutable buffer resource object.
+    /// ```ignore
+    /// #[repr(C)]
+    /// struct Vertex {
+    ///     pos: Vec2,
+    ///     uv: Vec2,
+    /// }
+    /// let vertices: [Vertex; 4] = [
+    ///     Vertex { pos : Vec2 { x: -0.5, y: -0.5 }, uv: Vec2 { x: 0., y: 0. } },
+    ///     Vertex { pos : Vec2 { x:  0.5, y: -0.5 }, uv: Vec2 { x: 1., y: 0. } },
+    ///     Vertex { pos : Vec2 { x:  0.5, y:  0.5 }, uv: Vec2 { x: 1., y: 1. } },
+    ///     Vertex { pos : Vec2 { x: -0.5, y:  0.5 }, uv: Vec2 { x: 0., y: 1. } },
+    /// ];
+    /// let buffer = ctx.new_buffer_immutable(BufferType::VertexBuffer, &vertices);
+    /// ```
+    fn new_buffer_immutable(&mut self, buffer_type: BufferType, data: Arg) -> BufferId {
+        assert!(data.is_slice);
+        let index_type = if buffer_type == BufferType::IndexBuffer {
+            Some(IndexType::for_type_size(data.element_size))
+        } else {
+            None
+        };
+
+        let gl_target = gl_buffer_target(&buffer_type);
+        let gl_usage = gl_usage(&Usage::Immutable);
+        let size = data.size;
+        let mut gl_buf: u32 = 0;
+
+        unsafe {
+            glGenBuffers(1, &mut gl_buf as *mut _);
+            self.cache.store_buffer_binding(gl_target);
+            self.cache.bind_buffer(gl_target, gl_buf, index_type);
+            glBufferData(gl_target, size as _, std::ptr::null() as *const _, gl_usage);
+            glBufferSubData(gl_target, 0, size as _, data.ptr as _);
+            self.cache.restore_buffer_binding(gl_target);
+        }
+
+        let buffer = Buffer {
+            gl_buf,
+            buffer_type,
+            size,
+            index_type,
+        };
+        self.buffers.push(buffer);
+        BufferId(self.buffers.len() - 1)
+    }
+
+    fn new_buffer_stream(&mut self, buffer_type: BufferType, size: usize) -> BufferId {
+        let index_type = if buffer_type == BufferType::IndexBuffer {
+            Some(IndexType::Short)
+        } else {
+            None
+        };
+
+        let gl_target = gl_buffer_target(&buffer_type);
+        let gl_usage = gl_usage(&Usage::Stream);
+        let mut gl_buf: u32 = 0;
+
+        unsafe {
+            glGenBuffers(1, &mut gl_buf as *mut _);
+            self.cache.store_buffer_binding(gl_target);
+            self.cache.bind_buffer(gl_target, gl_buf, None);
+            glBufferData(gl_target, size as _, std::ptr::null() as *const _, gl_usage);
+            self.cache.restore_buffer_binding(gl_target);
+        }
+
+        let buffer = Buffer {
+            gl_buf,
+            buffer_type,
+            size,
+            index_type,
+        };
+        self.buffers.push(buffer);
+        BufferId(self.buffers.len() - 1)
+    }
+
+    fn new_buffer_index_stream(&mut self, index_type: IndexType, size: usize) -> BufferId {
+        let gl_target = gl_buffer_target(&BufferType::IndexBuffer);
+        let gl_usage = gl_usage(&Usage::Stream);
+        let mut gl_buf: u32 = 0;
+
+        unsafe {
+            glGenBuffers(1, &mut gl_buf as *mut _);
+            self.cache.store_buffer_binding(gl_target);
+            self.cache.bind_buffer(gl_target, gl_buf, None);
+            glBufferData(gl_target, size as _, std::ptr::null() as *const _, gl_usage);
+            self.cache.restore_buffer_binding(gl_target);
+        }
+
+        let buffer = Buffer {
+            gl_buf,
+            buffer_type: BufferType::IndexBuffer,
+            size,
+            index_type: Some(index_type),
+        };
+        self.buffers.push(buffer);
+        BufferId(self.buffers.len() - 1)
+    }
+
+    fn buffer_update(&mut self, buffer: BufferId, data: Arg) {
+        assert!(data.is_slice);
+        let buffer = &self.buffers[buffer.0];
+        if buffer.buffer_type == BufferType::IndexBuffer {
+            assert!(buffer.index_type.is_some());
+            assert!(buffer.index_type.unwrap() == IndexType::for_type_size(data.element_size));
+        };
+
+        let size = data.size;
+
+        assert!(size <= buffer.size);
+
+        let gl_target = gl_buffer_target(&buffer.buffer_type);
+        self.cache.store_buffer_binding(gl_target);
+        self.cache
+            .bind_buffer(gl_target, buffer.gl_buf, buffer.index_type);
+        unsafe { glBufferSubData(gl_target, 0, size as _, data.ptr as _) };
+        self.cache.restore_buffer_binding(gl_target);
+    }
+
+    /// Size of buffer in bytes
+    fn buffer_size(&mut self, buffer: BufferId) -> usize {
+        self.buffers[buffer.0].size
+    }
+
+    /// Delete GPU buffer, leaving handle unmodified.
+    ///
+    /// More high-level code on top of miniquad probably is going to call this in Drop implementation of some
+    /// more RAII buffer object.
+    ///
+    /// There is no protection against using deleted textures later. However its not an UB in OpenGl and thats why
+    /// this function is not marked as unsafe
+    fn buffer_delete(&mut self, buffer: BufferId) {
+        unsafe { glDeleteBuffers(1, &self.buffers[buffer.0].gl_buf as *const _) }
+    }
+
+    fn set_cull_face(&mut self, cull_face: CullFace) {
+        if self.cache.cull_face == cull_face {
+            return;
+        }
+
+        match cull_face {
+            CullFace::Nothing => unsafe {
+                glDisable(GL_CULL_FACE);
+            },
+            CullFace::Front => unsafe {
+                glEnable(GL_CULL_FACE);
+                glCullFace(GL_FRONT);
+            },
+            CullFace::Back => unsafe {
+                glEnable(GL_CULL_FACE);
+                glCullFace(GL_BACK);
+            },
+        }
+        self.cache.cull_face = cull_face;
+    }
+
+    fn set_color_write(&mut self, color_write: ColorMask) {
+        if self.cache.color_write == color_write {
+            return;
+        }
+        let (r, g, b, a) = color_write;
+        unsafe { glColorMask(r as _, g as _, b as _, a as _) }
+        self.cache.color_write = color_write;
+    }
+
+    fn set_blend(&mut self, color_blend: Option<BlendState>, alpha_blend: Option<BlendState>) {
+        if color_blend.is_none() && alpha_blend.is_some() {
+            panic!("AlphaBlend without ColorBlend");
+        }
+        if self.cache.color_blend == color_blend && self.cache.alpha_blend == alpha_blend {
+            return;
+        }
+
+        unsafe {
+            if let Some(color_blend) = color_blend {
+                if self.cache.color_blend.is_none() {
+                    glEnable(GL_BLEND);
+                }
+
+                let BlendState {
+                    equation: eq_rgb,
+                    sfactor: src_rgb,
+                    dfactor: dst_rgb,
+                } = color_blend;
+
+                if let Some(BlendState {
+                    equation: eq_alpha,
+                    sfactor: src_alpha,
+                    dfactor: dst_alpha,
+                }) = alpha_blend
+                {
+                    glBlendFuncSeparate(
+                        src_rgb.into(),
+                        dst_rgb.into(),
+                        src_alpha.into(),
+                        dst_alpha.into(),
+                    );
+                    glBlendEquationSeparate(eq_rgb.into(), eq_alpha.into());
+                } else {
+                    glBlendFunc(src_rgb.into(), dst_rgb.into());
+                    glBlendEquationSeparate(eq_rgb.into(), eq_rgb.into());
+                }
+            } else if self.cache.color_blend.is_some() {
+                glDisable(GL_BLEND);
+            }
+        }
+
+        self.cache.color_blend = color_blend;
+        self.cache.alpha_blend = alpha_blend;
+    }
+
+    fn set_stencil(&mut self, stencil_test: Option<StencilState>) {
+        if self.cache.stencil == stencil_test {
+            return;
+        }
+        unsafe {
+            if let Some(stencil) = stencil_test {
+                if self.cache.stencil.is_none() {
+                    glEnable(GL_STENCIL_TEST);
+                }
+
+                let front = &stencil.front;
+                glStencilOpSeparate(
+                    GL_FRONT,
+                    front.fail_op.into(),
+                    front.depth_fail_op.into(),
+                    front.pass_op.into(),
+                );
+                glStencilFuncSeparate(
+                    GL_FRONT,
+                    front.test_func.into(),
+                    front.test_ref,
+                    front.test_mask,
+                );
+                glStencilMaskSeparate(GL_FRONT, front.write_mask);
+
+                let back = &stencil.back;
+                glStencilOpSeparate(
+                    GL_BACK,
+                    back.fail_op.into(),
+                    back.depth_fail_op.into(),
+                    back.pass_op.into(),
+                );
+                glStencilFuncSeparate(
+                    GL_BACK,
+                    back.test_func.into(),
+                    back.test_ref.into(),
+                    back.test_mask,
+                );
+                glStencilMaskSeparate(GL_BACK, back.write_mask);
+            } else if self.cache.stencil.is_some() {
+                glDisable(GL_STENCIL_TEST);
+            }
+        }
+
+        self.cache.stencil = stencil_test;
+    }
+
+    /// Set a new viewport rectangle.
+    /// Should be applied after begin_pass.
+    fn apply_viewport(&mut self, x: i32, y: i32, w: i32, h: i32) {
+        unsafe {
+            glViewport(x, y, w, h);
+        }
+    }
+
+    /// Set a new scissor rectangle.
+    /// Should be applied after begin_pass.
+    fn apply_scissor_rect(&mut self, x: i32, y: i32, w: i32, h: i32) {
+        unsafe {
+            glScissor(x, y, w, h);
+        }
+    }
+
+    fn apply_bindings(&mut self, bindings: &Bindings) {
+        let pip = &self.pipelines[self.cache.cur_pipeline.unwrap().0];
+        let shader = &self.shaders[pip.shader.0];
+
+        for (n, shader_image) in shader.images.iter().enumerate() {
+            let bindings_image = bindings
+                .images
+                .get(n)
+                .unwrap_or_else(|| panic!("Image count in bindings and shader did not match!"));
+            if let Some(gl_loc) = shader_image.gl_loc {
+                unsafe {
+                    self.cache
+                        .bind_texture(n, self.textures[bindings_image.0].texture);
+                    glUniform1i(gl_loc, n as i32);
+                }
+            }
+        }
+
+        self.cache.bind_buffer(
+            GL_ELEMENT_ARRAY_BUFFER,
+            self.buffers[bindings.index_buffer.0].gl_buf,
+            self.buffers[bindings.index_buffer.0].index_type,
+        );
+
+        let pip = &self.pipelines[self.cache.cur_pipeline.unwrap().0];
+
+        for attr_index in 0..MAX_VERTEX_ATTRIBUTES {
+            let cached_attr = &mut self.cache.attributes[attr_index];
+
+            let pip_attribute = pip.layout.get(attr_index).copied();
+
+            if let Some(Some(attribute)) = pip_attribute {
+                let vb = bindings.vertex_buffers[attribute.buffer_index];
+                let vb = self.buffers[vb.0];
+
+                if cached_attr.map_or(true, |cached_attr| {
+                    attribute != cached_attr.attribute || cached_attr.gl_vbuf != vb.gl_buf
+                }) {
+                    self.cache
+                        .bind_buffer(GL_ARRAY_BUFFER, vb.gl_buf, vb.index_type);
+
+                    unsafe {
+                        glVertexAttribPointer(
+                            attr_index as GLuint,
+                            attribute.size,
+                            attribute.type_,
+                            GL_FALSE as u8,
+                            attribute.stride,
+                            attribute.offset as *mut _,
+                        );
+                        if self.features.instancing {
+                            glVertexAttribDivisor(attr_index as GLuint, attribute.divisor as u32);
+                        }
+                        glEnableVertexAttribArray(attr_index as GLuint);
+                    };
+
+                    let cached_attr = &mut self.cache.attributes[attr_index];
+                    *cached_attr = Some(CachedAttribute {
+                        attribute,
+                        gl_vbuf: vb.gl_buf,
+                    });
+                }
+            } else {
+                if cached_attr.is_some() {
+                    unsafe {
+                        glDisableVertexAttribArray(attr_index as GLuint);
+                    }
+                    *cached_attr = None;
+                }
+            }
+        }
+    }
+
+    fn apply_uniforms_from_bytes(&mut self, uniform_ptr: *const u8, size: usize) {
+        let pip = &self.pipelines[self.cache.cur_pipeline.unwrap().0];
+        let shader = &self.shaders[pip.shader.0];
+
+        let mut offset = 0;
+
+        for (_, uniform) in shader.uniforms.iter().enumerate() {
+            use UniformType::*;
+
+            assert!(
+                offset <= size - uniform.uniform_type.size() / 4,
+                "Uniforms struct does not match shader uniforms layout"
+            );
+
+            unsafe {
+                let data = (uniform_ptr as *const f32).offset(offset as isize);
+                let data_int = (uniform_ptr as *const i32).offset(offset as isize);
+
+                if let Some(gl_loc) = uniform.gl_loc {
+                    match uniform.uniform_type {
+                        Float1 => {
+                            glUniform1fv(gl_loc, uniform.array_count, data);
+                        }
+                        Float2 => {
+                            glUniform2fv(gl_loc, uniform.array_count, data);
+                        }
+                        Float3 => {
+                            glUniform3fv(gl_loc, uniform.array_count, data);
+                        }
+                        Float4 => {
+                            glUniform4fv(gl_loc, uniform.array_count, data);
+                        }
+                        Int1 => {
+                            glUniform1iv(gl_loc, uniform.array_count, data_int);
+                        }
+                        Int2 => {
+                            glUniform2iv(gl_loc, uniform.array_count, data_int);
+                        }
+                        Int3 => {
+                            glUniform3iv(gl_loc, uniform.array_count, data_int);
+                        }
+                        Int4 => {
+                            glUniform4iv(gl_loc, uniform.array_count, data_int);
+                        }
+                        Mat4 => {
+                            glUniformMatrix4fv(gl_loc, uniform.array_count, 0, data);
+                        }
+                    }
+                }
+            }
+            offset += uniform.uniform_type.size() / 4 * uniform.array_count as usize;
+        }
+    }
+
+    fn clear(&self, color: Option<(f32, f32, f32, f32)>, depth: Option<f32>, stencil: Option<i32>) {
+        let mut bits = 0;
+        if let Some((r, g, b, a)) = color {
+            bits |= GL_COLOR_BUFFER_BIT;
+            unsafe {
+                glClearColor(r, g, b, a);
+            }
+        }
+
+        if let Some(v) = depth {
+            bits |= GL_DEPTH_BUFFER_BIT;
+            unsafe {
+                glClearDepthf(v);
+            }
+        }
+
+        if let Some(v) = stencil {
+            bits |= GL_STENCIL_BUFFER_BIT;
+            unsafe {
+                glClearStencil(v);
+            }
+        }
+
+        if bits != 0 {
+            unsafe {
+                glClear(bits);
+            }
+        }
+    }
+
+    fn begin_default_pass(&mut self, action: PassAction) {
+        self.begin_pass(None, action);
+    }
+
+    fn begin_pass(&mut self, pass: Option<RenderPass>, action: PassAction) {
+        let (framebuffer, w, h) = match pass {
+            None => {
+                let (screen_width, screen_height) = window::screen_size();
+
+                (
+                    self.default_framebuffer,
+                    screen_width as i32,
+                    screen_height as i32,
+                )
+            }
+            Some(pass) => {
+                let pass = &self.passes[pass.0];
+                (
+                    pass.gl_fb,
+                    self.textures[pass.texture.0].width as i32,
+                    self.textures[pass.texture.0].height as i32,
+                )
+            }
+        };
+        unsafe {
+            glBindFramebuffer(GL_FRAMEBUFFER, framebuffer);
+            glViewport(0, 0, w, h);
+            glScissor(0, 0, w, h);
+        }
+        match action {
+            PassAction::Nothing => {}
+            PassAction::Clear {
+                color,
+                depth,
+                stencil,
+            } => {
+                self.clear(color, depth, stencil);
+            }
+        }
+    }
+
+    fn end_render_pass(&mut self) {
+        unsafe {
+            glBindFramebuffer(GL_FRAMEBUFFER, self.default_framebuffer);
+            self.cache.bind_buffer(GL_ARRAY_BUFFER, 0, None);
+            self.cache.bind_buffer(GL_ELEMENT_ARRAY_BUFFER, 0, None);
+        }
+    }
+
+    fn commit_frame(&mut self) {
+        self.cache.clear_buffer_bindings();
+        self.cache.clear_texture_bindings();
+    }
+
+    fn draw(&self, base_element: i32, num_elements: i32, num_instances: i32) {
+        assert!(
+            self.cache.cur_pipeline.is_some(),
+            "Drawing without any binded pipeline"
+        );
+
+        if !self.features.instancing && num_instances != 1 {
+            println!("Instanced rendering is not supported by the GPU");
+            println!("Ignoring this draw call");
+            return;
+        }
+
+        let pip = &self.pipelines[self.cache.cur_pipeline.unwrap().0];
+        let primitive_type = pip.params.primitive_type.into();
+        let index_type = self.cache.index_type.expect("Unset index buffer type");
+
+        unsafe {
+            glDrawElementsInstanced(
+                primitive_type,
+                num_elements,
+                index_type.into(),
+                (index_type.size() as i32 * base_element) as *mut _,
+                num_instances,
+            );
+        }
+    }
+}

--- a/src/graphics/gl.rs
+++ b/src/graphics/gl.rs
@@ -745,7 +745,7 @@ impl RenderingBackend for GlContext {
     /// let buffer = ctx.new_buffer_immutable(BufferType::VertexBuffer, &vertices);
     /// ```
     fn new_buffer_immutable(&mut self, buffer_type: BufferType, data: Arg) -> BufferId {
-        assert!(data.is_slice);
+        debug_assert!(data.is_slice);
         let index_type = if buffer_type == BufferType::IndexBuffer {
             Some(IndexType::for_type_size(data.element_size))
         } else {
@@ -829,7 +829,7 @@ impl RenderingBackend for GlContext {
     }
 
     fn buffer_update(&mut self, buffer: BufferId, data: Arg) {
-        assert!(data.is_slice);
+        debug_assert!(data.is_slice);
         let buffer = &self.buffers[buffer.0];
         if buffer.buffer_type == BufferType::IndexBuffer {
             assert!(buffer.index_type.is_some());

--- a/src/graphics/gl.rs
+++ b/src/graphics/gl.rs
@@ -491,7 +491,29 @@ impl RenderingBackend for GlContext {
         self.textures.push(texture);
         TextureId(self.textures.len() - 1)
     }
-    fn update_texture_part(
+    fn texture_set_filter(&mut self, texture: TextureId, filter: FilterMode) {
+        let t = self.textures[texture.0];
+        t.set_filter(self, filter);
+    }
+    fn texture_set_wrap(&mut self, texture: TextureId, wrap: TextureWrap) {
+        let t = self.textures[texture.0];
+        t.set_wrap(self, wrap);
+    }
+    fn texture_resize(
+        &mut self,
+        texture: TextureId,
+        width: u32,
+        height: u32,
+        bytes: Option<&[u8]>,
+    ) {
+        let mut t = self.textures[texture.0];
+        t.resize(self, width, height, bytes);
+    }
+    fn texture_read_pixels(&mut self, texture: TextureId, bytes: &mut [u8]) {
+        let t = self.textures[texture.0];
+        t.read_pixels(bytes);
+    }
+    fn texture_update_part(
         &mut self,
         texture: TextureId,
         x_offset: i32,

--- a/src/graphics/gl/cache.rs
+++ b/src/graphics/gl/cache.rs
@@ -1,0 +1,115 @@
+use crate::graphics::*;
+
+#[derive(Clone, Copy, Debug, PartialEq, Default)]
+pub struct VertexAttributeInternal {
+    pub attr_loc: GLuint,
+    pub size: i32,
+    pub type_: GLuint,
+    pub offset: i64,
+    pub stride: i32,
+    pub buffer_index: usize,
+    pub divisor: i32,
+}
+
+#[derive(Default, Copy, Clone)]
+pub struct CachedAttribute {
+    pub attribute: VertexAttributeInternal,
+    pub gl_vbuf: GLuint,
+}
+
+pub struct GlCache {
+    pub stored_index_buffer: GLuint,
+    pub stored_index_type: Option<IndexType>,
+    pub stored_vertex_buffer: GLuint,
+    pub stored_texture: GLuint,
+    pub index_buffer: GLuint,
+    pub index_type: Option<IndexType>,
+    pub vertex_buffer: GLuint,
+    pub textures: [GLuint; MAX_SHADERSTAGE_IMAGES],
+    pub cur_pipeline: Option<Pipeline>,
+    pub color_blend: Option<BlendState>,
+    pub alpha_blend: Option<BlendState>,
+    pub stencil: Option<StencilState>,
+    pub color_write: ColorMask,
+    pub cull_face: CullFace,
+    pub attributes: [Option<CachedAttribute>; MAX_VERTEX_ATTRIBUTES],
+}
+
+impl GlCache {
+    pub fn bind_buffer(&mut self, target: GLenum, buffer: GLuint, index_type: Option<IndexType>) {
+        if target == GL_ARRAY_BUFFER {
+            if self.vertex_buffer != buffer {
+                self.vertex_buffer = buffer;
+                unsafe {
+                    glBindBuffer(target, buffer);
+                }
+            }
+        } else {
+            if self.index_buffer != buffer {
+                self.index_buffer = buffer;
+                unsafe {
+                    glBindBuffer(target, buffer);
+                }
+            }
+            self.index_type = index_type;
+        }
+    }
+
+    pub fn store_buffer_binding(&mut self, target: GLenum) {
+        if target == GL_ARRAY_BUFFER {
+            self.stored_vertex_buffer = self.vertex_buffer;
+        } else {
+            self.stored_index_buffer = self.index_buffer;
+            self.stored_index_type = self.index_type;
+        }
+    }
+
+    pub fn restore_buffer_binding(&mut self, target: GLenum) {
+        if target == GL_ARRAY_BUFFER {
+            if self.stored_vertex_buffer != 0 {
+                self.bind_buffer(target, self.stored_vertex_buffer, None);
+                self.stored_vertex_buffer = 0;
+            }
+        } else {
+            if self.stored_index_buffer != 0 {
+                self.bind_buffer(target, self.stored_index_buffer, self.stored_index_type);
+                self.stored_index_buffer = 0;
+            }
+        }
+    }
+
+    pub fn bind_texture(&mut self, slot_index: usize, texture: GLuint) {
+        unsafe {
+            glActiveTexture(GL_TEXTURE0 + slot_index as GLuint);
+            if self.textures[slot_index] != texture {
+                glBindTexture(GL_TEXTURE_2D, texture);
+                self.textures[slot_index] = texture;
+            }
+        }
+    }
+
+    pub fn store_texture_binding(&mut self, slot_index: usize) {
+        self.stored_texture = self.textures[slot_index];
+    }
+
+    pub fn restore_texture_binding(&mut self, slot_index: usize) {
+        self.bind_texture(slot_index, self.stored_texture);
+    }
+
+    pub fn clear_buffer_bindings(&mut self) {
+        self.bind_buffer(GL_ARRAY_BUFFER, 0, None);
+        self.vertex_buffer = 0;
+
+        self.bind_buffer(GL_ELEMENT_ARRAY_BUFFER, 0, None);
+        self.index_buffer = 0;
+    }
+
+    pub fn clear_texture_bindings(&mut self) {
+        for ix in 0..MAX_SHADERSTAGE_IMAGES {
+            if self.textures[ix] != 0 {
+                self.bind_texture(ix, 0);
+                self.textures[ix] = 0;
+            }
+        }
+    }
+}

--- a/src/graphics/metal.rs
+++ b/src/graphics/metal.rs
@@ -1,0 +1,1063 @@
+use crate::native::apple::{
+    apple_util::{self, msg_send_},
+    frameworks::*,
+};
+
+use super::*;
+
+// https://developer.apple.com/metal/Metal-Feature-Set-Tables.pdf
+const MAX_BUFFERS_PER_STAGE: usize = 14;
+const MAX_UNIFORM_BUFFER_SIZE: u64 = 4 * 1024 * 1024;
+const MAX_VERTEX_ATTRIBUTES: usize = 31;
+const UNIFORM_BUFFER_INDEX: u64 = 0;
+const NUM_INFLIGHT_FRAMES: usize = 3;
+#[cfg(any(target_os = "macos", all(target_os = "ios", target_arch = "x86_64")))]
+const UNIFORM_BUFFER_ALIGN: u64 = 256;
+#[cfg(all(target_os = "ios", not(target_arch = "x86_64")))]
+const UNIFORM_BUFFER_ALIGN: u64 = 16;
+
+impl From<VertexFormat> for MTLVertexFormat {
+    fn from(vf: VertexFormat) -> Self {
+        match vf {
+            VertexFormat::Float1 => MTLVertexFormat::Float,
+            VertexFormat::Float2 => MTLVertexFormat::Float2,
+            VertexFormat::Float3 => MTLVertexFormat::Float3,
+            VertexFormat::Float4 => MTLVertexFormat::Float4,
+            VertexFormat::Byte1 => MTLVertexFormat::UChar,
+            VertexFormat::Byte2 => MTLVertexFormat::UChar2,
+            VertexFormat::Byte3 => MTLVertexFormat::UChar3,
+            VertexFormat::Byte4 => MTLVertexFormat::UChar4,
+            VertexFormat::Short1 => MTLVertexFormat::Short,
+            VertexFormat::Short2 => MTLVertexFormat::Short2,
+            VertexFormat::Short3 => MTLVertexFormat::Short3,
+            VertexFormat::Short4 => MTLVertexFormat::Short4,
+            VertexFormat::Int1 => MTLVertexFormat::Int,
+            VertexFormat::Int2 => MTLVertexFormat::Int2,
+            VertexFormat::Int3 => MTLVertexFormat::Int3,
+            VertexFormat::Int4 => MTLVertexFormat::Int4,
+            VertexFormat::Mat4 => MTLVertexFormat::Float4,
+            _ => unreachable!(),
+        }
+    }
+}
+
+impl From<UniformType> for MTLVertexFormat {
+    fn from(ut: UniformType) -> Self {
+        match ut {
+            UniformType::Float1 => MTLVertexFormat::Float,
+            UniformType::Float2 => MTLVertexFormat::Float2,
+            UniformType::Float3 => MTLVertexFormat::Float3,
+            UniformType::Float4 => MTLVertexFormat::Float4,
+            UniformType::Int1 => MTLVertexFormat::Int,
+            UniformType::Int2 => MTLVertexFormat::Int2,
+            UniformType::Int3 => MTLVertexFormat::Int3,
+            UniformType::Int4 => MTLVertexFormat::Int4,
+            UniformType::Mat4 => MTLVertexFormat::Float4,
+            _ => unreachable!(),
+        }
+    }
+}
+
+impl From<Comparison> for MTLCompareFunction {
+    fn from(cmp: Comparison) -> Self {
+        match cmp {
+            Comparison::Never => MTLCompareFunction::Never,
+            Comparison::Less => MTLCompareFunction::Less,
+            Comparison::LessOrEqual => MTLCompareFunction::LessEqual,
+            Comparison::Greater => MTLCompareFunction::Greater,
+            Comparison::GreaterOrEqual => MTLCompareFunction::GreaterEqual,
+            Comparison::Equal => MTLCompareFunction::Equal,
+            Comparison::NotEqual => MTLCompareFunction::NotEqual,
+            Comparison::Always => MTLCompareFunction::Always,
+        }
+    }
+}
+
+impl From<BlendFactor> for MTLBlendFactor {
+    fn from(factor: BlendFactor) -> Self {
+        match factor {
+            BlendFactor::Zero => MTLBlendFactor::Zero,
+            BlendFactor::One => MTLBlendFactor::One,
+            BlendFactor::Value(BlendValue::SourceColor) => MTLBlendFactor::SourceColor,
+            BlendFactor::Value(BlendValue::SourceAlpha) => MTLBlendFactor::SourceAlpha,
+            BlendFactor::Value(BlendValue::DestinationColor) => MTLBlendFactor::DestinationColor,
+            BlendFactor::Value(BlendValue::DestinationAlpha) => MTLBlendFactor::DestinationAlpha,
+            BlendFactor::OneMinusValue(BlendValue::SourceColor) => {
+                MTLBlendFactor::OneMinusSourceColor
+            }
+            BlendFactor::OneMinusValue(BlendValue::SourceAlpha) => {
+                MTLBlendFactor::OneMinusSourceAlpha
+            }
+            BlendFactor::OneMinusValue(BlendValue::DestinationColor) => {
+                MTLBlendFactor::OneMinusDestinationColor
+            }
+            BlendFactor::OneMinusValue(BlendValue::DestinationAlpha) => {
+                MTLBlendFactor::OneMinusDestinationAlpha
+            }
+            BlendFactor::SourceAlphaSaturate => MTLBlendFactor::SourceAlphaSaturated,
+        }
+    }
+}
+
+// impl From<StencilOp> for MTLStencilOperation {
+//     fn from(op: StencilOp) -> Self {
+//         match op {
+//             StencilOp::Keep => MTLStencilOperation::Keep,
+//             StencilOp::Zero => MTLStencilOperation::Zero,
+//             StencilOp::Replace => MTLStencilOperation::Replace,
+//             StencilOp::IncrementClamp => MTLStencilOperation::IncrementClamp,
+//             StencilOp::DecrementClamp => MTLStencilOperation::DecrementClamp,
+//             StencilOp::Invert => MTLStencilOperation::Invert,
+//             StencilOp::IncrementWrap => MTLStencilOperation::IncrementWrap,
+//             StencilOp::DecrementWrap => MTLStencilOperation::DecrementWrap,
+//         }
+//     }
+// }
+
+impl From<CompareFunc> for MTLCompareFunction {
+    fn from(cf: CompareFunc) -> Self {
+        match cf {
+            CompareFunc::Always => MTLCompareFunction::Always,
+            CompareFunc::Never => MTLCompareFunction::Never,
+            CompareFunc::Less => MTLCompareFunction::Less,
+            CompareFunc::Equal => MTLCompareFunction::Equal,
+            CompareFunc::LessOrEqual => MTLCompareFunction::LessEqual,
+            CompareFunc::Greater => MTLCompareFunction::Greater,
+            CompareFunc::NotEqual => MTLCompareFunction::NotEqual,
+            CompareFunc::GreaterOrEqual => MTLCompareFunction::GreaterEqual,
+        }
+    }
+}
+
+impl From<VertexStep> for MTLVertexStepFunction {
+    fn from(vs: VertexStep) -> Self {
+        match vs {
+            VertexStep::PerVertex => MTLVertexStepFunction::PerVertex,
+            VertexStep::PerInstance => MTLVertexStepFunction::PerInstance,
+        }
+    }
+}
+
+impl From<PrimitiveType> for MTLPrimitiveType {
+    fn from(primitive_type: PrimitiveType) -> Self {
+        match primitive_type {
+            PrimitiveType::Triangles => MTLPrimitiveType::Triangle,
+            PrimitiveType::Lines => MTLPrimitiveType::Line,
+        }
+    }
+}
+
+impl Usage {
+    fn to_u64(self) -> u64 {
+        match self {
+            Usage::Immutable => MTLResourceOptions::StorageModeShared,
+            #[cfg(target_os = "macos")]
+            Usage::Dynamic | Usage::Stream => {
+                MTLResourceOptions::CPUCacheModeWriteCombined
+                    | MTLResourceOptions::StorageModeManaged
+            }
+            #[cfg(target_os = "ios")]
+            Usage::Dynamic | Usage::Stream => MTLResourceOptions::CPUCacheModeWriteCombined,
+        }
+    }
+}
+
+impl From<TextureFormat> for MTLPixelFormat {
+    fn from(format: TextureFormat) -> Self {
+        match format {
+            TextureFormat::RGBA8 => MTLPixelFormat::RGBA8Unorm,
+            //TODO: Depth16Unorm ?
+            TextureFormat::Depth => MTLPixelFormat::Depth32Float_Stencil8,
+            _ => todo!(),
+        }
+    }
+}
+
+// impl From<CullFace> for MTLCullMode {
+//     fn from(cull_face: CullFace) -> Self {
+//         match cull_face {
+//             CullFace::Back => MTLCullMode::Back,
+//             CullFace::Front => MTLCullMode::Front,
+//             CullFace::Nothing => MTLCullMode::None,
+//         }
+//     }
+// }
+
+// impl From<FrontFaceOrder> for MTLWinding {
+//     fn from(order: FrontFaceOrder) -> Self {
+//         match order {
+//             FrontFaceOrder::Clockwise => MTLWinding::Clockwise,
+//             FrontFaceOrder::CounterClockwise => MTLWinding::CounterClockwise,
+//         }
+//     }
+// }
+
+#[inline]
+fn roundup_ub_buffer(current_buffer: u64) -> u64 {
+    ((current_buffer) + ((UNIFORM_BUFFER_ALIGN) - 1)) & !((UNIFORM_BUFFER_ALIGN) - 1)
+}
+
+const WTF: usize = 200;
+#[derive(Clone, Copy, Debug)]
+pub struct Buffer {
+    raw: [ObjcId; WTF],
+    buffer_type: BufferType,
+    size: usize,
+    index_type: Option<IndexType>,
+    value: usize,
+    next_value: usize,
+}
+
+#[derive(Clone, Copy, Debug, PartialEq)]
+struct ShaderUniform {
+    size: u64,
+    offset: u64,
+    format: MTLVertexFormat,
+}
+
+#[derive(Debug)]
+struct ShaderInternal {
+    vertex_function: ObjcId,
+    fragment_function: ObjcId,
+    uniforms: Vec<ShaderUniform>,
+    // the distance, in bytes, between two uniforms in uniforms buffer
+    stride: u64,
+}
+
+struct RenderPassInternal {
+    render_pass_desc: ObjcId,
+    texture: TextureId,
+    depth_texture: Option<TextureId>,
+}
+
+#[derive(Clone, Debug)]
+struct PipelineInternal {
+    pipeline_state: ObjcId,
+    depth_stencil_state: ObjcId,
+    layout: Vec<BufferLayout>,
+    //attributes: Vec<VertexAttributeInternal>,
+    shader: ShaderId,
+    params: PipelineParams,
+}
+
+struct TextureInternal {
+    texture: ObjcId,
+    sampler: ObjcId,
+    width: u32,
+    height: u32,
+}
+
+pub struct MetalContext {
+    buffers: Vec<Buffer>,
+    shaders: Vec<ShaderInternal>,
+    pipelines: Vec<PipelineInternal>,
+    textures: Vec<TextureInternal>,
+    passes: Vec<RenderPassInternal>,
+    command_queue: ObjcId,
+    command_buffer: Option<ObjcId>,
+    render_encoder: Option<ObjcId>,
+    view: ObjcId,
+    device: ObjcId,
+    current_frame_index: usize,
+    uniform_buffers: [ObjcId; 3],
+    // cached index_buffer from apply_bindings
+    index_buffer: Option<ObjcId>,
+    // cached pipeline from apply_pipeline
+    current_pipeline: Option<Pipeline>,
+    current_ub_offset: u64,
+}
+
+impl MetalContext {
+    pub fn new() -> MetalContext {
+        unsafe {
+            let view = crate::window::apple_view().unwrap();
+            assert!(!view.is_null());
+            let device: ObjcId = msg_send![view, device];
+            assert!(!device.is_null());
+            let command_queue: ObjcId = msg_send![device, newCommandQueue];
+
+            if false {
+                let capture_manager = msg_send_![class![MTLCaptureManager], sharedCaptureManager];
+                assert!(!capture_manager.is_null());
+
+                let MTLCaptureDestinationGPUTraceDocument = 2u64;
+                if !msg_send![
+                    capture_manager,
+                    supportsDestination: MTLCaptureDestinationGPUTraceDocument
+                ] {
+                    panic!("capture failed");
+                }
+
+                let capture_descriptor =
+                    msg_send_![msg_send_![class![MTLCaptureDescriptor], alloc], init];
+                msg_send_![capture_descriptor, setCaptureObject: device];
+                msg_send_![
+                    capture_descriptor,
+                    setDestination: MTLCaptureDestinationGPUTraceDocument
+                ];
+                let path = apple_util::str_to_nsstring("/Users/fedor/wtf1.gputrace");
+                let url = msg_send_![class!(NSURL), fileURLWithPath: path];
+                msg_send_![capture_descriptor, setOutputURL: url];
+
+                let mut error: ObjcId = nil;
+                if !msg_send![capture_manager, startCaptureWithDescriptor:capture_descriptor
+                              error:&mut error]
+                {
+                    let description: ObjcId = msg_send![error, localizedDescription];
+                    let string = apple_util::nsstring_to_string(description);
+                    panic!("Capture error: {}", string);
+                }
+            }
+
+            let uniform_buffers = [
+                msg_send![device, newBufferWithLength:MAX_UNIFORM_BUFFER_SIZE
+                          options:Usage::Stream.to_u64()],
+                msg_send![device, newBufferWithLength:MAX_UNIFORM_BUFFER_SIZE
+                          options:Usage::Stream.to_u64()],
+                msg_send![device, newBufferWithLength:MAX_UNIFORM_BUFFER_SIZE
+                          options:Usage::Stream.to_u64()],
+            ];
+
+            MetalContext {
+                command_queue,
+                command_buffer: None,
+                render_encoder: None,
+                view,
+                device,
+                buffers: vec![],
+                shaders: vec![],
+                pipelines: vec![],
+                textures: vec![],
+                passes: vec![],
+                index_buffer: None,
+                current_pipeline: None,
+                uniform_buffers,
+                current_frame_index: 1,
+                current_ub_offset: 0,
+            }
+        }
+    }
+}
+
+impl RenderingBackend for MetalContext {
+    fn delete_render_pass(&mut self, render_pass: RenderPass) {}
+    fn pipeline_set_blend(&mut self, pipeline: &Pipeline, color_blend: Option<BlendState>) {}
+    fn new_buffer_index_stream(&mut self, index_type: IndexType, size: usize) -> BufferId {
+        unimplemented!()
+    }
+    fn buffer_size(&mut self, buffer: BufferId) -> usize {
+        unimplemented!()
+    }
+    fn buffer_delete(&mut self, buffer: BufferId) {}
+    fn set_cull_face(&mut self, cull_face: CullFace) {}
+    fn set_color_write(&mut self, color_write: ColorMask) {}
+    fn set_blend(&mut self, color_blend: Option<BlendState>, alpha_blend: Option<BlendState>) {}
+    fn set_stencil(&mut self, stencil_test: Option<StencilState>) {}
+    fn apply_viewport(&mut self, x: i32, y: i32, w: i32, h: i32) {}
+    fn apply_scissor_rect(&mut self, x: i32, y: i32, w: i32, h: i32) {}
+
+    fn clear(&self, color: Option<(f32, f32, f32, f32)>, depth: Option<f32>, stencil: Option<i32>) {
+    }
+
+    fn new_render_pass(
+        &mut self,
+        color_img: TextureId,
+        depth_img: Option<TextureId>,
+    ) -> RenderPass {
+        unsafe {
+            let render_pass_desc =
+                msg_send_![class!(MTLRenderPassDescriptor), renderPassDescriptor];
+            msg_send_![render_pass_desc, retain];
+            assert!(!render_pass_desc.is_null());
+            let color_texture = self.textures[color_img.0].texture;
+            let color_attachment = msg_send_![msg_send_![render_pass_desc, colorAttachments], objectAtIndexedSubscript:0];
+            msg_send_![color_attachment, setTexture: color_texture];
+            msg_send_![color_attachment, setLoadAction: MTLLoadAction::Clear];
+            msg_send_![color_attachment, setStoreAction: MTLStoreAction::Store];
+
+            if let Some(depth_img) = depth_img {
+                let depth_texture = self.textures[depth_img.0].texture;
+
+                let depth_attachment = msg_send_![render_pass_desc, depthAttachment];
+                msg_send_![depth_attachment, setTexture: depth_texture];
+                msg_send_![depth_attachment, setLoadAction: MTLLoadAction::Clear];
+                msg_send_![depth_attachment, setStoreAction: MTLStoreAction::Store];
+                msg_send_![depth_attachment, setClearDepth:1.];
+
+                let stencil_attachment = msg_send_![render_pass_desc, stencilAttachment];
+                msg_send_![stencil_attachment, setTexture: depth_texture];
+            }
+            let pass = RenderPassInternal {
+                render_pass_desc,
+                texture: color_img,
+                depth_texture: depth_img,
+            };
+
+            self.passes.push(pass);
+
+            RenderPass(self.passes.len() - 1)
+        }
+    }
+    fn render_pass_texture(&self, render_pass: RenderPass) -> TextureId {
+        self.passes[render_pass.0].texture
+    }
+    fn new_buffer_immutable(&mut self, buffer_type: BufferType, data: Arg) -> BufferId {
+        debug_assert!(data.is_slice);
+        let index_type = if buffer_type == BufferType::IndexBuffer {
+            Some(IndexType::for_type_size(data.element_size))
+        } else {
+            None
+        };
+
+        let size = data.size as u64;
+        let mut raw = [nil; WTF];
+        for i in 0..WTF {
+            let buffer: ObjcId = unsafe {
+                msg_send![self.device,
+                      newBufferWithBytes:data.ptr
+                      length:size
+                      options:MTLResourceOptions::StorageModeShared]
+            };
+            unsafe {
+                msg_send_![buffer, retain];
+            }
+            raw[i] = buffer;
+        }
+        let buffer = Buffer {
+            raw,
+            buffer_type,
+            size: size as usize,
+            index_type,
+            value: 0,
+            next_value: 0,
+        };
+        self.buffers.push(buffer);
+        BufferId(self.buffers.len() - 1)
+    }
+
+    fn new_buffer_stream(&mut self, buffer_type: BufferType, size: usize) -> BufferId {
+        let mut raw = [nil; WTF];
+        for i in 0..WTF {
+            let buffer: ObjcId = unsafe {
+                msg_send![self.device,
+                      newBufferWithLength:size
+                      options:MTLResourceOptions::CPUCacheModeWriteCombined | MTLResourceOptions::StorageModeManaged]
+            };
+            unsafe {
+                msg_send_![buffer, retain];
+            }
+            raw[i] = buffer;
+        }
+        let buffer = Buffer {
+            raw,
+            buffer_type,
+            size: size as usize,
+            index_type: None,
+            value: 0,
+            next_value: 0,
+        };
+        self.buffers.push(buffer);
+        BufferId(self.buffers.len() - 1)
+    }
+
+    fn buffer_update(&mut self, buffer: BufferId, data: Arg) {
+        let mut buffer = &mut self.buffers[buffer.0];
+        assert!(data.size <= buffer.size);
+
+        unsafe {
+            let dest: *mut std::ffi::c_void = msg_send![buffer.raw[buffer.next_value], contents];
+            std::ptr::copy(data.ptr, dest, data.size);
+
+            #[cfg(target_os = "macos")]
+            msg_send_![buffer.raw[buffer.next_value], didModifyRange:NSRange::new(0, data.size as u64)];
+        }
+        buffer.value = buffer.next_value;
+    }
+
+    fn new_shader(
+        &mut self,
+        shader: ShaderSource,
+        meta: ShaderMeta,
+    ) -> Result<ShaderId, ShaderError> {
+        unsafe {
+            let shader = apple_util::str_to_nsstring(shader.metal_shader.unwrap());
+            let mut error: ObjcId = nil;
+            let library: ObjcId = msg_send![
+                self.device,
+                newLibraryWithSource: shader
+                options:nil
+                error: &mut error
+            ];
+            if library.is_null() {
+                let description: ObjcId = msg_send![error, localizedDescription];
+                let string = apple_util::nsstring_to_string(description);
+                panic!("Shader {}", string);
+            }
+
+            let vertex_function: ObjcId = msg_send![library, newFunctionWithName: apple_util::str_to_nsstring("vertexShader")];
+            assert!(!vertex_function.is_null());
+            let fragment_function: ObjcId = msg_send![library, newFunctionWithName: apple_util::str_to_nsstring("fragmentShader")];
+            assert!(!fragment_function.is_null());
+
+            let mut stride = 0;
+            let mut index = 0;
+            let uniforms = meta
+                .uniforms
+                .uniforms
+                .iter()
+                .scan(0, |offset, uniform| {
+                    let size = uniform.uniform_type.size() as u64;
+                    stride += size;
+                    let shader_uniform = ShaderUniform {
+                        size: uniform.uniform_type.size() as u64,
+                        offset: *offset,
+                        format: uniform.uniform_type.into(),
+                    };
+                    index += 1;
+                    *offset += size as u64;
+                    Some(shader_uniform)
+                })
+                .collect();
+
+            let shader = ShaderInternal {
+                vertex_function,
+                fragment_function,
+                uniforms,
+                stride,
+            };
+            self.shaders.push(shader);
+            Ok(ShaderId(self.shaders.len() - 1))
+        }
+    }
+
+    fn new_texture(
+        &mut self,
+        access: TextureAccess,
+        bytes: Option<&[u8]>,
+        params: TextureParams,
+    ) -> TextureId {
+        let descriptor = unsafe { msg_send_![class!(MTLTextureDescriptor), new] };
+        unsafe {
+            msg_send_![descriptor, retain];
+        }
+        unsafe {
+            msg_send_![descriptor, setWidth:params.width as u64];
+            msg_send_![descriptor, setHeight:params.height as u64];
+            msg_send_![descriptor, setCpuCacheMode: MTLCPUCacheMode::DefaultCache];
+            msg_send_![descriptor, setPixelFormat: MTLPixelFormat::from(params.format)];
+
+            if access == TextureAccess::RenderTarget {
+                if params.format != TextureFormat::Depth {
+                    msg_send_![descriptor, setPixelFormat: MTLPixelFormat::RGBA8Unorm];
+                }
+                msg_send_![descriptor, setStorageMode: MTLStorageMode::Private];
+                msg_send_![
+                    descriptor,
+                    setUsage: MTLTextureUsage::RenderTarget as u64
+                        | MTLTextureUsage::ShaderRead as u64
+                        | MTLTextureUsage::ShaderWrite as u64
+                ];
+            } else {
+                msg_send_![descriptor, setUsage: MTLTextureUsage::ShaderRead];
+                #[cfg(target_os = "macos")]
+                {
+                    msg_send_![descriptor, setStorageMode: MTLStorageMode::Managed];
+                    msg_send_![
+                        descriptor,
+                        setResourceOptions: MTLResourceOptions::StorageModeManaged
+                    ];
+                }
+                // #[cfg(target_os = "ios")]
+                // {
+                //     texture_dsc.set_storage_mode(MTLStorageMode::Shared);
+                //     texture_dsc.set_resource_options(MTLResourceOptions::StorageModeShared);
+                // }
+            }
+        };
+
+        let texture = unsafe {
+            let sampler_dsc = msg_send_![class!(MTLSamplerDescriptor), new];
+            unsafe {
+                msg_send_![sampler_dsc, retain];
+            }
+            msg_send_![sampler_dsc, setMinFilter: MTLSamplerMinMagFilter::Linear];
+            msg_send_![sampler_dsc, setMagFilter: MTLSamplerMinMagFilter::Linear];
+
+            let sampler_state = msg_send_![self.device, newSamplerStateWithDescriptor: sampler_dsc];
+            unsafe {
+                msg_send_![sampler_state, retain];
+            }
+            let raw_texture = msg_send_![self.device, newTextureWithDescriptor: descriptor];
+
+            unsafe {
+                msg_send_![raw_texture, retain];
+            }
+            self.textures.push(TextureInternal {
+                sampler: sampler_state,
+                texture: raw_texture,
+                width: params.width as _,
+                height: params.height as _,
+            });
+            TextureId(self.textures.len() - 1)
+        };
+
+        if let Some(bytes) = bytes {
+            assert_eq!(
+                params.format.size(params.width, params.height) as usize,
+                bytes.len()
+            );
+
+            self.update_texture_part(texture, 0, 0, params.width as _, params.height as _, bytes);
+        }
+        texture
+    }
+
+    fn update_texture_part(
+        &mut self,
+        texture: TextureId,
+        x_offset: i32,
+        y_offset: i32,
+        width: i32,
+        height: i32,
+        bytes: &[u8],
+    ) {
+        let raw_texture = self.textures[texture.0].texture;
+        let region = MTLRegion {
+            origin: MTLOrigin {
+                x: x_offset as u64,
+                y: y_offset as u64,
+                z: 0,
+            },
+            size: MTLSize {
+                width: width as u64,
+                height: height as u64,
+                depth: 1,
+            },
+        };
+        unsafe {
+            msg_send_![raw_texture, replaceRegion:region
+                       mipmapLevel:0
+                       withBytes:bytes.as_ptr()
+                       bytesPerRow:(width * 4) as u64];
+        }
+    }
+
+    fn texture_size(&self, texture: TextureId) -> (u32, u32) {
+        let texture = &self.textures[texture.0];
+        (texture.width as _, texture.height as _)
+    }
+
+    fn new_pipeline(
+        &mut self,
+        buffer_layout: &[BufferLayout],
+        attributes: &[VertexAttribute],
+        shader: ShaderId,
+    ) -> Pipeline {
+        self.new_pipeline_with_params(buffer_layout, attributes, shader, Default::default())
+    }
+
+    fn new_pipeline_with_params(
+        &mut self,
+        buffer_layout: &[BufferLayout],
+        attributes: &[VertexAttribute],
+        shader: ShaderId,
+        params: PipelineParams,
+    ) -> Pipeline {
+        unsafe {
+            let shader_internal = &self.shaders[shader.0];
+
+            let vertex_descriptor: ObjcId =
+                msg_send![class!(MTLVertexDescriptor), vertexDescriptor];
+
+            let attribute = |i, buffer_index, offset, format: MTLVertexFormat| {
+                let mtl_attribute_desc = msg_send_![
+                    msg_send_![vertex_descriptor, attributes],
+                    objectAtIndexedSubscript: i
+                ];
+                msg_send_![mtl_attribute_desc, setBufferIndex: buffer_index];
+                msg_send_![mtl_attribute_desc, setOffset: offset];
+                msg_send_![mtl_attribute_desc, setFormat: format];
+            };
+            let layout = |i, step_func: VertexStep, stride, step_rate| {
+                let mtl_buffer_desc = msg_send_![
+                    msg_send_![vertex_descriptor, layouts],
+                    objectAtIndexedSubscript: i
+                ];
+                let step_func: MTLVertexStepFunction = step_func.into();
+                msg_send_![mtl_buffer_desc, setStride: stride];
+                msg_send_![mtl_buffer_desc, setStepFunction: step_func];
+                msg_send_![mtl_buffer_desc, setStepRate: step_rate];
+            };
+
+            let mut offsets = [0u64; 50];
+            for (i, a) in attributes.iter().enumerate() {
+                let offset = &mut offsets[a.buffer_index];
+                attribute(
+                    i as u64,
+                    a.buffer_index as u64 + 1,
+                    *offset,
+                    a.format.into(),
+                );
+                *offset += a.format.size_bytes() as u64;
+            }
+            for (i, buffer) in buffer_layout.iter().enumerate() {
+                layout(
+                    i as u64 + 1,
+                    buffer.step_func,
+                    if buffer.stride == 0 {
+                        offsets[i]
+                    } else {
+                        buffer.stride as u64
+                    },
+                    buffer.step_rate as u64,
+                );
+            }
+
+            let descriptor = msg_send_![class!(MTLRenderPipelineDescriptor), new];
+            msg_send_![descriptor, setVertexFunction:shader_internal.vertex_function];
+            msg_send_![descriptor, setFragmentFunction:shader_internal.fragment_function];
+            msg_send_![descriptor, setVertexDescriptor: vertex_descriptor];
+            let color_attachments = msg_send_![descriptor, colorAttachments];
+            let color_attachment = msg_send_![color_attachments, objectAtIndexedSubscript: 0];
+
+            let view_pixel_format: MTLPixelFormat = msg_send![self.view, colorPixelFormat];
+            msg_send_![color_attachment, setPixelFormat: view_pixel_format];
+            if params.color_blend.is_some() {
+                msg_send_![color_attachment, setBlendingEnabled: true];
+                //TODO: Set from pipe params
+                msg_send_![
+                    color_attachment,
+                    setRgbBlendOperation: MTLBlendOperation::Add
+                ];
+                msg_send_![
+                    color_attachment,
+                    setAlphaBlendOperation: MTLBlendOperation::Add
+                ];
+                msg_send_![
+                    color_attachment,
+                    setSourceRGBBlendFactor: MTLBlendFactor::SourceAlpha
+                ];
+                msg_send_![
+                    color_attachment,
+                    setSourceRGBBlendFactor: MTLBlendFactor::SourceAlpha
+                ];
+                msg_send_![
+                    color_attachment,
+                    setSourceAlphaBlendFactor: MTLBlendFactor::SourceAlpha
+                ];
+                msg_send_![
+                    color_attachment,
+                    setDestinationRGBBlendFactor: MTLBlendFactor::OneMinusSourceAlpha
+                ];
+                msg_send_![
+                    color_attachment,
+                    setDestinationAlphaBlendFactor: MTLBlendFactor::OneMinusSourceAlpha
+                ];
+            }
+
+            msg_send_![
+                descriptor,
+                setDepthAttachmentPixelFormat: MTLPixelFormat::Depth32Float_Stencil8
+            ];
+            msg_send_![
+                descriptor,
+                setStencilAttachmentPixelFormat: MTLPixelFormat::Depth32Float_Stencil8
+            ];
+
+            let mut error: ObjcId = nil;
+            let pipeline_state: ObjcId = msg_send![
+                self.device,
+                newRenderPipelineStateWithDescriptor: descriptor
+                error: &mut error
+            ];
+            if pipeline_state.is_null() {
+                let description: ObjcId = msg_send![error, localizedDescription];
+                let string = apple_util::nsstring_to_string(description);
+                panic!("newRenderPipelineStateWithDescriptor error: {}", string);
+            }
+
+            let depth_stencil_desc = msg_send_![class!(MTLDepthStencilDescriptor), new];
+            msg_send_![depth_stencil_desc, setDepthWriteEnabled: BOOL::from(params.depth_write)];
+            msg_send_![depth_stencil_desc, setDepthCompareFunction: MTLCompareFunction::from(params.depth_test)];
+
+            // if let Some(stencil_test) = params.stencil_test {
+            //     let back_face_stencil_desc = StencilDescriptor::new();
+            //     back_face_stencil_desc.set_stencil_compare_function(stencil_test.back.test_func.into());
+            //     back_face_stencil_desc.set_stencil_failure_operation(stencil_test.back.fail_op.into());
+            //     back_face_stencil_desc
+            //         .set_depth_failure_operation(stencil_test.back.depth_fail_op.into());
+            //     back_face_stencil_desc.set_read_mask(stencil_test.back.test_mask);
+            //     back_face_stencil_desc.set_write_mask(stencil_test.back.write_mask);
+
+            //     depth_stencil_desc.set_back_face_stencil(Some(back_face_stencil_desc.as_ref()));
+
+            //     let front_face_stencil_desc = StencilDescriptor::new();
+            //     front_face_stencil_desc
+            //         .set_stencil_compare_function(stencil_test.front.test_func.into());
+            //     front_face_stencil_desc
+            //         .set_stencil_failure_operation(stencil_test.front.fail_op.into());
+            //     front_face_stencil_desc
+            //         .set_depth_failure_operation(stencil_test.front.depth_fail_op.into());
+            //     front_face_stencil_desc.set_read_mask(stencil_test.front.test_mask);
+            //     front_face_stencil_desc.set_write_mask(stencil_test.front.write_mask);
+
+            //     depth_stencil_desc.set_front_face_stencil(Some(front_face_stencil_desc.as_ref()))
+            // }
+
+            let depth_stencil_state = msg_send_![
+                self.device,
+                newDepthStencilStateWithDescriptor: depth_stencil_desc
+            ];
+
+            let pipeline = PipelineInternal {
+                pipeline_state,
+                depth_stencil_state,
+                layout: buffer_layout.to_vec(),
+                //attributes: vertex_layout,
+                shader,
+                params,
+            };
+
+            self.pipelines.push(pipeline);
+
+            Pipeline(self.pipelines.len() - 1)
+        }
+    }
+
+    fn apply_pipeline(&mut self, pipeline: &Pipeline) {
+        assert!(
+            self.render_encoder.is_some(),
+            "apply_pipeline before begin_pass"
+        );
+        let render_encoder = self.render_encoder.unwrap();
+
+        unsafe {
+            self.current_pipeline = Some(*pipeline);
+            let pipeline = &self.pipelines[pipeline.0];
+
+            msg_send_![render_encoder, setRenderPipelineState: pipeline.pipeline_state];
+            msg_send_![render_encoder, setDepthStencilState:pipeline.depth_stencil_state];
+            // render_encoder.set_front_facing_winding(pipeline.params.front_face_order.into());
+            // render_encoder.set_cull_mode(pipeline.params.cull_face.into());
+        }
+    }
+
+    fn apply_bindings(&mut self, bindings: &Bindings) {
+        assert!(
+            self.render_encoder.is_some(),
+            "apply_bindings before begin_pass"
+        );
+
+        unsafe {
+            let render_encoder = self.render_encoder.unwrap();
+            for (index, vertex_buffer) in bindings.vertex_buffers.iter().enumerate() {
+                let buffer = &mut self.buffers[vertex_buffer.0];
+                let () = msg_send![render_encoder,
+                                   setVertexBuffer:buffer.raw[buffer.value]
+                                   offset:0
+                                   atIndex:(index + 1) as u64];
+                buffer.next_value = buffer.value + 1;
+            }
+            let mut index_buffer = &mut self.buffers[bindings.index_buffer.0];
+            self.index_buffer = Some(index_buffer.raw[index_buffer.value]);
+            index_buffer.next_value = index_buffer.value + 1;
+
+            let img_count = bindings.images.len();
+            if img_count > 0 {
+                for (n, img) in bindings.images.iter().enumerate() {
+                    let TextureInternal {
+                        sampler, texture, ..
+                    } = self.textures[img.0];
+                    msg_send_![render_encoder, setFragmentSamplerState:sampler
+                               atIndex:n
+                    ];
+                    msg_send_![render_encoder, setFragmentTexture:texture
+                               atIndex:n
+                    ];
+                }
+            }
+        }
+    }
+
+    fn apply_uniforms_from_bytes(&mut self, uniform_ptr: *const u8, size: usize) {
+        assert!(
+            self.current_pipeline.is_some(),
+            "apply_uniforms before apply_pipeline"
+        );
+        assert!(
+            self.render_encoder.is_some(),
+            "apply_uniforms before begin_pass"
+        );
+
+        let current_pipeline = &self.pipelines[self.current_pipeline.unwrap().0];
+        let render_encoder = self.render_encoder.unwrap();
+
+        self.current_frame_index = (self.current_frame_index + 1) % NUM_INFLIGHT_FRAMES;
+
+        let shader = &self.shaders[current_pipeline.shader.0];
+
+        let data_lenght = shader.stride;
+
+        assert!(size < MAX_UNIFORM_BUFFER_SIZE as usize);
+
+        assert!(self.current_ub_offset < MAX_UNIFORM_BUFFER_SIZE);
+
+        let buffer = self.uniform_buffers[self.current_frame_index];
+        unsafe {
+            let dest: *mut std::ffi::c_void = msg_send![buffer, contents];
+            std::ptr::copy(
+                uniform_ptr as _,
+                dest.add(self.current_ub_offset as usize),
+                size,
+            );
+
+            #[cfg(target_os = "macos")]
+            msg_send_![buffer, didModifyRange:NSRange::new(0, size as u64)];
+
+            msg_send_![render_encoder,
+                       setVertexBuffer:buffer
+                       offset:self.current_ub_offset
+                       atIndex:0];
+            msg_send_![render_encoder,
+                       setFragmentBuffer:buffer
+                       offset:self.current_ub_offset
+                       atIndex:0];
+        }
+        self.current_ub_offset = roundup_ub_buffer(self.current_ub_offset + size as u64);
+    }
+
+    fn begin_default_pass(&mut self, action: PassAction) {
+        self.begin_pass(None, action)
+    }
+
+    fn begin_pass(&mut self, pass: Option<RenderPass>, action: PassAction) {
+        unsafe {
+            if self.command_buffer.is_none() {
+                self.command_buffer = Some(msg_send![self.command_queue, commandBuffer]);
+            }
+
+            let (descriptor, w, h) = match pass {
+                None => {
+                    let (screen_width, screen_height) = crate::window::screen_size();
+                    (
+                        {
+                            let a = msg_send_![self.view, currentRenderPassDescriptor];
+                            msg_send_![a, retain];
+                            a
+                        },
+                        screen_width as f64,
+                        screen_height as f64,
+                    )
+                }
+                Some(pass) => {
+                    //self.current_pass = Some(pass);
+
+                    let pass_internal = &self.passes[pass.0];
+                    (
+                        pass_internal.render_pass_desc,
+                        self.textures[pass_internal.texture.0].width as f64,
+                        self.textures[pass_internal.texture.0].height as f64,
+                    )
+                }
+            };
+            assert!(!descriptor.is_null());
+
+            let color_attachments = msg_send_![descriptor, colorAttachments];
+            let color_attachment = msg_send_![color_attachments, objectAtIndexedSubscript: 0];
+
+            msg_send_![color_attachment, setStoreAction: MTLStoreAction::Store];
+
+            match action {
+                PassAction::Clear {
+                    color,
+                    depth,
+                    stencil,
+                } => {
+                    msg_send_![color_attachment, setLoadAction: MTLLoadAction::Clear];
+
+                    if let Some(color) = color {
+                        msg_send_![color_attachment, setClearColor:MTLClearColor::new(color.0 as _, color.1 as _, color.2 as _, color.3 as _)];
+                    }
+                }
+                PassAction::Nothing => {
+                    msg_send_![color_attachment, setLoadAction: MTLLoadAction::Load];
+                }
+            }
+
+            let render_encoder = msg_send_![
+                self.command_buffer.unwrap(),
+                renderCommandEncoderWithDescriptor: descriptor
+            ];
+
+            // render_encoder.set_viewport(MTLViewport {
+            //     originX: 0.0,
+            //     originY: 0.0,
+            //     width: w,
+            //     height: h,
+            //     znear: 0.0,
+            //     zfar: 1.0,
+            // });
+            // render_encoder.set_scissor_rect(MTLScissorRect {
+            //     x: 0,
+            //     y: 0,
+            //     width: w as u64,
+            //     height: h as u64,
+            // });
+
+            self.render_encoder = Some(render_encoder);
+        }
+    }
+
+    fn end_render_pass(&mut self) {
+        assert!(
+            self.render_encoder.is_some(),
+            "end_render_pass unpaired with begin_render_pass!"
+        );
+
+        let render_encoder = self.render_encoder.unwrap();
+        unsafe { msg_send_!(render_encoder, endEncoding) };
+
+        self.render_encoder = None;
+        self.index_buffer = None;
+    }
+
+    fn draw(&self, base_element: i32, num_elements: i32, num_instances: i32) {
+        assert!(self.render_encoder.is_some(), "draw before begin_pass!");
+        let render_encoder = self.render_encoder.unwrap();
+        assert!(self.index_buffer.is_some());
+        let index_buffer = self.index_buffer.unwrap();
+
+        assert!(base_element == 0); // TODO: figure indexBufferOffset/baseVertex
+        unsafe {
+            msg_send_![render_encoder, drawIndexedPrimitives:MTLPrimitiveType::Triangle
+                       indexCount:num_elements as u64
+                       indexType:MTLIndexType::UInt16
+                       indexBuffer:index_buffer
+                       indexBufferOffset:0
+                       instanceCount:num_instances as u64
+                       baseVertex:0
+                       baseInstance:0
+            ];
+        }
+    }
+
+    fn commit_frame(&mut self) {
+        unsafe {
+            assert!(!self.command_queue.is_null());
+            let drawable: ObjcId = msg_send!(self.view, currentDrawable);
+            msg_send_![drawable, retain];
+            msg_send_![self.command_buffer.unwrap(), presentDrawable: drawable];
+            msg_send_![self.command_buffer.unwrap(), commit];
+            msg_send_![self.command_buffer.unwrap(), waitUntilCompleted];
+        }
+        for buffer in &mut self.buffers {
+            buffer.next_value = 0;
+        }
+        self.current_ub_offset = 0;
+        self.current_pipeline = None;
+        self.command_buffer = None;
+        if (self.current_frame_index + 1) >= 3 {
+            self.current_frame_index = 0;
+        }
+    }
+}

--- a/src/graphics/metal.rs
+++ b/src/graphics/metal.rs
@@ -401,7 +401,7 @@ impl RenderingBackend for MetalContext {
     fn render_pass_texture(&self, render_pass: RenderPass) -> TextureId {
         self.passes[render_pass.0].texture
     }
-    fn new_buffer_immutable(&mut self, buffer_type: BufferType, data: Arg) -> BufferId {
+    fn new_buffer_immutable(&mut self, buffer_type: BufferType, data: BufferSource) -> BufferId {
         debug_assert!(data.is_slice);
         let index_type = if buffer_type == BufferType::IndexBuffer {
             Some(IndexType::for_type_size(data.element_size))
@@ -460,7 +460,7 @@ impl RenderingBackend for MetalContext {
         BufferId(self.buffers.len() - 1)
     }
 
-    fn buffer_update(&mut self, buffer: BufferId, data: Arg) {
+    fn buffer_update(&mut self, buffer: BufferId, data: BufferSource) {
         let mut buffer = &mut self.buffers[buffer.0];
         assert!(data.size <= buffer.size);
 

--- a/src/graphics/metal.rs
+++ b/src/graphics/metal.rs
@@ -355,7 +355,10 @@ impl RenderingBackend for MetalContext {
     fn set_stencil(&mut self, stencil_test: Option<StencilState>) {}
     fn apply_viewport(&mut self, x: i32, y: i32, w: i32, h: i32) {}
     fn apply_scissor_rect(&mut self, x: i32, y: i32, w: i32, h: i32) {}
-
+    fn texture_set_filter(&self, texture: TextureId, filter: FilterMode) {}
+    fn texture_set_wrap(&mut self, texture: TextureId, wrap: TextureWrap) {}
+    fn texture_resize(&mut self, texture: TextureId, width: u32, height: u32, bytes: Option<&[u8]>) {}
+    fn texture_read_pixels(&mut self, texture: TextureId, bytes: &mut [u8]) {}
     fn clear(&self, color: Option<(f32, f32, f32, f32)>, depth: Option<f32>, stencil: Option<i32>) {
     }
 
@@ -607,12 +610,12 @@ impl RenderingBackend for MetalContext {
                 bytes.len()
             );
 
-            self.update_texture_part(texture, 0, 0, params.width as _, params.height as _, bytes);
+            self.texture_update_part(texture, 0, 0, params.width as _, params.height as _, bytes);
         }
         texture
     }
 
-    fn update_texture_part(
+    fn texture_update_part(
         &mut self,
         texture: TextureId,
         x_offset: i32,

--- a/src/graphics/texture.rs
+++ b/src/graphics/texture.rs
@@ -1,7 +1,7 @@
-use crate::{native::gl::*, native::*, Context};
+use crate::{graphics::gl::GlContext as GraphicsContext, native::gl::*, native::*};
 
 #[derive(Clone, Copy, Debug, PartialEq, Hash)]
-pub struct Texture {
+struct Texture {
     pub(crate) texture: GLuint,
     pub width: u32,
     pub height: u32,
@@ -54,37 +54,24 @@ pub enum TextureFormat {
     RGBA8,
     Depth,
     Alpha,
-    LuminanceAlpha,
 }
 
-impl TextureFormat {
-    /// Converts from TextureFormat to (internal_format, format, pixel_type)
-    fn into_gl_params(self, alpha_texture: bool) -> (GLenum, GLenum, GLenum) {
-        match self {
+/// Converts from TextureFormat to (internal_format, format, pixel_type)
+impl From<TextureFormat> for (GLenum, GLenum, GLenum) {
+    fn from(format: TextureFormat) -> Self {
+        match format {
             TextureFormat::RGB8 => (GL_RGB, GL_RGB, GL_UNSIGNED_BYTE),
             TextureFormat::RGBA8 => (GL_RGBA, GL_RGBA, GL_UNSIGNED_BYTE),
             TextureFormat::Depth => (GL_DEPTH_COMPONENT, GL_DEPTH_COMPONENT, GL_UNSIGNED_SHORT),
-
             #[cfg(target_arch = "wasm32")]
             TextureFormat::Alpha => (GL_ALPHA, GL_ALPHA, GL_UNSIGNED_BYTE),
             #[cfg(not(target_arch = "wasm32"))]
-            TextureFormat::Alpha if alpha_texture => (GL_ALPHA, GL_ALPHA, GL_UNSIGNED_BYTE),
-            #[cfg(not(target_arch = "wasm32"))]
             TextureFormat::Alpha => (GL_R8, GL_RED, GL_UNSIGNED_BYTE), // texture updates will swizzle Red -> Alpha to match WASM
-
-            #[cfg(target_arch = "wasm32")]
-            TextureFormat::LuminanceAlpha => {
-                (GL_LUMINANCE_ALPHA, GL_LUMINANCE_ALPHA, GL_UNSIGNED_BYTE)
-            }
-            #[cfg(not(target_arch = "wasm32"))]
-            TextureFormat::LuminanceAlpha if alpha_texture => {
-                (GL_LUMINANCE_ALPHA, GL_LUMINANCE_ALPHA, GL_UNSIGNED_BYTE)
-            }
-            #[cfg(not(target_arch = "wasm32"))]
-            TextureFormat::LuminanceAlpha => (GL_RG, GL_RG, GL_UNSIGNED_BYTE), // texture updates will swizzle Green -> Alpha to match WASM
         }
     }
+}
 
+impl TextureFormat {
     /// Returns the size in bytes of texture with `dimensions`.
     pub fn size(self, width: u32, height: u32) -> u32 {
         let square = width * height;
@@ -93,7 +80,6 @@ impl TextureFormat {
             TextureFormat::RGBA8 => 4 * square,
             TextureFormat::Depth => 2 * square,
             TextureFormat::Alpha => 1 * square,
-            TextureFormat::LuminanceAlpha => 2 * square,
         }
     }
 }
@@ -146,12 +132,12 @@ pub struct TextureParams {
 
 impl Texture {
     /// Shorthand for `new(ctx, TextureAccess::RenderTarget, params)`
-    pub fn new_render_texture(ctx: &mut Context, params: TextureParams) -> Texture {
+    pub fn new_render_texture(ctx: &mut GraphicsContext, params: TextureParams) -> Texture {
         Self::new(ctx, TextureAccess::RenderTarget, None, params)
     }
 
     pub fn new(
-        ctx: &mut Context,
+        ctx: &mut GraphicsContext,
         _access: TextureAccess,
         bytes: Option<&[u8]>,
         params: TextureParams,
@@ -163,8 +149,7 @@ impl Texture {
             );
         }
 
-        let (internal_format, format, pixel_type) =
-            params.format.into_gl_params(ctx.features().alpha_texture);
+        let (internal_format, format, pixel_type) = params.format.into();
 
         ctx.cache.store_texture_binding(0);
 
@@ -174,6 +159,18 @@ impl Texture {
             glGenTextures(1, &mut texture as *mut _);
             ctx.cache.bind_texture(0, texture);
             glPixelStorei(GL_UNPACK_ALIGNMENT, 1); // miniquad always uses row alignment of 1
+
+            if cfg!(not(target_arch = "wasm32")) {
+                // if not WASM
+                if params.format == TextureFormat::Alpha {
+                    // if alpha miniquad texture, the value on non-WASM is stored in red channel
+                    // swizzle red -> alpha
+                    glTexParameteri(GL_TEXTURE_2D, GL_TEXTURE_SWIZZLE_A, GL_RED as _);
+                } else {
+                    // keep alpha -> alpha
+                    glTexParameteri(GL_TEXTURE_2D, GL_TEXTURE_SWIZZLE_A, GL_ALPHA as _);
+                }
+            }
 
             glTexImage2D(
                 GL_TEXTURE_2D,
@@ -194,23 +191,6 @@ impl Texture {
             glTexParameteri(GL_TEXTURE_2D, GL_TEXTURE_WRAP_T, params.wrap as i32);
             glTexParameteri(GL_TEXTURE_2D, GL_TEXTURE_MIN_FILTER, params.filter as i32);
             glTexParameteri(GL_TEXTURE_2D, GL_TEXTURE_MAG_FILTER, params.filter as i32);
-
-            #[cfg(not(target_arch = "wasm32"))]
-            match params.format {
-                // on non-WASM alpha value is stored in red channel
-                // swizzle red -> alpha, zero red
-                TextureFormat::Alpha if !ctx.features().alpha_texture => {
-                    glTexParameteri(GL_TEXTURE_2D, GL_TEXTURE_SWIZZLE_A, GL_RED as _);
-                    glTexParameteri(GL_TEXTURE_2D, GL_TEXTURE_SWIZZLE_R, GL_ZERO as _);
-                }
-                // on non-WASM luminance is stored in red channel, alpha is stored in green channel
-                // keep red, swizzle green -> alpha, zero green
-                TextureFormat::LuminanceAlpha if !ctx.features().alpha_texture => {
-                    glTexParameteri(GL_TEXTURE_2D, GL_TEXTURE_SWIZZLE_A, GL_GREEN as _);
-                    glTexParameteri(GL_TEXTURE_2D, GL_TEXTURE_SWIZZLE_G, GL_ZERO as _);
-                }
-                _ => {}
-            }
         }
         ctx.cache.restore_texture_binding(0);
 
@@ -223,12 +203,16 @@ impl Texture {
     }
 
     /// Upload texture to GPU with given TextureParams
-    pub fn from_data_and_format(ctx: &mut Context, bytes: &[u8], params: TextureParams) -> Texture {
+    pub fn from_data_and_format(
+        ctx: &mut GraphicsContext,
+        bytes: &[u8],
+        params: TextureParams,
+    ) -> Texture {
         Self::new(ctx, TextureAccess::Static, Some(bytes), params)
     }
 
     /// Upload RGBA8 texture to GPU
-    pub fn from_rgba8(ctx: &mut Context, width: u16, height: u16, bytes: &[u8]) -> Texture {
+    pub fn from_rgba8(ctx: &mut GraphicsContext, width: u16, height: u16, bytes: &[u8]) -> Texture {
         assert_eq!(width as usize * height as usize * 4, bytes.len());
 
         Self::from_data_and_format(
@@ -244,7 +228,7 @@ impl Texture {
         )
     }
 
-    pub fn set_filter(&self, ctx: &mut Context, filter: FilterMode) {
+    pub fn set_filter(&self, ctx: &mut GraphicsContext, filter: FilterMode) {
         ctx.cache.store_texture_binding(0);
         ctx.cache.bind_texture(0, self.texture);
         unsafe {
@@ -254,7 +238,7 @@ impl Texture {
         ctx.cache.restore_texture_binding(0);
     }
 
-    pub fn set_wrap(&self, ctx: &mut Context, wrap: TextureWrap) {
+    pub fn set_wrap(&self, ctx: &mut GraphicsContext, wrap: TextureWrap) {
         ctx.cache.store_texture_binding(0);
         ctx.cache.bind_texture(0, self.texture);
         unsafe {
@@ -264,19 +248,21 @@ impl Texture {
         ctx.cache.restore_texture_binding(0);
     }
 
-    pub fn resize(&mut self, ctx: &mut Context, width: u32, height: u32, bytes: Option<&[u8]>) {
+    pub fn resize(
+        &mut self,
+        ctx: &mut GraphicsContext,
+        width: u32,
+        height: u32,
+        bytes: Option<&[u8]>,
+    ) {
         ctx.cache.store_texture_binding(0);
-        ctx.cache.bind_texture(0, self.texture);
 
-        let (internal_format, format, pixel_type) =
-            self.format.into_gl_params(ctx.features().alpha_texture);
+        let (internal_format, format, pixel_type) = self.format.into();
 
         self.width = width;
         self.height = height;
 
         unsafe {
-            glPixelStorei(GL_UNPACK_ALIGNMENT, 1); // miniquad always uses row alignment of 1
-
             glTexImage2D(
                 GL_TEXTURE_2D,
                 0,
@@ -298,7 +284,7 @@ impl Texture {
 
     /// Update whole texture content
     /// bytes should be width * height * 4 size - non rgba8 textures are not supported yet anyway
-    pub fn update(&self, ctx: &mut Context, bytes: &[u8]) {
+    pub fn update(&self, ctx: &mut GraphicsContext, bytes: &[u8]) {
         assert_eq!(self.size(self.width, self.height), bytes.len());
 
         self.update_texture_part(
@@ -313,7 +299,7 @@ impl Texture {
 
     pub fn update_texture_part(
         &self,
-        ctx: &mut Context,
+        ctx: &mut GraphicsContext,
         x_offset: i32,
         y_offset: i32,
         width: i32,
@@ -327,10 +313,22 @@ impl Texture {
         ctx.cache.store_texture_binding(0);
         ctx.cache.bind_texture(0, self.texture);
 
-        let (_, format, pixel_type) = self.format.into_gl_params(ctx.features().alpha_texture);
+        let (_, format, pixel_type) = self.format.into();
 
         unsafe {
             glPixelStorei(GL_UNPACK_ALIGNMENT, 1); // miniquad always uses row alignment of 1
+
+            if cfg!(not(target_arch = "wasm32")) {
+                // if not WASM
+                if self.format == TextureFormat::Alpha {
+                    // if alpha miniquad texture, the value on non-WASM is stored in red channel
+                    // swizzle red -> alpha
+                    glTexParameteri(GL_TEXTURE_2D, GL_TEXTURE_SWIZZLE_A, GL_RED as _);
+                } else {
+                    // keep alpha -> alpha
+                    glTexParameteri(GL_TEXTURE_2D, GL_TEXTURE_SWIZZLE_A, GL_ALPHA as _);
+                }
+            }
 
             glTexSubImage2D(
                 GL_TEXTURE_2D,
@@ -350,10 +348,7 @@ impl Texture {
 
     /// Read texture data into CPU memory
     pub fn read_pixels(&self, bytes: &mut [u8]) {
-        if self.format == TextureFormat::Alpha || self.format == TextureFormat::LuminanceAlpha {
-            unimplemented!("read_pixels is not implement for Alpha and LuminanceAlpha textures");
-        }
-        let (_, format, pixel_type) = self.format.into_gl_params(false);
+        let (_, format, pixel_type) = self.format.into();
 
         let mut fbo = 0;
         unsafe {

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -168,7 +168,15 @@ pub mod window {
         with_native_display!(d, d.show_keyboard(show))
     }
 
-    ///
+    /// The same as
+    /// ```ignore
+    /// if metal {
+    ///    Box::new(MetalContext::new())
+    /// } else {
+    ///   Box::new(GlContext::new())
+    /// };
+    /// ```
+    /// but under #[cfg] gate to avoid MetalContext on non-apple platforms
     pub fn new_rendering_backend() -> Box<dyn RenderingBackend> {
         #[cfg(target_vendor = "apple")]
         {

--- a/src/native.rs
+++ b/src/native.rs
@@ -49,6 +49,10 @@ pub trait NativeDisplay: std::any::Any {
         None
     }
     fn show_keyboard(&mut self, _show: bool) {}
+    #[cfg(target_vendor = "apple")]
+    fn apple_gfx_api(&self) -> crate::conf::AppleGfxApi;
+    #[cfg(target_vendor = "apple")]
+    fn apple_view(&mut self) -> Option<crate::native::apple::frameworks::ObjcId>;
 
     fn as_any(&mut self) -> &mut dyn std::any::Any;
 }
@@ -87,13 +91,10 @@ pub mod egl;
 
 // there is no glGetProcAddr on webgl, so its impossible to make "gl" module work
 // on macos.. well, there is, but way easier to just statically link to gl
-#[cfg(not(any(target_arch = "wasm32", target_os = "macos", target_os = "ios")))]
+#[cfg(not(target_arch = "wasm32"))]
 pub mod gl;
 
 #[cfg(target_arch = "wasm32")]
 pub use wasm::webgl as gl;
-
-#[cfg(any(target_os = "macos", target_os = "ios"))]
-pub use apple::gl;
 
 pub mod query_stab;

--- a/src/native/apple.rs
+++ b/src/native/apple.rs
@@ -1,3 +1,2 @@
 pub mod apple_util;
 pub mod frameworks;
-pub mod gl;

--- a/src/native/apple/apple_util.rs
+++ b/src/native/apple/apple_util.rs
@@ -546,6 +546,18 @@ pub fn load_mouse_cursor(cursor: CursorIcon) -> ObjcId {
 //     }
 // }
 
+macro_rules! msg_send_ {
+    ($obj:expr, $name:ident) => ({
+        let res: ObjcId = msg_send!($obj, $name);
+        res
+    });
+    ($obj:expr, $($name:ident : $arg:expr)+) => ({
+        let res: ObjcId = msg_send!($obj, $($name: $arg)*);
+        res
+    });
+}
+pub(crate) use msg_send_;
+
 pub extern "C" fn yes(_: &Object, _: Sel) -> BOOL {
     YES
 }

--- a/src/native/apple/frameworks.rs
+++ b/src/native/apple/frameworks.rs
@@ -410,13 +410,12 @@ pub struct NSRange {
     pub location: u64,
     pub length: u64,
 }
-/*
 impl NSRange {
     #[inline]
     pub fn new(location: u64, length: u64) -> NSRange {
-        NSRange {location, length}
+        NSRange { location, length }
     }
-}*/
+}
 
 unsafe impl Encode for NSRange {
     fn encode() -> Encoding {
@@ -502,6 +501,16 @@ pub struct MTLClearColor {
     pub blue: f64,
     pub alpha: f64,
 }
+impl MTLClearColor {
+    pub fn new(r: f64, g: f64, b: f64, a: f64) -> MTLClearColor {
+        MTLClearColor {
+            red: r,
+            green: g,
+            blue: b,
+            alpha: a,
+        }
+    }
+}
 
 #[repr(u64)]
 #[allow(non_camel_case_types)]
@@ -512,8 +521,84 @@ pub enum MTLPixelFormat {
     Stencil8 = 253,
     Depth24Unorm_Stencil8 = 255,
     Depth32Float_Stencil8 = 260,
+    RGBA8Unorm = 70,
 }
 
+/// See <https://developer.apple.com/documentation/metal/mtlsamplerminmagfilter>
+#[repr(u64)]
+#[derive(Copy, Clone, Debug, Eq, PartialEq, Hash)]
+pub enum MTLSamplerMinMagFilter {
+    Nearest = 0,
+    Linear = 1,
+}
+
+#[repr(u64)]
+#[allow(non_camel_case_types)]
+#[derive(Copy, Clone, Debug, Eq, PartialEq, Hash)]
+pub enum MTLVertexFormat {
+    Invalid = 0,
+    UChar2 = 1,
+    UChar3 = 2,
+    UChar4 = 3,
+    Char2 = 4,
+    Char3 = 5,
+    Char4 = 6,
+    UChar2Normalized = 7,
+    UChar3Normalized = 8,
+    UChar4Normalized = 9,
+    Char2Normalized = 10,
+    Char3Normalized = 11,
+    Char4Normalized = 12,
+    UShort2 = 13,
+    UShort3 = 14,
+    UShort4 = 15,
+    Short2 = 16,
+    Short3 = 17,
+    Short4 = 18,
+    UShort2Normalized = 19,
+    UShort3Normalized = 20,
+    UShort4Normalized = 21,
+    Short2Normalized = 22,
+    Short3Normalized = 23,
+    Short4Normalized = 24,
+    Half2 = 25,
+    Half3 = 26,
+    Half4 = 27,
+    Float = 28,
+    Float2 = 29,
+    Float3 = 30,
+    Float4 = 31,
+    Int = 32,
+    Int2 = 33,
+    Int3 = 34,
+    Int4 = 35,
+    UInt = 36,
+    UInt2 = 37,
+    UInt3 = 38,
+    UInt4 = 39,
+    Int1010102Normalized = 40,
+    UInt1010102Normalized = 41,
+    UChar4Normalized_BGRA = 42,
+    UChar = 45,
+    Char = 46,
+    UCharNormalized = 47,
+    CharNormalized = 48,
+    UShort = 49,
+    Short = 50,
+    UShortNormalized = 51,
+    ShortNormalized = 52,
+    Half = 53,
+}
+
+#[repr(u64)]
+#[derive(Copy, Clone, Debug, Eq, PartialEq, Hash)]
+pub enum MTLVertexStepFunction {
+    Constant = 0,
+    PerVertex = 1,
+    PerInstance = 2,
+    PerPatch = 3,
+    PerPatchControlPoint = 4,
+}
 #[repr(u64)]
 #[allow(non_camel_case_types)]
 #[derive(Clone, Copy, PartialEq, Eq, Hash, Debug)]

--- a/src/native/gl.rs
+++ b/src/native/gl.rs
@@ -327,6 +327,7 @@ macro_rules! gl_loader {
 }
 
 gl_loader!(
+    fn glGetStringi(name: GLenum, index: GLuint) -> *const GLubyte,
     fn glGetString(name: GLenum) -> *const GLubyte,
     fn glFramebufferTextureLayer(
         target: GLenum,
@@ -338,6 +339,9 @@ gl_loader!(
     fn glGenFramebuffers(n: GLsizei, framebuffers: *mut GLuint) -> (),
     fn glBindFramebuffer(target: GLenum, framebuffer: GLuint) -> (),
     fn glBindRenderbuffer(target: GLenum, renderbuffer: GLuint) -> (),
+    fn glClearBufferfi(buffer: GLenum, drawbuffer: GLint, depth: GLfloat, stencil: GLint) -> (),
+    fn glClearBufferfv(buffer: GLenum, drawbuffer: GLint, value: *const GLfloat) -> (),
+    fn glClearBufferuiv(buffer: GLenum, drawbuffer: GLint, value: *const GLuint) -> (),
     fn glDeleteRenderbuffers(n: GLsizei, renderbuffers: *const GLuint) -> (),
     fn glUniform4fv(location: GLint, count: GLsizei, value: *const GLfloat) -> (),
     fn glUniform3fv(location: GLint, count: GLsizei, value: *const GLfloat) -> (),
@@ -635,8 +639,5 @@ pub unsafe fn is_gl2() -> bool {
         .to_str()
         .unwrap();
 
-    println!("GL_VERSION: {}", version_string);
-    version_string.is_empty()
-        || version_string.starts_with("2")
-        || version_string.starts_with("OpenGL ES 2")
+    version_string.starts_with("2") || version_string.starts_with("OpenGL ES 2")
 }

--- a/src/native/ios.rs
+++ b/src/native/ios.rs
@@ -4,7 +4,7 @@
 //!
 use {
     crate::{
-        conf::Conf,
+        conf::{self, AppleGfxApi, Conf},
         event::{EventHandler, MouseButton},
         fs,
         native::{
@@ -14,13 +14,14 @@ use {
             },
             NativeDisplayData,
         },
-        Context, GraphicsContext,
     },
     std::os::raw::c_void,
 };
 
 struct IosDisplay {
     data: NativeDisplayData,
+    view: ObjcId,
+    gfx_api: conf::AppleGfxApi,
 }
 
 impl crate::native::NativeDisplay for IosDisplay {
@@ -52,25 +53,55 @@ impl crate::native::NativeDisplay for IosDisplay {
         None
     }
     fn clipboard_set(&mut self, _data: &str) {}
+    #[cfg(target_vendor = "apple")]
+    fn apple_gfx_api(&self) -> crate::conf::AppleGfxApi {
+        self.gfx_api
+    }
+    #[cfg(target_vendor = "apple")]
+    fn apple_view(&mut self) -> Option<crate::native::apple::frameworks::ObjcId> {
+        Some(self.view)
+    }
+
     fn as_any(&mut self) -> &mut dyn std::any::Any {
         self
     }
 }
+mod tl_display {
+    use super::*;
+    use crate::NATIVE_DISPLAY;
+
+    use std::cell::RefCell;
+
+    thread_local! {
+        static DISPLAY: RefCell<Option<IosDisplay>> = RefCell::new(None);
+    }
+
+    fn with_native_display(f: &mut dyn FnMut(&mut dyn crate::NativeDisplay)) {
+        DISPLAY.with(|d| {
+            let mut d = d.borrow_mut();
+            let mut d = d.as_mut().unwrap();
+            f(&mut *d);
+        })
+    }
+
+    pub(super) fn with<T>(mut f: impl FnMut(&mut IosDisplay) -> T) -> T {
+        DISPLAY.with(|d| {
+            let mut d = d.borrow_mut();
+            let mut d = d.as_mut().unwrap();
+            f(&mut *d)
+        })
+    }
+
+    pub(super) fn set_display(display: IosDisplay) {
+        DISPLAY.with(|d| *d.borrow_mut() = Some(display));
+        NATIVE_DISPLAY.with(|d| *d.borrow_mut() = Some(with_native_display));
+    }
+}
 
 struct WindowPayload {
-    display: IosDisplay,
-    context: Option<GraphicsContext>,
     event_handler: Option<Box<dyn EventHandler>>,
     gles2: bool,
-    f: Option<Box<dyn 'static + FnOnce(&mut crate::Context) -> Box<dyn EventHandler>>>,
-}
-impl WindowPayload {
-    pub fn context(&mut self) -> Option<(&mut Context, &mut dyn EventHandler)> {
-        let a = self.context.as_mut()?;
-        let event_handler = self.event_handler.as_deref_mut()?;
-
-        Some((a.with_display(&mut self.display), event_handler))
-    }
+    f: Option<Box<dyn 'static + FnOnce() -> Box<dyn EventHandler>>>,
 }
 
 fn get_window_payload(this: &Object) -> &mut WindowPayload {
@@ -80,8 +111,7 @@ fn get_window_payload(this: &Object) -> &mut WindowPayload {
     }
 }
 
-pub fn define_glk_view() -> *const Class {
-    let superclass = class!(GLKView);
+pub fn define_glk_or_mtk_view(superclass: &Class) -> *const Class {
     let mut decl = ClassDecl::new("QuadView", superclass).unwrap();
 
     extern "C" fn touches_began(this: &Object, _: Sel, _: ObjcId, event: ObjcId) {
@@ -99,13 +129,14 @@ pub fn define_glk_view() -> *const Class {
             } {
                 let mut ios_pos: NSPoint = msg_send![ios_touch, locationInView: this];
 
-                if payload.display.data.high_dpi {
-                    ios_pos.x *= 2.;
-                    ios_pos.y *= 2.;
-                }
-                if let Some((context, event_handler)) = payload.context() {
+                tl_display::with(|d| {
+                    if d.data.high_dpi {
+                        ios_pos.x *= 2.;
+                        ios_pos.y *= 2.;
+                    }
+                });
+                if let Some(ref mut event_handler) = payload.event_handler {
                     event_handler.mouse_button_down_event(
-                        context,
                         MouseButton::Left,
                         ios_pos.x as _,
                         ios_pos.y as _,
@@ -145,25 +176,58 @@ pub fn define_glk_view() -> *const Class {
     return decl.register();
 }
 
-pub fn define_glk_view_dlg() -> *const Class {
-    let superclass = class!(NSObject);
+unsafe fn get_proc_address(name: *const u8) -> Option<unsafe extern "C" fn()> {
+    mod libc {
+        use std::ffi::{c_char, c_int, c_void};
+
+        pub const RTLD_LAZY: c_int = 1;
+        extern "C" {
+            pub fn dlopen(filename: *const c_char, flag: c_int) -> *mut c_void;
+            pub fn dlsym(handle: *mut c_void, symbol: *const c_char) -> *mut c_void;
+        }
+    }
+    static mut opengl: *mut std::ffi::c_void = std::ptr::null_mut();
+
+    if opengl.is_null() {
+        opengl = libc::dlopen(
+            b"/System/Library/Frameworks/OpenGLES.framework/OpenGLES\0".as_ptr() as _,
+            libc::RTLD_LAZY,
+        );
+    }
+
+    assert!(!opengl.is_null());
+
+    let symbol = libc::dlsym(opengl, name as _);
+    if symbol.is_null() {
+        return None;
+    }
+    Some(unsafe { std::mem::transmute_copy(&symbol) })
+}
+
+pub fn define_glk_or_mtk_view_dlg(superclass: &Class) -> *const Class {
     let mut decl = ClassDecl::new("QuadViewDlg", superclass).unwrap();
 
     extern "C" fn draw_in_rect(this: &Object, _: Sel, _: ObjcId, _: ObjcId) {
         let payload = get_window_payload(this);
         if payload.event_handler.is_none() {
             let f = payload.f.take().unwrap();
-            payload.context = Some(GraphicsContext::new(payload.gles2));
-            payload.event_handler = Some(f(payload
-                .context
-                .as_mut()
-                .unwrap()
-                .with_display(&mut payload.display)));
+
+            if tl_display::with(|d| d.gfx_api == AppleGfxApi::OpenGl) {
+                crate::native::gl::load_gl_funcs(|proc| {
+                    let name = std::ffi::CString::new(proc).unwrap();
+
+                    unsafe { get_proc_address(name.as_ptr() as _) }
+                });
+            }
+
+            payload.event_handler = Some(f());
         }
 
         let main_screen: ObjcId = unsafe { msg_send![class!(UIScreen), mainScreen] };
         let screen_rect: NSRect = unsafe { msg_send![main_screen, bounds] };
-        let (screen_width, screen_height) = if payload.display.data.high_dpi {
+        let high_dpi = tl_display::with(|d| d.data.high_dpi);
+
+        let (screen_width, screen_height) = if high_dpi {
             (
                 screen_rect.size.width as i32 * 2,
                 screen_rect.size.height as i32 * 2,
@@ -175,20 +239,26 @@ pub fn define_glk_view_dlg() -> *const Class {
             )
         };
 
-        if payload.display.data.screen_width != screen_width
-            || payload.display.data.screen_height != screen_height
+        if tl_display::with(|d| d.data.screen_width != screen_width)
+            || tl_display::with(|d| d.data.screen_height != screen_height)
         {
-            payload.display.data.screen_width = screen_width;
-            payload.display.data.screen_height = screen_height;
-            if let Some((context, event_handler)) = payload.context() {
-                event_handler.resize_event(context, screen_width as _, screen_height as _);
+            tl_display::with(|d| {
+                d.data.screen_width = screen_width;
+                d.data.screen_height = screen_height;
+            });
+            if let Some(ref mut event_handler) = payload.event_handler {
+                event_handler.resize_event(screen_width as _, screen_height as _);
             }
         }
 
-        if let Some((context, event_handler)) = payload.context() {
-            event_handler.update(context);
-            event_handler.draw(context);
+        if let Some(ref mut event_handler) = payload.event_handler {
+            event_handler.update();
+            event_handler.draw();
         }
+    }
+    // wrapper to make sel! macros happy
+    extern "C" fn draw_in_rect2(this: &Object, s: Sel, o: ObjcId) {
+        draw_in_rect(this, s, o, nil);
     }
 
     unsafe {
@@ -196,9 +266,104 @@ pub fn define_glk_view_dlg() -> *const Class {
             sel!(glkView: drawInRect:),
             draw_in_rect as extern "C" fn(&Object, Sel, ObjcId, ObjcId),
         );
+
+        decl.add_method(
+            sel!(drawInMTKView:),
+            draw_in_rect2 as extern "C" fn(&Object, Sel, ObjcId),
+        );
     }
+
     decl.add_ivar::<*mut c_void>("display_ptr");
     return decl.register();
+}
+
+// metal or opengl view and the objects required to collect all the window events
+struct View {
+    view: ObjcId,
+    view_dlg: ObjcId,
+    view_ctrl: ObjcId,
+    // this view failed to create gles3 context, but succeeded with gles2
+    gles2: bool,
+}
+
+unsafe fn create_opengl_view(screen_rect: NSRect, sample_count: i32, high_dpi: bool) -> View {
+    let glk_view_obj: ObjcId = msg_send![define_glk_or_mtk_view(class!(GLKView)), alloc];
+    let glk_view_obj: ObjcId = msg_send![glk_view_obj, initWithFrame: screen_rect];
+
+    let glk_view_dlg_obj: ObjcId = msg_send![define_glk_or_mtk_view_dlg(class!(NSObject)), alloc];
+    let glk_view_dlg_obj: ObjcId = msg_send![glk_view_dlg_obj, init];
+
+    let eagl_context_obj: ObjcId = msg_send![class!(EAGLContext), alloc];
+    let mut eagl_context_obj: ObjcId = msg_send![eagl_context_obj, initWithAPI: 3];
+    let mut gles2 = false;
+    if eagl_context_obj.is_null() {
+        eagl_context_obj = msg_send![eagl_context_obj, initWithAPI: 2];
+        gles2 = true;
+    }
+
+    msg_send_![
+        glk_view_obj,
+        setDrawableColorFormat: frameworks::GLKViewDrawableColorFormatRGBA8888
+    ];
+    msg_send_![
+        glk_view_obj,
+        setDrawableDepthFormat: frameworks::GLKViewDrawableDepthFormat::Format24 as i32
+    ];
+    msg_send_![
+        glk_view_obj,
+        setDrawableStencilFormat: frameworks::GLKViewDrawableStencilFormat::FormatNone as i32
+    ];
+    msg_send_![glk_view_obj, setContext: eagl_context_obj];
+
+    msg_send_![glk_view_obj, setDelegate: glk_view_dlg_obj];
+    msg_send_![glk_view_obj, setEnableSetNeedsDisplay: NO];
+    msg_send_![glk_view_obj, setUserInteractionEnabled: YES];
+    msg_send_![glk_view_obj, setMultipleTouchEnabled: YES];
+    if high_dpi {
+        msg_send_![glk_view_obj, setContentScaleFactor: 2.0];
+    } else {
+        msg_send_![glk_view_obj, setContentScaleFactor: 1.0];
+    }
+
+    let view_ctrl_obj: ObjcId = msg_send![class!(GLKViewController), alloc];
+    let view_ctrl_obj: ObjcId = msg_send![view_ctrl_obj, init];
+
+    msg_send_![view_ctrl_obj, setView: glk_view_obj];
+    msg_send_![view_ctrl_obj, setPreferredFramesPerSecond:60];
+
+    View {
+        view: glk_view_obj,
+        view_dlg: glk_view_dlg_obj,
+        view_ctrl: view_ctrl_obj,
+        gles2,
+    }
+}
+
+unsafe fn create_metal_view(screen_rect: NSRect, sample_count: i32, high_dpi: bool) -> View {
+    let mtk_view_obj: ObjcId = msg_send![define_glk_or_mtk_view(class!(MTKView)), alloc];
+    let mtk_view_obj: ObjcId = msg_send![mtk_view_obj, initWithFrame: screen_rect];
+
+    let mtk_view_dlg_obj: ObjcId = msg_send![define_glk_or_mtk_view_dlg(class!(NSObject)), alloc];
+    let mtk_view_dlg_obj: ObjcId = msg_send![mtk_view_dlg_obj, init];
+
+    let view_ctrl_obj: ObjcId = msg_send![class!(UIViewController), alloc];
+    let view_ctrl_obj: ObjcId = msg_send![view_ctrl_obj, init];
+
+    msg_send_![view_ctrl_obj, setView: mtk_view_obj];
+
+    msg_send_![mtk_view_obj, setPreferredFramesPerSecond:60];
+    msg_send_![mtk_view_obj, setDelegate: mtk_view_dlg_obj];
+    let device = MTLCreateSystemDefaultDevice();
+    msg_send_![mtk_view_obj, setDevice: device];
+    msg_send_![mtk_view_obj, setUserInteractionEnabled: YES];
+
+    View {
+        view: mtk_view_obj,
+        view_dlg: mtk_view_dlg_obj,
+        view_ctrl: view_ctrl_obj,
+
+        gles2: false,
+    }
 }
 
 pub fn define_app_delegate() -> *const Class {
@@ -232,73 +397,40 @@ pub fn define_app_delegate() -> *const Class {
             let window_obj: ObjcId = msg_send![class!(UIWindow), alloc];
             let window_obj: ObjcId = msg_send![window_obj, initWithFrame: screen_rect];
 
-            let eagl_context_obj: ObjcId = msg_send![class!(EAGLContext), alloc];
-            let mut eagl_context_obj: ObjcId = msg_send![eagl_context_obj, initWithAPI: 3];
-            let mut gles2 = false;
-            if eagl_context_obj.is_null() {
-                eagl_context_obj = msg_send![eagl_context_obj, initWithAPI: 2];
-                gles2 = true;
-            }
+            let view = match conf.platform.apple_gfx_api {
+                AppleGfxApi::OpenGl => {
+                    create_opengl_view(screen_rect, conf.sample_count, conf.high_dpi)
+                }
+                AppleGfxApi::Metal => {
+                    create_metal_view(screen_rect, conf.sample_count, conf.high_dpi)
+                }
+            };
 
-            let payload = Box::new(WindowPayload {
-                display: IosDisplay {
-                    data: NativeDisplayData {
-                        screen_width,
-                        screen_height,
-                        high_dpi: conf.high_dpi,
-                        ..Default::default()
-                    },
+            tl_display::set_display(IosDisplay {
+                data: NativeDisplayData {
+                    screen_width,
+                    screen_height,
+                    high_dpi: conf.high_dpi,
+                    ..Default::default()
                 },
+                view: view.view,
+                gfx_api: conf.platform.apple_gfx_api,
+            });
+            let payload = Box::new(WindowPayload {
                 f: Some(Box::new(f)),
                 event_handler: None,
-                context: None,
-                gles2,
+                gles2: view.gles2,
             });
             let payload_ptr = Box::into_raw(payload) as *mut std::ffi::c_void;
 
-            let glk_view_dlg_obj: ObjcId = msg_send![define_glk_view_dlg(), alloc];
-            let glk_view_dlg_obj: ObjcId = msg_send![glk_view_dlg_obj, init];
+            (*view.view).set_ivar("display_ptr", payload_ptr);
+            (*view.view_dlg).set_ivar("display_ptr", payload_ptr);
 
-            (*glk_view_dlg_obj).set_ivar("display_ptr", payload_ptr);
+            msg_send_![window_obj, addSubview: view.view];
 
-            let glk_view_obj: ObjcId = msg_send![define_glk_view(), alloc];
-            let glk_view_obj: ObjcId = msg_send![glk_view_obj, initWithFrame: screen_rect];
+            msg_send_![window_obj, setRootViewController: view.view_ctrl];
 
-            (*glk_view_obj).set_ivar("display_ptr", payload_ptr);
-
-            let _: () = msg_send![
-                glk_view_obj,
-                setDrawableColorFormat: frameworks::GLKViewDrawableColorFormatRGBA8888
-            ];
-            let _: () = msg_send![
-                glk_view_obj,
-                setDrawableDepthFormat: frameworks::GLKViewDrawableDepthFormat::Format24 as i32
-            ];
-            let _: () = msg_send![
-                glk_view_obj,
-                setDrawableStencilFormat: frameworks::GLKViewDrawableStencilFormat::FormatNone
-                    as i32
-            ];
-            let _: () = msg_send![glk_view_obj, setContext: eagl_context_obj];
-            let _: () = msg_send![glk_view_obj, setDelegate: glk_view_dlg_obj];
-            let _: () = msg_send![glk_view_obj, setEnableSetNeedsDisplay: NO];
-            let _: () = msg_send![glk_view_obj, setUserInteractionEnabled: YES];
-            let _: () = msg_send![glk_view_obj, setMultipleTouchEnabled: YES];
-            if conf.high_dpi {
-                let _: () = msg_send![glk_view_obj, setContentScaleFactor: 2.0];
-            } else {
-                let _: () = msg_send![glk_view_obj, setContentScaleFactor: 1.0];
-            }
-            let _: () = msg_send![window_obj, addSubview: glk_view_obj];
-
-            let view_ctrl_obj: ObjcId = msg_send![class!(GLKViewController), alloc];
-            let view_ctrl_obj: ObjcId = msg_send![view_ctrl_obj, init];
-
-            let _: () = msg_send![view_ctrl_obj, setView: glk_view_obj];
-            let _: () = msg_send![view_ctrl_obj, setPreferredFramesPerSecond:60];
-            let _: () = msg_send![window_obj, setRootViewController: view_ctrl_obj];
-
-            let _: () = msg_send![window_obj, makeKeyAndVisible];
+            msg_send_![window_obj, makeKeyAndVisible];
         }
         YES
     }
@@ -353,14 +485,11 @@ pub fn load_file<F: Fn(crate::fs::Response) + 'static>(path: &str, on_loaded: F)
 
 // this is the way to pass argument to UiApplicationMain
 // this static will be used exactly once, to .take() the "run" arguments
-static mut RUN_ARGS: Option<(
-    Box<dyn FnOnce(&mut crate::Context) -> Box<dyn EventHandler>>,
-    Conf,
-)> = None;
+static mut RUN_ARGS: Option<(Box<dyn FnOnce() -> Box<dyn EventHandler>>, Conf)> = None;
 
 pub unsafe fn run<F>(conf: Conf, f: F)
 where
-    F: 'static + FnOnce(&mut crate::Context) -> Box<dyn EventHandler>,
+    F: 'static + FnOnce() -> Box<dyn EventHandler>,
 {
     RUN_ARGS = Some((Box::new(f), conf));
 

--- a/src/native/linux_wayland/libwayland_client.rs
+++ b/src/native/linux_wayland/libwayland_client.rs
@@ -440,8 +440,9 @@ pub type wl_display_roundtrip =
 pub type wl_display_dispatch_pending =
     unsafe extern "C" fn(display: *mut wl_display) -> ::std::os::raw::c_int;
 
+#[derive(Clone)]
 pub struct LibWaylandClient {
-    _module: crate::native::module::Module,
+    _module: std::rc::Rc<crate::native::module::Module>,
     pub wl_display_connect: wl_display_connect,
     pub wl_proxy_destroy: wl_proxy_destroy,
     pub wl_proxy_marshal: wl_proxy_marshal,
@@ -494,7 +495,7 @@ impl LibWaylandClient {
                 wl_shm_interface: module.get_symbol("wl_shm_interface").unwrap(),
                 wl_shm_pool_interface: module.get_symbol("wl_shm_pool_interface").unwrap(),
 
-                _module: module,
+                _module: std::rc::Rc::new(module),
             })
             .ok()
     }

--- a/src/native/linux_x11/keycodes.rs
+++ b/src/native/linux_x11/keycodes.rs
@@ -3,171 +3,165 @@
 //!
 //! All the data entries in this file came from sokol_app.h
 
-use super::X11Display;
+use super::{Display, LibX11};
 use crate::event::{KeyCode, KeyMods, MouseButton};
 
-impl X11Display {
-    pub unsafe fn translate_key(&mut self, scancode: i32) -> KeyCode {
-        let mut dummy: libc::c_int = 0;
-        let keysyms = (self.libx11.XGetKeyboardMapping)(
-            self.display,
-            scancode as _,
-            1 as libc::c_int,
-            &mut dummy,
-        );
-        assert!(!keysyms.is_null());
+pub unsafe fn translate_key(libx11: &mut LibX11, display: *mut Display, scancode: i32) -> KeyCode {
+    let mut dummy: libc::c_int = 0;
+    let keysyms =
+        (libx11.XGetKeyboardMapping)(display, scancode as _, 1 as libc::c_int, &mut dummy);
+    assert!(!keysyms.is_null());
 
-        let keysym = *keysyms.offset(0 as libc::c_int as isize);
-        (self.libx11.XFree)(keysyms as *mut libc::c_void);
-        match keysym {
-            65307 => return KeyCode::Escape,
-            65289 => return KeyCode::Tab,
-            65505 => return KeyCode::LeftShift,
-            65506 => return KeyCode::RightShift,
-            65507 => return KeyCode::LeftControl,
-            65508 => return KeyCode::RightControl,
-            65511 | 65513 => return KeyCode::LeftAlt,
-            65406 | 65027 | 65512 | 65514 => return KeyCode::RightAlt,
-            65515 => return KeyCode::LeftSuper,
-            65516 => return KeyCode::RightSuper,
-            65383 => return KeyCode::Menu,
-            65407 => return KeyCode::NumLock,
-            65509 => return KeyCode::CapsLock,
-            65377 => return KeyCode::PrintScreen,
-            65300 => return KeyCode::ScrollLock,
-            65299 => return KeyCode::Pause,
-            65535 => return KeyCode::Delete,
-            65288 => return KeyCode::Backspace,
-            65293 => return KeyCode::Enter,
-            65360 => return KeyCode::Home,
-            65367 => return KeyCode::End,
-            65365 => return KeyCode::PageUp,
-            65366 => return KeyCode::PageDown,
-            65379 => return KeyCode::Insert,
-            65361 => return KeyCode::Left,
-            65363 => return KeyCode::Right,
-            65364 => return KeyCode::Down,
-            65362 => return KeyCode::Up,
-            65470 => return KeyCode::F1,
-            65471 => return KeyCode::F2,
-            65472 => return KeyCode::F3,
-            65473 => return KeyCode::F4,
-            65474 => return KeyCode::F5,
-            65475 => return KeyCode::F6,
-            65476 => return KeyCode::F7,
-            65477 => return KeyCode::F8,
-            65478 => return KeyCode::F9,
-            65479 => return KeyCode::F10,
-            65480 => return KeyCode::F11,
-            65481 => return KeyCode::F12,
-            65482 => return KeyCode::F13,
-            65483 => return KeyCode::F14,
-            65484 => return KeyCode::F15,
-            65485 => return KeyCode::F16,
-            65486 => return KeyCode::F17,
-            65487 => return KeyCode::F18,
-            65488 => return KeyCode::F19,
-            65489 => return KeyCode::F20,
-            65490 => return KeyCode::F21,
-            65491 => return KeyCode::F22,
-            65492 => return KeyCode::F23,
-            65493 => return KeyCode::F24,
-            65494 => return KeyCode::F25,
-            65455 => return KeyCode::KpDivide,
-            65450 => return KeyCode::KpMultiply,
-            65453 => return KeyCode::KpSubtract,
-            65451 => return KeyCode::KpAdd,
-            65438 => return KeyCode::Kp0,
-            65436 => return KeyCode::Kp1,
-            65433 => return KeyCode::Kp2,
-            65435 => return KeyCode::Kp3,
-            65430 => return KeyCode::Kp4,
-            65437 => return KeyCode::Kp5,
-            65432 => return KeyCode::Kp6,
-            65429 => return KeyCode::Kp7,
-            65431 => return KeyCode::Kp8,
-            65434 => return KeyCode::Kp9,
-            65439 => return KeyCode::KpDecimal,
-            65469 => return KeyCode::KpEqual,
-            65421 => return KeyCode::KpEnter,
-            97 => return KeyCode::A,
-            98 => return KeyCode::B,
-            99 => return KeyCode::C,
-            100 => return KeyCode::D,
-            101 => return KeyCode::E,
-            102 => return KeyCode::F,
-            103 => return KeyCode::G,
-            104 => return KeyCode::H,
-            105 => return KeyCode::I,
-            106 => return KeyCode::J,
-            107 => return KeyCode::K,
-            108 => return KeyCode::L,
-            109 => return KeyCode::M,
-            110 => return KeyCode::N,
-            111 => return KeyCode::O,
-            112 => return KeyCode::P,
-            113 => return KeyCode::Q,
-            114 => return KeyCode::R,
-            115 => return KeyCode::S,
-            116 => return KeyCode::T,
-            117 => return KeyCode::U,
-            118 => return KeyCode::V,
-            119 => return KeyCode::W,
-            120 => return KeyCode::X,
-            121 => return KeyCode::Y,
-            122 => return KeyCode::Z,
-            49 => return KeyCode::Key1,
-            50 => return KeyCode::Key2,
-            51 => return KeyCode::Key3,
-            52 => return KeyCode::Key4,
-            53 => return KeyCode::Key5,
-            54 => return KeyCode::Key6,
-            55 => return KeyCode::Key7,
-            56 => return KeyCode::Key8,
-            57 => return KeyCode::Key9,
-            48 => return KeyCode::Key0,
-            32 => return KeyCode::Space,
-            45 => return KeyCode::Minus,
-            61 => return KeyCode::Equal,
-            91 => return KeyCode::LeftBracket,
-            93 => return KeyCode::RightBracket,
-            92 => return KeyCode::Backslash,
-            59 => return KeyCode::Semicolon,
-            39 => return KeyCode::Apostrophe,
-            96 => return KeyCode::GraveAccent,
-            44 => return KeyCode::Comma,
-            46 => return KeyCode::Period,
-            47 => return KeyCode::Slash,
-            60 => return KeyCode::World1,
-            _ => return KeyCode::Unknown,
-        };
-    }
+    let keysym = *keysyms.offset(0 as libc::c_int as isize);
+    (libx11.XFree)(keysyms as *mut libc::c_void);
+    match keysym {
+        65307 => return KeyCode::Escape,
+        65289 => return KeyCode::Tab,
+        65505 => return KeyCode::LeftShift,
+        65506 => return KeyCode::RightShift,
+        65507 => return KeyCode::LeftControl,
+        65508 => return KeyCode::RightControl,
+        65511 | 65513 => return KeyCode::LeftAlt,
+        65406 | 65027 | 65512 | 65514 => return KeyCode::RightAlt,
+        65515 => return KeyCode::LeftSuper,
+        65516 => return KeyCode::RightSuper,
+        65383 => return KeyCode::Menu,
+        65407 => return KeyCode::NumLock,
+        65509 => return KeyCode::CapsLock,
+        65377 => return KeyCode::PrintScreen,
+        65300 => return KeyCode::ScrollLock,
+        65299 => return KeyCode::Pause,
+        65535 => return KeyCode::Delete,
+        65288 => return KeyCode::Backspace,
+        65293 => return KeyCode::Enter,
+        65360 => return KeyCode::Home,
+        65367 => return KeyCode::End,
+        65365 => return KeyCode::PageUp,
+        65366 => return KeyCode::PageDown,
+        65379 => return KeyCode::Insert,
+        65361 => return KeyCode::Left,
+        65363 => return KeyCode::Right,
+        65364 => return KeyCode::Down,
+        65362 => return KeyCode::Up,
+        65470 => return KeyCode::F1,
+        65471 => return KeyCode::F2,
+        65472 => return KeyCode::F3,
+        65473 => return KeyCode::F4,
+        65474 => return KeyCode::F5,
+        65475 => return KeyCode::F6,
+        65476 => return KeyCode::F7,
+        65477 => return KeyCode::F8,
+        65478 => return KeyCode::F9,
+        65479 => return KeyCode::F10,
+        65480 => return KeyCode::F11,
+        65481 => return KeyCode::F12,
+        65482 => return KeyCode::F13,
+        65483 => return KeyCode::F14,
+        65484 => return KeyCode::F15,
+        65485 => return KeyCode::F16,
+        65486 => return KeyCode::F17,
+        65487 => return KeyCode::F18,
+        65488 => return KeyCode::F19,
+        65489 => return KeyCode::F20,
+        65490 => return KeyCode::F21,
+        65491 => return KeyCode::F22,
+        65492 => return KeyCode::F23,
+        65493 => return KeyCode::F24,
+        65494 => return KeyCode::F25,
+        65455 => return KeyCode::KpDivide,
+        65450 => return KeyCode::KpMultiply,
+        65453 => return KeyCode::KpSubtract,
+        65451 => return KeyCode::KpAdd,
+        65438 => return KeyCode::Kp0,
+        65436 => return KeyCode::Kp1,
+        65433 => return KeyCode::Kp2,
+        65435 => return KeyCode::Kp3,
+        65430 => return KeyCode::Kp4,
+        65437 => return KeyCode::Kp5,
+        65432 => return KeyCode::Kp6,
+        65429 => return KeyCode::Kp7,
+        65431 => return KeyCode::Kp8,
+        65434 => return KeyCode::Kp9,
+        65439 => return KeyCode::KpDecimal,
+        65469 => return KeyCode::KpEqual,
+        65421 => return KeyCode::KpEnter,
+        97 => return KeyCode::A,
+        98 => return KeyCode::B,
+        99 => return KeyCode::C,
+        100 => return KeyCode::D,
+        101 => return KeyCode::E,
+        102 => return KeyCode::F,
+        103 => return KeyCode::G,
+        104 => return KeyCode::H,
+        105 => return KeyCode::I,
+        106 => return KeyCode::J,
+        107 => return KeyCode::K,
+        108 => return KeyCode::L,
+        109 => return KeyCode::M,
+        110 => return KeyCode::N,
+        111 => return KeyCode::O,
+        112 => return KeyCode::P,
+        113 => return KeyCode::Q,
+        114 => return KeyCode::R,
+        115 => return KeyCode::S,
+        116 => return KeyCode::T,
+        117 => return KeyCode::U,
+        118 => return KeyCode::V,
+        119 => return KeyCode::W,
+        120 => return KeyCode::X,
+        121 => return KeyCode::Y,
+        122 => return KeyCode::Z,
+        49 => return KeyCode::Key1,
+        50 => return KeyCode::Key2,
+        51 => return KeyCode::Key3,
+        52 => return KeyCode::Key4,
+        53 => return KeyCode::Key5,
+        54 => return KeyCode::Key6,
+        55 => return KeyCode::Key7,
+        56 => return KeyCode::Key8,
+        57 => return KeyCode::Key9,
+        48 => return KeyCode::Key0,
+        32 => return KeyCode::Space,
+        45 => return KeyCode::Minus,
+        61 => return KeyCode::Equal,
+        91 => return KeyCode::LeftBracket,
+        93 => return KeyCode::RightBracket,
+        92 => return KeyCode::Backslash,
+        59 => return KeyCode::Semicolon,
+        39 => return KeyCode::Apostrophe,
+        96 => return KeyCode::GraveAccent,
+        44 => return KeyCode::Comma,
+        46 => return KeyCode::Period,
+        47 => return KeyCode::Slash,
+        60 => return KeyCode::World1,
+        _ => return KeyCode::Unknown,
+    };
+}
 
-    pub unsafe fn translate_mod(&self, x11_mods: i32) -> KeyMods {
-        let mut mods = KeyMods::default();
-        if x11_mods & super::libx11::ShiftMask != 0 {
-            mods.shift = true;
-        }
-        if x11_mods & super::libx11::ControlMask != 0 {
-            mods.ctrl = true;
-        }
-        if x11_mods & super::libx11::Mod1Mask != 0 {
-            mods.alt = true;
-        }
-        if x11_mods & super::libx11::Mod4Mask != 0 {
-            mods.logo = true;
-        }
-        return mods;
+pub unsafe fn translate_mod(x11_mods: i32) -> KeyMods {
+    let mut mods = KeyMods::default();
+    if x11_mods & super::libx11::ShiftMask != 0 {
+        mods.shift = true;
     }
+    if x11_mods & super::libx11::ControlMask != 0 {
+        mods.ctrl = true;
+    }
+    if x11_mods & super::libx11::Mod1Mask != 0 {
+        mods.alt = true;
+    }
+    if x11_mods & super::libx11::Mod4Mask != 0 {
+        mods.logo = true;
+    }
+    return mods;
+}
 
-    pub unsafe fn translate_mouse_button(&self, button: i32) -> MouseButton {
-        match button {
-            1 => return MouseButton::Left,
-            2 => return MouseButton::Middle,
-            3 => return MouseButton::Right,
-            _ => return MouseButton::Unknown,
-        };
-    }
+pub unsafe fn translate_mouse_button(button: i32) -> MouseButton {
+    match button {
+        1 => return MouseButton::Left,
+        2 => return MouseButton::Middle,
+        3 => return MouseButton::Right,
+        _ => return MouseButton::Unknown,
+    };
 }
 
 #[derive(Copy, Clone)]
@@ -1069,35 +1063,33 @@ const KEYSYMTAB: [CodePair; 884] = [
     CodePair::new(0xffff /*	Delete	    */, 0xf000 + 76u16),
 ];
 
-impl X11Display {
-    pub unsafe extern "C" fn keysym_to_unicode(&self, keysym: super::libx11::KeySym) -> i32 {
-        let mut min = 0 as libc::c_int;
-        let mut max = (::std::mem::size_of::<[CodePair; 884]>() as libc::c_ulong)
-            .wrapping_div(::std::mem::size_of::<CodePair>() as libc::c_ulong)
-            .wrapping_sub(1 as libc::c_int as libc::c_ulong) as libc::c_int;
-        let mut mid;
-        if (keysym >= 0x20 as libc::c_int as libc::c_ulong
-            && keysym <= 0x7e as libc::c_int as libc::c_ulong)
-            || (keysym >= 0xa0 as libc::c_int as libc::c_ulong
-                && keysym <= 0xff as libc::c_int as libc::c_ulong)
-        {
-            return keysym as i32;
-        }
-        if keysym & 0xff000000 as libc::c_uint as libc::c_ulong
-            == 0x1000000 as libc::c_int as libc::c_ulong
-        {
-            return (keysym & 0xffffff as libc::c_int as libc::c_ulong) as i32;
-        }
-        while max >= min {
-            mid = (min + max) / 2 as libc::c_int;
-            if (KEYSYMTAB[mid as usize].keysym as libc::c_ulong) < keysym {
-                min = mid + 1 as libc::c_int
-            } else if KEYSYMTAB[mid as usize].keysym as libc::c_ulong > keysym {
-                max = mid - 1 as libc::c_int
-            } else {
-                return KEYSYMTAB[mid as usize].ucs as i32;
-            }
-        }
-        return -(1 as libc::c_int);
+pub unsafe extern "C" fn keysym_to_unicode(keysym: super::libx11::KeySym) -> i32 {
+    let mut min = 0 as libc::c_int;
+    let mut max = (::std::mem::size_of::<[CodePair; 884]>() as libc::c_ulong)
+        .wrapping_div(::std::mem::size_of::<CodePair>() as libc::c_ulong)
+        .wrapping_sub(1 as libc::c_int as libc::c_ulong) as libc::c_int;
+    let mut mid;
+    if (keysym >= 0x20 as libc::c_int as libc::c_ulong
+        && keysym <= 0x7e as libc::c_int as libc::c_ulong)
+        || (keysym >= 0xa0 as libc::c_int as libc::c_ulong
+            && keysym <= 0xff as libc::c_int as libc::c_ulong)
+    {
+        return keysym as i32;
     }
+    if keysym & 0xff000000 as libc::c_uint as libc::c_ulong
+        == 0x1000000 as libc::c_int as libc::c_ulong
+    {
+        return (keysym & 0xffffff as libc::c_int as libc::c_ulong) as i32;
+    }
+    while max >= min {
+        mid = (min + max) / 2 as libc::c_int;
+        if (KEYSYMTAB[mid as usize].keysym as libc::c_ulong) < keysym {
+            min = mid + 1 as libc::c_int
+        } else if KEYSYMTAB[mid as usize].keysym as libc::c_ulong > keysym {
+            max = mid - 1 as libc::c_int
+        } else {
+            return KEYSYMTAB[mid as usize].ucs as i32;
+        }
+    }
+    return -(1 as libc::c_int);
 }

--- a/src/native/linux_x11/libx11_ex.rs
+++ b/src/native/linux_x11/libx11_ex.rs
@@ -1,0 +1,194 @@
+// little helpers for LibX11
+use super::*;
+
+impl LibX11 {
+    pub unsafe fn update_system_dpi(&mut self, display: *mut Display) -> f32 {
+        let mut dpi_scale = 1.;
+        let rms = (self.XResourceManagerString)(display);
+        if !rms.is_null() {
+            let db = (self.XrmGetStringDatabase)(rms);
+            if !db.is_null() {
+                let mut value = XrmValue {
+                    size: 0,
+                    addr: 0 as *mut libc::c_char,
+                };
+                let mut type_ = std::ptr::null_mut();
+                if (self.XrmGetResource)(
+                    db,
+                    b"Xft.dpi\x00".as_ptr() as _,
+                    b"Xft.Dpi\x00".as_ptr() as _,
+                    &mut type_,
+                    &mut value,
+                ) != 0
+                {
+                    if !type_.is_null() && libc::strcmp(type_, b"String\x00".as_ptr() as _) == 0 {
+                        dpi_scale = libc::atof(value.addr as *const _) as f32 / 96.0;
+                    }
+                }
+                (self.XrmDestroyDatabase)(db);
+            }
+        };
+        dpi_scale
+    }
+
+    pub unsafe fn grab_error_handler(&mut self) {
+        pub unsafe extern "C" fn _sapp_x11_error_handler(
+            mut _display: *mut Display,
+            event: *mut XErrorEvent,
+        ) -> libc::c_int {
+            println!("Error: {}", (*event).error_code);
+            return 0 as libc::c_int;
+        }
+
+        (self.XSetErrorHandler)(Some(
+            _sapp_x11_error_handler
+                as unsafe extern "C" fn(_: *mut Display, _: *mut XErrorEvent) -> libc::c_int,
+        ));
+    }
+
+    pub unsafe fn release_error_handler(&mut self, display: *mut Display) {
+        (self.XSync)(display, false as _);
+        (self.XSetErrorHandler)(None);
+    }
+
+    pub unsafe fn query_window_size(
+        &mut self,
+        display: *mut Display,
+        window: Window,
+    ) -> (i32, i32) {
+        let mut attribs: XWindowAttributes = std::mem::zeroed();
+        (self.XGetWindowAttributes)(display, window, &mut attribs);
+        (attribs.width, attribs.height)
+    }
+
+    pub unsafe fn update_window_title(&mut self, display: *mut Display, window: Window, title: &str) {
+        let c_title = std::ffi::CString::new(title).unwrap();
+
+        (self.Xutf8SetWMProperties)(
+            display,
+            window,
+            c_title.as_ptr(),
+            c_title.as_ptr(),
+            std::ptr::null_mut(),
+            0 as libc::c_int,
+            std::ptr::null_mut(),
+            std::ptr::null_mut(),
+            std::ptr::null_mut(),
+        );
+        (self.XChangeProperty)(
+            display,
+            window,
+            self.extensions.net_wm_name,
+            self.extensions.utf8_string,
+            8 as libc::c_int,
+            PropModeReplace,
+            c_title.as_ptr() as *mut libc::c_uchar,
+            libc::strlen(c_title.as_ptr()) as libc::c_int,
+        );
+        (self.XChangeProperty)(
+            display,
+            window,
+            self.extensions.net_wm_icon_name,
+            self.extensions.utf8_string,
+            8 as libc::c_int,
+            PropModeReplace,
+            c_title.as_ptr() as *mut libc::c_uchar,
+            libc::strlen(c_title.as_ptr()) as libc::c_int,
+        );
+        (self.XFlush)(display);
+    }
+
+    pub unsafe fn create_window(
+        &mut self,
+        root: Window,
+        display: *mut Display,
+        visual: *mut Visual,
+        depth: libc::c_int,
+        conf: &crate::conf::Conf,
+    ) -> Window {
+        let mut wa = XSetWindowAttributes {
+            background_pixmap: 0,
+            background_pixel: 0,
+            border_pixmap: 0,
+            border_pixel: 0,
+            bit_gravity: 0,
+            win_gravity: 0,
+            backing_store: 0,
+            backing_planes: 0,
+            backing_pixel: 0,
+            save_under: 0,
+            event_mask: 0,
+            do_not_propagate_mask: 0,
+            override_redirect: 0,
+            colormap: 0,
+            cursor: 0,
+        };
+        libc::memset(
+            &mut wa as *mut XSetWindowAttributes as *mut libc::c_void,
+            0 as libc::c_int,
+            ::std::mem::size_of::<XSetWindowAttributes>() as _,
+        );
+        let wamask = (CWBorderPixel | CWColormap | CWEventMask) as u32;
+
+        if !visual.is_null() {
+            let colormap = (self.XCreateColormap)(display, root, visual, AllocNone);
+            wa.colormap = colormap;
+        }
+        wa.border_pixel = 0 as libc::c_int as libc::c_ulong;
+        wa.event_mask = StructureNotifyMask
+            | KeyPressMask
+            | KeyReleaseMask
+            | PointerMotionMask
+            | ButtonPressMask
+            | ButtonReleaseMask
+            | ExposureMask
+            | FocusChangeMask
+            | VisibilityChangeMask
+            | EnterWindowMask
+            | LeaveWindowMask
+            | PropertyChangeMask;
+        self.grab_error_handler();
+
+        let window = (self.XCreateWindow)(
+            display,
+            root,
+            0 as libc::c_int,
+            0 as libc::c_int,
+            conf.window_width as _,
+            conf.window_height as _,
+            0 as libc::c_int as libc::c_uint,
+            depth,
+            InputOutput as libc::c_uint,
+            visual,
+            wamask as libc::c_ulong,
+            &mut wa,
+        );
+        self.release_error_handler(display);
+        assert!(window != 0, "X11: Failed to create window");
+
+        let mut protocols: [Atom; 1] = [self.extensions.wm_delete_window];
+        (self.XSetWMProtocols)(display, window, protocols.as_mut_ptr(), 1 as libc::c_int);
+        let mut hints = (self.XAllocSizeHints)();
+        (*hints).flags |= PWinGravity;
+        if conf.window_resizable == false {
+            (*hints).flags |= PMinSize | PMaxSize;
+            (*hints).min_width = conf.window_width;
+            (*hints).min_height = conf.window_height;
+            (*hints).max_width = conf.window_width;
+            (*hints).max_height = conf.window_height;
+        }
+        (*hints).win_gravity = StaticGravity;
+        (self.XSetWMNormalHints)(display, window, hints);
+        (self.XFree)(hints as *mut libc::c_void);
+
+        self.update_window_title(display, window, &conf.window_title);
+
+        window
+    }
+
+    pub unsafe fn show_window(&mut self, display: *mut Display, window: Window) {
+        (self.XMapWindow)(display, window);
+        (self.XRaiseWindow)(display, window);
+        (self.XFlush)(display);
+    }
+}

--- a/src/native/macos.rs
+++ b/src/native/macos.rs
@@ -335,7 +335,8 @@ unsafe fn get_proc_address(name: *const u8) -> Option<unsafe extern "C" fn()> {
     Some(unsafe { std::mem::transmute_copy(&symbol) })
 }
 
-unsafe fn wtf(decl: &mut ClassDecl) {
+// methods for both metal or opengl view
+unsafe fn view_base_decl(decl: &mut ClassDecl) {
     extern "C" fn mouse_moved(this: &Object, _sel: Sel, event: ObjcId) {
         let payload = get_window_payload(this);
 
@@ -592,7 +593,7 @@ pub fn define_opengl_view_class() -> *const Class {
             draw_rect as extern "C" fn(&Object, Sel, NSRect),
         );
 
-        wtf(&mut decl);
+        view_base_decl(&mut decl);
     }
 
     decl.add_ivar::<*mut c_void>("display_ptr");
@@ -643,7 +644,7 @@ pub fn define_metal_view_class() -> *const Class {
             draw_rect as extern "C" fn(&Object, Sel, NSRect),
         );
 
-        wtf(&mut decl);
+        view_base_decl(&mut decl);
     }
 
     return decl.register();

--- a/src/native/wasm/webgl.rs
+++ b/src/native/wasm/webgl.rs
@@ -2,6 +2,8 @@
 //! The only way to get gl functions - actually tell the linker to link with
 //! their gl.js counterparts.
 
+#![allow(non_snake_case, non_camel_case_types, non_upper_case_globals)]
+
 pub type GLenum = ::std::os::raw::c_uint;
 pub type GLboolean = ::std::os::raw::c_uchar;
 pub type GLbitfield = ::std::os::raw::c_uint;
@@ -1242,6 +1244,18 @@ extern "C" {
     pub fn glClearBufferiv(buffer: GLenum, drawbuffer: GLint, value: *const GLint);
 }
 extern "C" {
+    pub fn glClearBufferuiv(buffer: GLenum, drawbuffer: GLint, value: *const GLuint);
+}
+extern "C" {
+    pub fn glClearBufferfv(buffer: GLenum, drawbuffer: GLint, value: *const GLfloat);
+}
+extern "C" {
+    pub fn glClearBufferfi(buffer: GLenum, drawbuffer: GLint, depth: GLfloat, stencil: GLint);
+}
+extern "C" {
+    pub fn glGetStringi(name: GLenum, index: GLuint) -> *const GLubyte;
+}
+extern "C" {
     pub fn glCopyBufferSubData(
         readTarget: GLenum,
         writeTarget: GLenum,
@@ -1460,4 +1474,8 @@ extern "C" {
         bufSize: GLsizei,
         params: *mut GLint,
     );
+}
+
+pub unsafe fn is_gl2() -> bool {
+    false
 }

--- a/src/native/windows.rs
+++ b/src/native/windows.rs
@@ -2,7 +2,7 @@ use crate::{
     conf::{Conf, Icon},
     event::{KeyMods, MouseButton},
     native::NativeDisplayData,
-    Context, CursorIcon, EventHandler, GraphicsContext,
+    CursorIcon, EventHandler,
 };
 
 use winapi::{
@@ -28,7 +28,7 @@ mod wgl;
 
 use libopengl32::LibOpengl32;
 
-pub(crate) struct Display {
+pub(crate) struct WindowsDisplay {
     fullscreen: bool,
     dpi_aware: bool,
     window_resizable: bool,
@@ -50,7 +50,39 @@ pub(crate) struct Display {
     dc: HDC,
 }
 
-impl crate::native::NativeDisplay for Display {
+mod tl_display {
+    use super::*;
+    use crate::NATIVE_DISPLAY;
+
+    use std::cell::RefCell;
+
+    thread_local! {
+        static DISPLAY: RefCell<Option<WindowsDisplay>> = RefCell::new(None);
+    }
+
+    fn with_native_display(f: &mut dyn FnMut(&mut dyn crate::NativeDisplay)) {
+        DISPLAY.with(|d| {
+            let mut d = d.borrow_mut();
+            let mut d = d.as_mut().unwrap();
+            f(&mut *d);
+        })
+    }
+
+    pub(super) fn with<T>(mut f: impl FnMut(&mut WindowsDisplay) -> T) -> T {
+        DISPLAY.with(|d| {
+            let mut d = d.borrow_mut();
+            let mut d = d.as_mut().unwrap();
+            f(&mut *d)
+        })
+    }
+
+    pub(super) fn set_display(display: WindowsDisplay) {
+        DISPLAY.with(|d| *d.borrow_mut() = Some(display));
+        NATIVE_DISPLAY.with(|d| *d.borrow_mut() = Some(with_native_display));
+    }
+}
+
+impl crate::native::NativeDisplay for WindowsDisplay {
     fn screen_size(&self) -> (f32, f32) {
         (
             self.display_data.screen_width as _,
@@ -158,7 +190,10 @@ impl crate::native::NativeDisplay for Display {
         let win_style: DWORD = get_win_style(self.fullscreen, self.window_resizable);
 
         unsafe {
-            SetWindowLongPtrA(self.wnd, GWL_STYLE, win_style as _);
+            #[cfg(target = "x86_64")]
+            SetWindowLongPtrA(wnd, GWLP_USERDATA, win_style as _);
+            #[cfg(target = "i686")]
+            SetWindowLong(wnd, GWLP_USERDATA, win_style as _);
 
             if self.fullscreen {
                 SetWindowPos(
@@ -199,8 +234,6 @@ impl crate::native::NativeDisplay for Display {
 
 struct WindowPayload {
     event_handler: Box<dyn EventHandler>,
-    context: GraphicsContext,
-    display: Display,
 }
 
 fn get_win_style(is_fullscreen: bool, is_resizable: bool) -> DWORD {
@@ -271,38 +304,54 @@ unsafe extern "system" fn win32_wndproc(
     wparam: WPARAM,
     lparam: LPARAM,
 ) -> LRESULT {
-    let display_ptr = GetWindowLongPtrA(hwnd, GWLP_USERDATA);
+    let mut display_ptr: isize = 0;
+
+    #[cfg(target = "x86_64")]
+    {
+        display_ptr = GetWindowLongPtrA(hwnd, GWLP_USERDATA)
+    }
+
+    #[cfg(target = "i686")]
+    {
+        display_ptr = GetWindowLong(hwnd, GWLP_USERDATA)
+    }
+
     if display_ptr == 0 {
         return DefWindowProcW(hwnd, umsg, wparam, lparam);
     }
     let &mut WindowPayload {
-        ref mut display,
-        ref mut context,
         ref mut event_handler,
     } = &mut *(display_ptr as *mut WindowPayload);
 
     match umsg {
         WM_CLOSE => {
-            // only give user a chance to intervene when sapp_quit() wasn't already called
-            if !display.display_data.quit_ordered {
-                // if window should be closed and event handling is enabled, give user code
-                // a change to intervene via sapp_cancel_quit()
-                display.display_data.quit_requested = true;
-                event_handler.quit_requested_event(context.with_display(display));
-                // if user code hasn't intervened, quit the app
-                if display.display_data.quit_requested {
-                    display.display_data.quit_ordered = true;
+            let mut quit_requested = false;
+
+            tl_display::with(|display| {
+                // only give user a chance to intervene when sapp_quit() wasn't already called
+                if !display.display_data.quit_ordered {
+                    // if window should be closed and event handling is enabled, give user code
+                    // a change to intervene via sapp_cancel_quit()
+                    display.display_data.quit_requested = true;
+                    quit_requested = true;
+                    // if user code hasn't intervened, quit the app
+                    if display.display_data.quit_requested {
+                        display.display_data.quit_ordered = true;
+                    }
                 }
-            }
-            if display.display_data.quit_ordered {
-                PostQuitMessage(0);
+                if display.display_data.quit_ordered {
+                    PostQuitMessage(0);
+                }
+            });
+            if quit_requested {
+                event_handler.quit_requested_event();
             }
             return 0;
         }
         WM_SYSCOMMAND => {
             match wparam & 0xFFF0 {
                 SC_SCREENSAVE | SC_MONITORPOWER => {
-                    if display.fullscreen {
+                    if tl_display::with(|d| d.fullscreen) {
                         // disable screen saver and blanking in fullscreen mode
                         return 0;
                     }
@@ -318,91 +367,68 @@ unsafe extern "system" fn win32_wndproc(
             return 1;
         }
         WM_SIZE => {
-            if display.cursor_grabbed {
+            if tl_display::with(|d| d.cursor_grabbed) {
                 update_clip_rect(hwnd);
             }
 
             let iconified = wparam == SIZE_MINIMIZED;
-            if iconified != display.iconified {
-                display.iconified = iconified;
+            if iconified != tl_display::with(|d| d.iconified) {
+                tl_display::with(|d| d.iconified = iconified);
                 if iconified {
-                    event_handler.window_minimized_event(context.with_display(display));
+                    event_handler.window_minimized_event();
                 } else {
-                    event_handler.window_restored_event(context.with_display(display));
+                    event_handler.window_restored_event();
                 }
             }
         }
         WM_SETCURSOR => {
-            if display.user_cursor && LOWORD(lparam as _) == HTCLIENT as _ {
-                SetCursor(display.cursor);
+            if tl_display::with(|d| d.user_cursor) && LOWORD(lparam as _) == HTCLIENT as _ {
+                SetCursor(tl_display::with(|d| d.cursor));
 
                 return 1;
             }
         }
         WM_LBUTTONDOWN => {
-            let mouse_x = display.mouse_x;
-            let mouse_y = display.mouse_y;
-            event_handler.mouse_button_down_event(
-                context.with_display(display),
-                MouseButton::Left,
-                mouse_x,
-                mouse_y,
-            );
+            let mouse_x = tl_display::with(|d| d.mouse_x);
+            let mouse_y = tl_display::with(|d| d.mouse_y);
+            event_handler.mouse_button_down_event(MouseButton::Left, mouse_x, mouse_y);
         }
         WM_RBUTTONDOWN => {
-            let mouse_x = display.mouse_x;
-            let mouse_y = display.mouse_y;
-            event_handler.mouse_button_down_event(
-                context.with_display(display),
-                MouseButton::Right,
-                mouse_x,
-                mouse_y,
-            );
+            let mouse_x = tl_display::with(|d| d.mouse_x);
+            let mouse_y = tl_display::with(|d| d.mouse_y);
+
+            event_handler.mouse_button_down_event(MouseButton::Right, mouse_x, mouse_y);
         }
         WM_MBUTTONDOWN => {
-            let mouse_x = display.mouse_x;
-            let mouse_y = display.mouse_y;
-            event_handler.mouse_button_down_event(
-                context.with_display(display),
-                MouseButton::Middle,
-                mouse_x,
-                mouse_y,
-            );
+            let mouse_x = tl_display::with(|d| d.mouse_x);
+            let mouse_y = tl_display::with(|d| d.mouse_y);
+
+            event_handler.mouse_button_down_event(MouseButton::Middle, mouse_x, mouse_y);
         }
         WM_LBUTTONUP => {
-            let mouse_x = display.mouse_x;
-            let mouse_y = display.mouse_y;
-            event_handler.mouse_button_up_event(
-                context.with_display(display),
-                MouseButton::Left,
-                mouse_x,
-                mouse_y,
-            );
+            let mouse_x = tl_display::with(|d| d.mouse_x);
+            let mouse_y = tl_display::with(|d| d.mouse_y);
+
+            event_handler.mouse_button_up_event(MouseButton::Left, mouse_x, mouse_y);
         }
         WM_RBUTTONUP => {
-            let mouse_x = display.mouse_x;
-            let mouse_y = display.mouse_y;
-            event_handler.mouse_button_up_event(
-                context.with_display(display),
-                MouseButton::Right,
-                mouse_x,
-                mouse_y,
-            );
+            let mouse_x = tl_display::with(|d| d.mouse_x);
+            let mouse_y = tl_display::with(|d| d.mouse_y);
+
+            event_handler.mouse_button_up_event(MouseButton::Right, mouse_x, mouse_y);
         }
         WM_MBUTTONUP => {
-            let mouse_x = display.mouse_x;
-            let mouse_y = display.mouse_y;
-            event_handler.mouse_button_up_event(
-                context.with_display(display),
-                MouseButton::Middle,
-                mouse_x,
-                mouse_y,
-            );
+            let mouse_x = tl_display::with(|d| d.mouse_x);
+            let mouse_y = tl_display::with(|d| d.mouse_y);
+
+            event_handler.mouse_button_up_event(MouseButton::Middle, mouse_x, mouse_y);
         }
 
         WM_MOUSEMOVE => {
-            display.mouse_x = GET_X_LPARAM(lparam) as f32 * display.mouse_scale;
-            display.mouse_y = GET_Y_LPARAM(lparam) as f32 * display.mouse_scale;
+            tl_display::with(|d| {
+                d.mouse_x = GET_X_LPARAM(lparam) as f32 * d.mouse_scale;
+                d.mouse_y = GET_Y_LPARAM(lparam) as f32 * d.mouse_scale;
+            });
 
             // mouse enter was not handled by miniquad anyway
             // if !_sapp.win32_mouse_tracked {
@@ -420,13 +446,13 @@ unsafe extern "system" fn win32_wndproc(
             //     );
             // }
 
-            let mouse_x = display.mouse_x;
-            let mouse_y = display.mouse_y;
+            let mouse_x = tl_display::with(|d| d.mouse_x);
+            let mouse_y = tl_display::with(|d| d.mouse_y);
 
-            event_handler.mouse_motion_event(context.with_display(display), mouse_x, mouse_y);
+            event_handler.mouse_motion_event(mouse_x, mouse_y);
         }
 
-        WM_MOVE if display.cursor_grabbed => {
+        WM_MOVE if tl_display::with(|d| d.cursor_grabbed) => {
             update_clip_rect(hwnd);
         }
 
@@ -448,9 +474,10 @@ unsafe extern "system" fn win32_wndproc(
                 unimplemented!("Got MOUSE_MOVE_ABSOLUTE on WM_INPUT, related issue: https://github.com/not-fl3/miniquad/issues/165");
             }
 
-            let dx = data.data.mouse().lLastX as f32 * display.mouse_scale;
-            let dy = data.data.mouse().lLastY as f32 * display.mouse_scale;
-            event_handler.raw_mouse_motion(context.with_display(display), dx as f32, dy as f32);
+            let mouse_scale = tl_display::with(|d| d.mouse_scale);
+            let dx = data.data.mouse().lLastX as f32 * mouse_scale;
+            let dy = data.data.mouse().lLastY as f32 * mouse_scale;
+            event_handler.raw_mouse_motion(dx as f32, dy as f32);
         }
 
         WM_MOUSELEAVE => {
@@ -462,19 +489,11 @@ unsafe extern "system" fn win32_wndproc(
             // );
         }
         WM_MOUSEWHEEL => {
-            event_handler.mouse_wheel_event(
-                context.with_display(display),
-                0.0,
-                (HIWORD(wparam as _) as i16) as f32,
-            );
+            event_handler.mouse_wheel_event(0.0, (HIWORD(wparam as _) as i16) as f32);
         }
 
         WM_MOUSEHWHEEL => {
-            event_handler.mouse_wheel_event(
-                context.with_display(display),
-                (HIWORD(wparam as _) as i16) as f32,
-                0.0,
-            );
+            event_handler.mouse_wheel_event((HIWORD(wparam as _) as i16) as f32, 0.0);
         }
         WM_CHAR => {
             let chr = wparam as u32;
@@ -482,7 +501,7 @@ unsafe extern "system" fn win32_wndproc(
             let mods = key_mods();
             if chr > 0 {
                 if let Some(chr) = std::char::from_u32(chr as u32) {
-                    event_handler.char_event(context.with_display(display), chr, mods, repeat);
+                    event_handler.char_event(chr, mods, repeat);
                 }
             }
         }
@@ -491,13 +510,13 @@ unsafe extern "system" fn win32_wndproc(
             let keycode = keycodes::translate_keycode(keycode);
             let mods = key_mods();
             let repeat = !!(lparam & 0x40000000) != 0;
-            event_handler.key_down_event(context.with_display(display), keycode, mods, repeat);
+            event_handler.key_down_event(keycode, mods, repeat);
         }
         WM_KEYUP | WM_SYSKEYUP => {
             let keycode = HIWORD(lparam as _) as u32 & 0x1FF;
             let keycode = keycodes::translate_keycode(keycode);
             let mods = key_mods();
-            event_handler.key_up_event(context.with_display(display), keycode, mods);
+            event_handler.key_up_event(keycode, mods);
         }
 
         _ => {}
@@ -722,7 +741,7 @@ unsafe fn create_msg_window() -> (HWND, HDC) {
     (msg_hwnd, msg_dc)
 }
 
-impl Display {
+impl WindowsDisplay {
     unsafe fn get_proc_address(&mut self, proc: &str) -> Option<unsafe extern "C" fn() -> ()> {
         let proc = std::ffi::CString::new(proc).unwrap();
         let mut proc_ptr = (self.libopengl32.wglGetProcAddress)(proc.as_ptr());
@@ -793,7 +812,7 @@ impl Display {
 
 pub fn run<F>(conf: &Conf, f: F)
 where
-    F: 'static + FnOnce(&mut Context) -> Box<dyn EventHandler>,
+    F: 'static + FnOnce() -> Box<dyn EventHandler>,
 {
     unsafe {
         if conf.high_dpi {
@@ -813,7 +832,7 @@ where
         let libopengl32 = LibOpengl32::try_load().expect("Failed to load opengl32.dll.");
 
         let (msg_wnd, msg_dc) = create_msg_window();
-        let mut display = Display {
+        let mut display = WindowsDisplay {
             fullscreen: false,
             dpi_aware: false,
             window_resizable: conf.window_resizable,
@@ -847,21 +866,20 @@ where
 
         super::gl::load_gl_funcs(|proc| display.get_proc_address(proc));
 
-        let mut context = GraphicsContext::new(crate::gl::is_gl2());
+        tl_display::set_display(display);
 
-        let event_handler = f(context.with_display(&mut display));
+        let event_handler = f();
 
-        let mut p = WindowPayload {
-            display,
-            context,
-            event_handler,
-        };
+        let mut p = WindowPayload { event_handler };
         // well, technically this is UB and we are suppose to use *mut WindowPayload instead of &mut WindowPayload forever from now on...
         // so if there going to be some weird bugs someday in the future - check this out!
+        #[cfg(target = "x86_64")]
         SetWindowLongPtrA(wnd, GWLP_USERDATA, &mut p as *mut _ as isize);
+        #[cfg(target = "i686")]
+        SetWindowLong(wnd, GWLP_USERDATA, &mut p as *mut _ as isize);
 
         let mut done = false;
-        while !(done || p.display.display_data.quit_ordered) {
+        while !(done || tl_display::with(|d| d.display_data.quit_ordered)) {
             let mut msg: MSG = std::mem::zeroed();
             while PeekMessageW(&mut msg as *mut _ as _, NULL as _, 0, 0, PM_REMOVE) != 0 {
                 if WM_QUIT == msg.message {
@@ -872,22 +890,26 @@ where
                     DispatchMessageW(&mut msg as *mut _ as _);
                 }
             }
-            p.event_handler
-                .update(p.context.with_display(&mut p.display));
-            p.event_handler.draw(p.context.with_display(&mut p.display));
-            SwapBuffers(p.display.dc);
+            p.event_handler.update();
+            p.event_handler.draw();
 
-            if p.display.update_dimensions(wnd) {
-                let width = p.display.display_data.screen_width as _;
-                let height = p.display.display_data.screen_height as _;
-                p.event_handler
-                    .resize_event(p.context.with_display(&mut p.display), width, height);
+            SwapBuffers(tl_display::with(|d| d.dc));
+
+            if tl_display::with(|d| d.update_dimensions(wnd)) {
+                let width = tl_display::with(|d| d.display_data.screen_width as f32);
+                let height = tl_display::with(|d| d.display_data.screen_height as f32);
+                p.event_handler.resize_event(width, height);
             }
-            if p.display.display_data.quit_requested {
-                PostMessageW(p.display.wnd, WM_CLOSE, 0, 0);
-            }
+            tl_display::with(|d| {
+                if d.display_data.quit_requested {
+                    PostMessageW(d.wnd, WM_CLOSE, 0, 0);
+                }
+            });
         }
-        (p.display.libopengl32.wglDeleteContext)(gl_ctx);
+
+        tl_display::with(|d| {
+            (d.libopengl32.wglDeleteContext)(gl_ctx);
+        });
         DestroyWindow(wnd);
     }
 }

--- a/src/native/windows/wgl.rs
+++ b/src/native/windows/wgl.rs
@@ -7,7 +7,7 @@ use winapi::{
     um::{errhandlingapi::GetLastError, wingdi::*},
 };
 
-use super::{Display, LibOpengl32};
+use super::{LibOpengl32, WindowsDisplay};
 
 pub const WGL_NUMBER_PIXEL_FORMATS_ARB: u32 = 0x2000;
 pub const WGL_SUPPORT_OPENGL_ARB: u32 = 0x2010;
@@ -211,7 +211,7 @@ unsafe fn get_wgl_proc_address<T>(libopengl32: &mut LibOpengl32, proc: &str) -> 
 }
 
 impl Wgl {
-    pub(crate) unsafe fn new(display: &mut Display) -> Wgl {
+    pub(crate) unsafe fn new(display: &mut WindowsDisplay) -> Wgl {
         let mut pfd: PIXELFORMATDESCRIPTOR = std::mem::zeroed();
         pfd.nSize = std::mem::size_of_val(&pfd) as _;
         pfd.nVersion = 1;
@@ -294,7 +294,12 @@ impl Wgl {
         }
     }
 
-    unsafe fn wgl_attrib(&self, display: &mut Display, pixel_format: i32, attrib: i32) -> i32 {
+    unsafe fn wgl_attrib(
+        &self,
+        display: &mut WindowsDisplay,
+        pixel_format: i32,
+        attrib: i32,
+    ) -> i32 {
         let mut value = 0;
         if !(self.GetPixelFormatAttribivARB.unwrap())(
             display.dc,
@@ -309,7 +314,7 @@ impl Wgl {
         return value;
     }
 
-    unsafe fn wgl_find_pixel_format(&self, display: &mut Display, sample_count: i32) -> u32 {
+    unsafe fn wgl_find_pixel_format(&self, display: &mut WindowsDisplay, sample_count: i32) -> u32 {
         let native_count = self.wgl_attrib(display, 1, WGL_NUMBER_PIXEL_FORMATS_ARB as _);
         let mut usable_configs = vec![GlFbconfig::default(); native_count as usize];
 
@@ -367,7 +372,7 @@ impl Wgl {
 
     pub(crate) unsafe fn create_context(
         &mut self,
-        display: &mut Display,
+        display: &mut WindowsDisplay,
         sample_count: i32,
         swap_interval: i32,
     ) -> HGLRC {


### PR DESCRIPTION
This PR introduce Metal backend and multi-backend possibilities in general. A lot of breaking changed happened!

## Api changes: 

No more "Context" for event handlers. 
RenderingBackend is now owned by the client code, and for window manipulation miniquad now provide a static "window" module. 

For events, it looks like:
```diff
impl EventHandler for Stage {
-    fn update(&mut self, _ctx: &mut Context) {
+    fn update(&mut self) {
```

For functions that used to be part of the context, it became:
```diff
- ctx.screen_size();
+ window::screen_size()
```

And for rendering functions, now its 
```rust
let gl_context = GlContext::new();

gl_context.begin_default_pass();
```

In multiple places miniquad used to receive arguments like this: 
```
pub fn immutable<T>(ctx: &mut Context, buffer_type: BufferType, data: &[T]) -> Buffer;
```
With rendering backend being a trait object, this is no longer possible. 
Now it looks like this: 
```rust
fn new_buffer_immutable(&mut self, buffer_type: BufferType, data: BufferSource) -> BufferId;
```

On the call site, the change required is:
```diff
- .. &indices);
+ BufferSource::slice(&indices));
```

## Multiple rendering backens

Miniquad do not automatically choose which rendering backend to use.

```rust
conf.platform.apple_gfx_api = if metal {
        conf::AppleGfxApi::Metal
    } else {
        conf::AppleGfxApi::OpenGl
    };
miniquad::start(conf, ..);
```

For `OpenGL`, `GlContext::new()` will panic, on `Metal`, `MetalContext::new()` will panic. 

Miniquad got a little helper to create an appropriate render context, 
```rust
let mut ctx: Box<dyn RenderingBackend> = window::new_rendering_backend();
```

Same for shaders, miniquad do not cross-compile or post-process shaders, this is the job for a libraries. 

```diff
- Shader::new(ctx, shader::VERTEX, shader::FRAGMENT, shader::meta());
+ ctx.new_shader(ShaderSource {
+   glsl_vertex: Some(shader::VERTEX),
+   glsl_fragment: Some(shader::FRAGMENT),
+   metal_shader: Some(shader::METAL),
+ }, shader::meta()),
```

# Meta 

This is going to be published as 0.4-alpha, with the code living in 0.4 branch. Last time, 0.3-alpha was in alpha forever and, basically, was the version to use. This mistake is going to be fixed this time - 0.4-alpha really is alpha, just for preview and testing. 0.3/gh-master is the branch to use!

# What's missing to go from 0.4-alpha to 0.4

- a bunch of RenderingBackend functions are not implemented for metal: https://github.com/not-fl3/miniquad/compare/0.4...metal?expand=1#diff-398de6bdf9c98a030badebd4bd1cd9bf97c35e412d56ce0c25082290b70948c6R343

- in both gl and metal miniquad now use a always-growing array to generate unique ids. This should be replaced by some sort of a generational array

- in metal, there are a bunch of `retain` calls thrown randomly here and there to prevent the runtime to collect garbage to early. Need to be more careful with memory and double check that all the ObjC pointers are managed correctly

- naming and the API design in general. This is going to be the last chance (for quite some time) to make a lot of breaking changes and fix all the naming inconsistencies. 
