### PR TITLE
Add a get_info method to get GL_VENDOR, GL_RENDERER, GL_VERSION

### DIFF
--- a/src/graphics.rs
+++ b/src/graphics.rs
@@ -1,4 +1,6 @@
-use std::{ffi::CString, mem};
+use std::ffi::CStr;
+use std::ffi::CString;
+use std::mem;
 
 mod texture;
 
@@ -2000,5 +2002,38 @@ impl ElapsedQuery {
     pub fn delete(&mut self) {
         unsafe { glDeleteQueries(1, &mut self.gl_query) }
         self.gl_query = 0;
+    }
+}
+
+#[allow(dead_code)]
+#[derive(Debug)]
+pub struct Info {
+    pub vendor: String,
+    pub renderer: String,
+    pub version: String,
+}
+
+impl Info {
+    pub fn get_info() -> Info {
+        Info {
+            vendor: unsafe {
+                CStr::from_ptr(glGetString(GL_VENDOR) as *const i8)
+                    .to_str()
+                    .unwrap()
+                    .to_string()
+            },
+            renderer: unsafe {
+                CStr::from_ptr(glGetString(GL_RENDERER) as *const i8)
+                    .to_str()
+                    .unwrap()
+                    .to_string()
+            },
+            version: unsafe {
+                CStr::from_ptr(glGetString(GL_VERSION) as *const i8)
+                    .to_str()
+                    .unwrap()
+                    .to_string()
+            },
+        }
     }
 }

--- a/src/native/gl.rs
+++ b/src/native/gl.rs
@@ -245,6 +245,7 @@ pub const GL_TIME_ELAPSED: u32 = 35007;
 pub const GL_QUERY_RESULT: u32 = 34918;
 pub const GL_QUERY_RESULT_AVAILABLE: u32 = 34919;
 pub const GL_VENDOR: u32 = 0x1F00;
+pub const GL_RENDERER: u32 = 0x1F01;
 pub const GL_VERSION: u32 = 0x1F02;
 
 pub const WGL_NUMBER_PIXEL_FORMATS_ARB: u32 = 0x2000;

--- a/src/native/wasm/webgl.rs
+++ b/src/native/wasm/webgl.rs
@@ -248,6 +248,7 @@ pub const GL_TIME_ELAPSED: u32 = 35007;
 pub const GL_QUERY_RESULT: u32 = 34918;
 pub const GL_QUERY_RESULT_AVAILABLE: u32 = 34919;
 pub const GL_VENDOR: u32 = 0x1F00;
+pub const GL_RENDERER: u32 = 0x1F01;
 pub const GL_VERSION: u32 = 0x1F02;
 
 pub const WGL_NUMBER_PIXEL_FORMATS_ARB: u32 = 0x2000;


### PR DESCRIPTION
My laptop is equipped with Nvidia Optimus technology, but I wasn't sure about the renderer being utilized by my macroquad applications. To address this, this pull request introduces a method to retrieve information such as GL_VENDOR, GL_RENDERER, and GL_VERSION. This method allows for the identification and confirmation of the correct GPU being utilized.


By incorporating this code into the application, it will provide the following output based on the renderer being used:
```rust
    let info = Info::get_info();

    info!("Vendor: {}", info.vendor);
    info!("Renderer: {}", info.renderer);
    info!("Version: {}", info.version);
```

```
 🦉 uggla   main  ~  workspace  rust  fztaosi   cargo run --release
   Compiling miniquad v0.3.15 (/home/uggla/workspace/rust/miniquad)
   Compiling macroquad v0.3.25 (/home/uggla/workspace/rust/macroquad)
   Compiling fztaosi v0.1.0 (/home/uggla/workspace/rust/fztaosi)
    Finished release [optimized] target(s) in 12.02s
     Running `target/release/fztaosi`
Vendor: Intel
Renderer: Mesa Intel(R) HD Graphics 630 (KBL GT2)
Version: 4.6 (Compatibility Profile) Mesa 23.0.3
```

```
 🦉 uggla   main  ~  workspace  rust  fztaosi __NV_PRIME_RENDER_OFFLOAD=1 __GLX_VENDOR_LIBRARY_NAME=nvidia cargo run --release
    Finished release [optimized] target(s) in 0.03s
     Running `target/release/fztaosi`
Vendor: NVIDIA Corporation
Renderer: NVIDIA GeForce GTX 1050/PCIe/SSE2
Version: 4.6.0 NVIDIA 530.41.03
```
