### PR TITLE
Window focus events

### DIFF
--- a/js/gl.js
+++ b/js/gl.js
@@ -1253,6 +1253,18 @@ var importObject = {
                 wasm_exports.on_files_dropped_finish();
             };
 
+            let lastFocus = document.hasFocus();
+            var checkFocus = function() {
+                let hasFocus = document.hasFocus();
+                if(lastFocus == hasFocus){
+                    wasm_exports.focus(hasFocus);
+                    lastFocus = hasFocus;
+                }
+            }
+            document.addEventListener("visibilitychange", checkFocus);
+            window.addEventListener("focus", checkFocus);
+            window.addEventListener("blur", checkFocus);
+
             window.requestAnimationFrame(animation);
         },
 

--- a/src/event.rs
+++ b/src/event.rs
@@ -228,11 +228,15 @@ pub trait EventHandler {
     fn raw_mouse_motion(&mut self, _ctx: &mut Context, _dx: f32, _dy: f32) {}
 
     /// Window has been minimized
-    /// Right now is only implemented on Android, and is called on a Pause ndk callback
+    /// Right now is only implemented on Android X11 and wasm, 
+    /// On Andoid window_minimized_event is called on a Pause ndk callback
+    /// On X11 and wasm it will be called on focus change events.
     fn window_minimized_event(&mut self, _ctx: &mut Context) {}
 
     /// Window has been restored
-    /// Right now is only implemented on Android, and is called on a Resume ndk callback
+    /// Right now is only implemented on Android X11 and wasm, 
+    /// On Andoid window_minimized_event is called on a Pause ndk callback
+    /// On X11 and wasm it will be called on focus change events.
     fn window_restored_event(&mut self, _ctx: &mut Context) {}
 
     /// This event is sent when the userclicks the window's close button

--- a/src/event.rs
+++ b/src/event.rs
@@ -228,13 +228,13 @@ pub trait EventHandler {
     fn raw_mouse_motion(&mut self, _ctx: &mut Context, _dx: f32, _dy: f32) {}
 
     /// Window has been minimized
-    /// Right now is only implemented on Android X11 and wasm, 
+    /// Right now is only implemented on Android, X11 and wasm, 
     /// On Andoid window_minimized_event is called on a Pause ndk callback
     /// On X11 and wasm it will be called on focus change events.
     fn window_minimized_event(&mut self, _ctx: &mut Context) {}
 
     /// Window has been restored
-    /// Right now is only implemented on Android X11 and wasm, 
+    /// Right now is only implemented on Android, X11 and wasm, 
     /// On Andoid window_minimized_event is called on a Pause ndk callback
     /// On X11 and wasm it will be called on focus change events.
     fn window_restored_event(&mut self, _ctx: &mut Context) {}

--- a/src/native/linux_x11.rs
+++ b/src/native/linux_x11.rs
@@ -574,6 +574,12 @@ impl X11Display {
                 let y = (*event).xmotion.y as libc::c_float;
                 event_handler.mouse_motion_event(context.with_display(&mut *self), x, y);
             }
+            9 => {
+                event_handler.window_restored_event(context.with_display(&mut *self));
+            }
+            10 => {
+                event_handler.window_minimized_event(context.with_display(&mut *self));
+            }
             22 => {
                 if (*event).xconfigure.width != self.data.screen_width
                     || (*event).xconfigure.height != self.data.screen_height

--- a/src/native/wasm.rs
+++ b/src/native/wasm.rs
@@ -411,6 +411,22 @@ pub extern "C" fn touch(phase: u32, id: u32, x: f32, y: f32) {
 }
 
 #[no_mangle]
+pub extern "C" fn focus(hasFocus: bool) {
+    with(|globals| {
+        if hasFocus {
+            globals.event_handler.window_restored_event(
+                globals.context.with_display(&mut globals.display)
+            );
+        } else {
+            globals.event_handler.window_minimized_event(
+                globals.context.with_display(&mut globals.display)
+            );
+        }
+        
+    });
+}
+
+#[no_mangle]
 pub extern "C" fn on_files_dropped_start() {
     with(|globals| {
         globals.display.dropped_files = Default::default();


### PR DESCRIPTION
Added window_minimized_event and window_restored_event for linux_x11 and wasm.
These events will be called on focus change events.
The names of this events are maybe not the best,
but I think this way is better then implementing a new event?!
changes:
- added extern fn focus in wasm.rs
- added a call to this fn in gl.js
- added calls from XEvent 9 and 10 to the window_events