### PR TITLE
Fixes for x11 and focus events for x11 and wasm

### DIFF
--- a/js/gl.js
+++ b/js/gl.js
@@ -1253,6 +1253,18 @@ var importObject = {
                 wasm_exports.on_files_dropped_finish();
             };
 
+            let lastFocus = document.hasFocus();
+            var checkFocus = function() {
+                let hasFocus = document.hasFocus();
+                if(lastFocus == hasFocus){
+                    wasm_exports.focus(hasFocus);
+                    lastFocus = hasFocus;
+                }
+            }
+            document.addEventListener("visibilitychange", checkFocus);
+            window.addEventListener("focus", checkFocus);
+            window.addEventListener("blur", checkFocus);
+
             window.requestAnimationFrame(animation);
         },
 

--- a/src/event.rs
+++ b/src/event.rs
@@ -228,11 +228,15 @@ pub trait EventHandler {
     fn raw_mouse_motion(&mut self, _ctx: &mut Context, _dx: f32, _dy: f32) {}
 
     /// Window has been minimized
-    /// Right now is only implemented on Android, and is called on a Pause ndk callback
+    /// Right now is only implemented on Android X11 and wasm, 
+    /// On Andoid window_minimized_event is called on a Pause ndk callback
+    /// On X11 and wasm it will be called on focus change events.
     fn window_minimized_event(&mut self, _ctx: &mut Context) {}
 
     /// Window has been restored
-    /// Right now is only implemented on Android, and is called on a Resume ndk callback
+    /// Right now is only implemented on Android X11 and wasm, 
+    /// On Andoid window_minimized_event is called on a Pause ndk callback
+    /// On X11 and wasm it will be called on focus change events.
     fn window_restored_event(&mut self, _ctx: &mut Context) {}
 
     /// This event is sent when the userclicks the window's close button

--- a/src/event.rs
+++ b/src/event.rs
@@ -228,13 +228,13 @@ pub trait EventHandler {
     fn raw_mouse_motion(&mut self, _ctx: &mut Context, _dx: f32, _dy: f32) {}
 
     /// Window has been minimized
-    /// Right now is only implemented on Android X11 and wasm, 
+    /// Right now is only implemented on Android, X11 and wasm, 
     /// On Andoid window_minimized_event is called on a Pause ndk callback
     /// On X11 and wasm it will be called on focus change events.
     fn window_minimized_event(&mut self, _ctx: &mut Context) {}
 
     /// Window has been restored
-    /// Right now is only implemented on Android X11 and wasm, 
+    /// Right now is only implemented on Android, X11 and wasm, 
     /// On Andoid window_minimized_event is called on a Pause ndk callback
     /// On X11 and wasm it will be called on focus change events.
     fn window_restored_event(&mut self, _ctx: &mut Context) {}

--- a/src/native/linux_x11.rs
+++ b/src/native/linux_x11.rs
@@ -125,8 +125,10 @@ impl crate::native::NativeDisplay for X11Display {
         }
     }
 
-    fn set_window_size(&mut self, _new_width: u32, _new_height: u32) {
-        eprintln!("set_window_size not implemented on linux/x11")
+    fn set_window_size(&mut self, new_width: u32, new_height: u32) {
+        unsafe {
+            self.set_window_size(self.window, new_width as i32, new_height as i32);
+        }
     }
 
     fn set_fullscreen(&mut self, fullscreen: bool) {
@@ -344,6 +346,11 @@ impl X11Display {
             c_title.as_ptr() as *mut libc::c_uchar,
             libc::strlen(c_title.as_ptr()) as libc::c_int,
         );
+        (self.libx11.XFlush)(self.display);
+    }
+
+    unsafe fn set_window_size(&mut self, window: Window, new_width: i32, new_height: i32) {
+        (self.libx11.XResizeWindow)(self.display, window, new_width, new_height);
         (self.libx11.XFlush)(self.display);
     }
 

--- a/src/native/linux_x11.rs
+++ b/src/native/linux_x11.rs
@@ -642,32 +642,38 @@ impl X11Display {
         let libx11 = &mut self.libx11;
         let display = self.display;
 
-        let cursor = match cursor {
-            None => {
-                // empty_cursor was created during create_window
-                self.empty_cursor.unwrap()
-            }
-            Some(cursor_icon) => *self.cursor_cache.entry(cursor_icon).or_insert_with(|| {
-                (libx11.XCreateFontCursor)(
-                    display,
-                    match cursor_icon {
-                        CursorIcon::Default => libx11::XC_left_ptr,
-                        CursorIcon::Help => libx11::XC_question_arrow,
-                        CursorIcon::Pointer => libx11::XC_hand2,
-                        CursorIcon::Wait => libx11::XC_watch,
-                        CursorIcon::Crosshair => libx11::XC_crosshair,
-                        CursorIcon::Text => libx11::XC_xterm,
-                        CursorIcon::Move => libx11::XC_fleur,
-                        CursorIcon::NotAllowed => libx11::XC_pirate,
-                        CursorIcon::EWResize => libx11::XC_sb_h_double_arrow,
-                        CursorIcon::NSResize => libx11::XC_sb_v_double_arrow,
-                        CursorIcon::NESWResize => libx11::XC_top_right_corner,
-                        CursorIcon::NWSEResize => libx11::XC_top_left_corner,
-                    },
-                )
-            }),
-        };
-        (libx11.XDefineCursor)(display, window, cursor);
+        if cursor == Some(CursorIcon::Default) {
+            (libx11.XUndefineCursor)(display, window);
+        } else {
+            let cursor = match cursor {
+                None => {
+                    // empty_cursor was created during create_window
+                    self.empty_cursor.unwrap()
+                }
+                Some(cursor_icon) => *self.cursor_cache.entry(cursor_icon).or_insert_with(|| {
+                    (libx11.XCreateFontCursor)(
+                        display,
+                        match cursor_icon {
+                            CursorIcon::Default => libx11::XC_left_ptr,
+                            CursorIcon::Help => libx11::XC_question_arrow,
+                            CursorIcon::Pointer => libx11::XC_hand2,
+                            CursorIcon::Wait => libx11::XC_watch,
+                            CursorIcon::Crosshair => libx11::XC_crosshair,
+                            CursorIcon::Text => libx11::XC_xterm,
+                            CursorIcon::Move => libx11::XC_fleur,
+                            CursorIcon::NotAllowed => libx11::XC_pirate,
+                            CursorIcon::EWResize => libx11::XC_sb_h_double_arrow,
+                            CursorIcon::NSResize => libx11::XC_sb_v_double_arrow,
+                            CursorIcon::NESWResize => libx11::XC_top_right_corner,
+                            CursorIcon::NWSEResize => libx11::XC_top_left_corner,
+                        },
+                    )
+                }),
+            };
+            (libx11.XDefineCursor)(display, window, cursor);
+        }
+
+        
     }
 
     // pub unsafe fn process_requests(&mut self, window: Window, event_handler: &mut super::UserData) {

--- a/src/native/linux_x11.rs
+++ b/src/native/linux_x11.rs
@@ -582,6 +582,12 @@ impl X11Display {
                 let y = (*event).xmotion.y as libc::c_float;
                 event_handler.mouse_motion_event(context.with_display(&mut *self), x, y);
             }
+            9 => {
+                event_handler.window_restored_event(context.with_display(&mut *self));
+            }
+            10 => {
+                event_handler.window_minimized_event(context.with_display(&mut *self));
+            }
             22 => {
                 if (*event).xconfigure.width != self.data.screen_width
                     || (*event).xconfigure.height != self.data.screen_height

--- a/src/native/linux_x11.rs
+++ b/src/native/linux_x11.rs
@@ -347,9 +347,9 @@ impl X11Display {
         (self.libx11.XFlush)(self.display);
     }
 
-    // TODO: _fullscreen is not used, this function always setting window fullscreen
-    // should be able to able to go back from fullscreen to windowed instead
-    unsafe fn set_fullscreen(&mut self, window: Window, _fullscreen: bool) {
+    // Not 100% this is the correct way to leave fullscreen, but seems to work.
+    // TODO: Fix: On going back to windowed Title disappears and window size has changed.
+    unsafe fn set_fullscreen(&mut self, window: Window, fullscreen: bool) {
         let wm_state = (self.libx11.XInternAtom)(
             self.display,
             b"_NET_WM_STATE\x00" as *const u8 as *const _,
@@ -369,7 +369,7 @@ impl X11Display {
             (self.libx11.XUnmapWindow)(self.display, window);
             (self.libx11.XSync)(self.display, false as _);
 
-            let mut atoms: [Atom; 2] = [wm_fullscreen, 0 as _];
+            let mut atoms: [Atom; 2] = [if fullscreen { wm_fullscreen } else { 0 as _ }, 0 as _];
             (self.libx11.XChangeProperty)(
                 self.display,
                 window,
@@ -378,7 +378,7 @@ impl X11Display {
                 32,
                 PropModeReplace,
                 atoms.as_mut_ptr() as *mut _ as *mut _,
-                1,
+                if fullscreen { 1 } else { 0 },
             );
             (self.libx11.XMapWindow)(self.display, window);
             (self.libx11.XRaiseWindow)(self.display, window);
@@ -390,7 +390,8 @@ impl X11Display {
         {
             let mut data = [0isize; 5];
 
-            data[0] = 1;
+            // changing this 1 to 0 seems to help with closing fullscreen
+            data[0] = if fullscreen { 1 } else { 0 };
             data[1] = wm_fullscreen as isize;
             data[2] = 0;
 

--- a/src/native/linux_x11/libx11.rs
+++ b/src/native/linux_x11/libx11.rs
@@ -856,6 +856,12 @@ pub type XGetWindowAttributes =
 pub type XMapWindow = unsafe extern "C" fn(_: *mut Display, _: Window) -> libc::c_int;
 pub type XLowerWindow = unsafe extern "C" fn(_: *mut Display, _: Window) -> libc::c_int;
 pub type XRaiseWindow = unsafe extern "C" fn(_: *mut Display, _: Window) -> libc::c_int;
+pub type XResizeWindow = unsafe extern "C" fn(
+    _: *mut Display,
+    _: Window,
+    _: libc::c_int,
+    _: libc::c_int,
+) -> libc::c_int;
 pub type XPending = unsafe extern "C" fn(_: *mut Display) -> libc::c_int;
 pub type XNextEvent = unsafe extern "C" fn(_: *mut Display, _: *mut XEvent) -> libc::c_int;
 pub type XGetKeyboardMapping = unsafe extern "C" fn(
@@ -998,6 +1004,7 @@ pub struct LibX11 {
     pub XMapWindow: XMapWindow,
     pub XLowerWindow: XLowerWindow,
     pub XRaiseWindow: XRaiseWindow,
+    pub XResizeWindow: XResizeWindow,
     pub XPending: XPending,
     pub XNextEvent: XNextEvent,
     pub XGetKeyboardMapping: XGetKeyboardMapping,
@@ -1049,6 +1056,7 @@ impl LibX11 {
                 XMapWindow: module.get_symbol("XMapWindow").unwrap(),
                 XLowerWindow: module.get_symbol("XLowerWindow").unwrap(),
                 XRaiseWindow: module.get_symbol("XRaiseWindow").unwrap(),
+                XResizeWindow: module.get_symbol("XResizeWindow").unwrap(),
                 XPending: module.get_symbol("XPending").unwrap(),
                 XNextEvent: module.get_symbol("XNextEvent").unwrap(),
                 XGetKeyboardMapping: module.get_symbol("XGetKeyboardMapping").unwrap(),

--- a/src/native/linux_x11/libx11.rs
+++ b/src/native/linux_x11/libx11.rs
@@ -982,6 +982,7 @@ pub type XCreatePixmapCursor = unsafe extern "C" fn(
 ) -> Cursor;
 pub type XFreePixmap = unsafe extern "C" fn(_: *mut Display, _: Pixmap) -> libc::c_int;
 pub type XDefineCursor = unsafe extern "C" fn(_: *mut Display, _: Window, _: Cursor) -> libc::c_int;
+pub type XUndefineCursor = unsafe extern "C" fn(_: *mut Display, _: Window) -> libc::c_int;
 
 pub struct LibX11 {
     pub module: module::Module,
@@ -1030,6 +1031,7 @@ pub struct LibX11 {
     pub XCreatePixmapCursor: XCreatePixmapCursor,
     pub XFreePixmap: XFreePixmap,
     pub XDefineCursor: XDefineCursor,
+    pub XUndefineCursor: XUndefineCursor,
 }
 
 impl LibX11 {
@@ -1084,6 +1086,7 @@ impl LibX11 {
                 XCreatePixmapCursor: module.get_symbol("XCreatePixmapCursor").unwrap(),
                 XFreePixmap: module.get_symbol("XFreePixmap").unwrap(),
                 XDefineCursor: module.get_symbol("XDefineCursor").unwrap(),
+                XUndefineCursor: module.get_symbol("XUndefineCursor").unwrap(),
                 module,
             })
             .ok()

--- a/src/native/wasm.rs
+++ b/src/native/wasm.rs
@@ -411,6 +411,22 @@ pub extern "C" fn touch(phase: u32, id: u32, x: f32, y: f32) {
 }
 
 #[no_mangle]
+pub extern "C" fn focus(hasFocus: bool) {
+    with(|globals| {
+        if hasFocus {
+            globals.event_handler.window_restored_event(
+                globals.context.with_display(&mut globals.display)
+            );
+        } else {
+            globals.event_handler.window_minimized_event(
+                globals.context.with_display(&mut globals.display)
+            );
+        }
+        
+    });
+}
+
+#[no_mangle]
 pub extern "C" fn on_files_dropped_start() {
     with(|globals| {
         globals.display.dropped_files = Default::default();


### PR DESCRIPTION
Added the posebility to leave fullscreen on x11.
- Not 100% sure this is the correct way, but better then befor.

Implemented set_window_size for x11.

Fixed Default Cursor for x11.
- Befor the change the cursor was set to XC_left_ptr, but this is not always the default cursor. (e.g. with changed System default)
- Fix was to use XUndefineCursor to withdraw cursor changes.

Added calling window_minimized_event and window_restored_event for x11 and wasm triggered on focus change events.
- The Name of this events are maybe not the best but the calls on android could also be seen as focus change events.
- I thing implementing it this way is better then adding a new event.