### PR TITLE
added get_gl_proc_addr to GraphicsContext

### DIFF
--- a/src/native/linux_x11.rs
+++ b/src/native/linux_x11.rs
@@ -1,6 +1,10 @@
 //!
 //! Spiritual successor of an X11 part of https://github.com/floooh/sokol/blob/master/sokol_app.h
 
+use std::rc::Rc;
+use std::cell::RefCell;
+use std::ffi::c_void;
+
 mod clipboard;
 mod glx;
 mod keycodes;
@@ -734,6 +738,11 @@ where
     display.data.screen_height = h;
 
     let mut context = GraphicsContext::new(gl::is_gl2());
+
+    let libgl=glx.libgl.clone();
+    context.gl_proc_addr_getter=Some(Box::new(move|procname: &str|{
+        libgl.get_procaddr(procname).unwrap() as *const c_void
+    }));
 
     let mut data = (f.take().unwrap())(context.with_display(&mut display));
 

--- a/src/native/linux_x11/glx.rs
+++ b/src/native/linux_x11/glx.rs
@@ -1,5 +1,7 @@
 #![allow(dead_code, non_snake_case)]
 
+use std::rc::Rc;
+
 use super::{libx11::*, X11Display};
 
 use crate::native::module;
@@ -203,7 +205,7 @@ pub struct GlxExtensions {
 }
 
 pub struct Glx {
-    pub libgl: LibGlx,
+    pub libgl: Rc<LibGlx>,
     multisample: bool,
     extensions: GlxExtensions,
     fbconfig: GLXFBConfig,
@@ -299,7 +301,7 @@ impl Glx {
         };
 
         Some(Glx {
-            libgl,
+            libgl: Rc::new(libgl),
             multisample,
             visual,
             depth,


### PR DESCRIPTION
It would be nice to be able to use miniquad together with [gl](https://crates.io/crates/gl), as is now possible with SDL, Glutin and glfw. Currently it is not possible with miniquad, since miniquad doesn't expose any way to get an OpenGL proc address.

This PR adds this functionality to GraphicsContext with a new function `get_gl_proc_addr`.

It is currently only implemented for X11. Adding this PR to see is the idea as well and the way it is currently implemented for X11 is well received.