### PR TITLE
Fixing default Cursor for x11

### DIFF
--- a/src/native/linux_x11.rs
+++ b/src/native/linux_x11.rs
@@ -634,32 +634,38 @@ impl X11Display {
         let libx11 = &mut self.libx11;
         let display = self.display;
 
-        let cursor = match cursor {
-            None => {
-                // empty_cursor was created during create_window
-                self.empty_cursor.unwrap()
-            }
-            Some(cursor_icon) => *self.cursor_cache.entry(cursor_icon).or_insert_with(|| {
-                (libx11.XCreateFontCursor)(
-                    display,
-                    match cursor_icon {
-                        CursorIcon::Default => libx11::XC_left_ptr,
-                        CursorIcon::Help => libx11::XC_question_arrow,
-                        CursorIcon::Pointer => libx11::XC_hand2,
-                        CursorIcon::Wait => libx11::XC_watch,
-                        CursorIcon::Crosshair => libx11::XC_crosshair,
-                        CursorIcon::Text => libx11::XC_xterm,
-                        CursorIcon::Move => libx11::XC_fleur,
-                        CursorIcon::NotAllowed => libx11::XC_pirate,
-                        CursorIcon::EWResize => libx11::XC_sb_h_double_arrow,
-                        CursorIcon::NSResize => libx11::XC_sb_v_double_arrow,
-                        CursorIcon::NESWResize => libx11::XC_top_right_corner,
-                        CursorIcon::NWSEResize => libx11::XC_top_left_corner,
-                    },
-                )
-            }),
-        };
-        (libx11.XDefineCursor)(display, window, cursor);
+        if cursor == Some(CursorIcon::Default) {
+            (libx11.XUndefineCursor)(display, window);
+        } else {
+            let cursor = match cursor {
+                None => {
+                    // empty_cursor was created during create_window
+                    self.empty_cursor.unwrap()
+                }
+                Some(cursor_icon) => *self.cursor_cache.entry(cursor_icon).or_insert_with(|| {
+                    (libx11.XCreateFontCursor)(
+                        display,
+                        match cursor_icon {
+                            CursorIcon::Default => libx11::XC_left_ptr,
+                            CursorIcon::Help => libx11::XC_question_arrow,
+                            CursorIcon::Pointer => libx11::XC_hand2,
+                            CursorIcon::Wait => libx11::XC_watch,
+                            CursorIcon::Crosshair => libx11::XC_crosshair,
+                            CursorIcon::Text => libx11::XC_xterm,
+                            CursorIcon::Move => libx11::XC_fleur,
+                            CursorIcon::NotAllowed => libx11::XC_pirate,
+                            CursorIcon::EWResize => libx11::XC_sb_h_double_arrow,
+                            CursorIcon::NSResize => libx11::XC_sb_v_double_arrow,
+                            CursorIcon::NESWResize => libx11::XC_top_right_corner,
+                            CursorIcon::NWSEResize => libx11::XC_top_left_corner,
+                        },
+                    )
+                }),
+            };
+            (libx11.XDefineCursor)(display, window, cursor);
+        }
+
+        
     }
 
     // pub unsafe fn process_requests(&mut self, window: Window, event_handler: &mut super::UserData) {

--- a/src/native/linux_x11/libx11.rs
+++ b/src/native/linux_x11/libx11.rs
@@ -976,6 +976,7 @@ pub type XCreatePixmapCursor = unsafe extern "C" fn(
 ) -> Cursor;
 pub type XFreePixmap = unsafe extern "C" fn(_: *mut Display, _: Pixmap) -> libc::c_int;
 pub type XDefineCursor = unsafe extern "C" fn(_: *mut Display, _: Window, _: Cursor) -> libc::c_int;
+pub type XUndefineCursor = unsafe extern "C" fn(_: *mut Display, _: Window) -> libc::c_int;
 
 pub struct LibX11 {
     pub module: module::Module,
@@ -1023,6 +1024,7 @@ pub struct LibX11 {
     pub XCreatePixmapCursor: XCreatePixmapCursor,
     pub XFreePixmap: XFreePixmap,
     pub XDefineCursor: XDefineCursor,
+    pub XUndefineCursor: XUndefineCursor,
 }
 
 impl LibX11 {
@@ -1076,6 +1078,7 @@ impl LibX11 {
                 XCreatePixmapCursor: module.get_symbol("XCreatePixmapCursor").unwrap(),
                 XFreePixmap: module.get_symbol("XFreePixmap").unwrap(),
                 XDefineCursor: module.get_symbol("XDefineCursor").unwrap(),
+                XUndefineCursor: module.get_symbol("XUndefineCursor").unwrap(),
                 module,
             })
             .ok()


### PR DESCRIPTION
When the default System cursor was changed XC_left_ptr is not the default Cursor.
- Added XUndefineCursor to libx11.rs
- Changed to calling XUndefineCursor, when calling set_cursor with CursorIcon::Default