### PR TITLE
wayland: add a flag to disable drawing decorations when decoration manager is not found

### DIFF
--- a/src/conf.rs
+++ b/src/conf.rs
@@ -103,6 +103,10 @@ pub struct Platform {
     /// TODO: Make it works on web, on web it should make a transparent HTML5 canvas
     /// TODO: Document(and check) what does it actually mean on android. Transparent window?
     pub framebuffer_alpha: bool,
+
+    /// Whether to draw the default window decorations on Wayland.
+    /// Only works when using the Wayland backend.
+    pub wayland_use_fallback_decorations: bool,
 }
 
 impl Default for Platform {
@@ -113,6 +117,7 @@ impl Default for Platform {
             linux_backend: LinuxBackend::X11Only,
             apple_gfx_api: AppleGfxApi::OpenGl,
             framebuffer_alpha: false,
+            wayland_use_fallback_decorations: true,
         }
     }
 }

--- a/src/native/linux_wayland.rs
+++ b/src/native/linux_wayland.rs
@@ -384,7 +384,7 @@ where
         assert!(display.subcompositor.is_null() == false);
         assert!(display.seat.is_null() == false);
 
-        if display.decoration_manager.is_null() {
+        if display.decoration_manager.is_null() && conf.platform.wayland_use_fallback_decorations {
             eprintln!("Decoration manager not found, will draw fallback decorations");
         }
 
@@ -492,7 +492,7 @@ where
                 extensions::xdg_decoration::zxdg_toplevel_decoration_v1::set_mode,
                 extensions::xdg_decoration::ZXDG_TOPLEVEL_DECORATION_V1_MODE_SERVER_SIDE
             );
-        } else {
+        } else if conf.platform.wayland_use_fallback_decorations {
             display.decorations = Some(decorations::Decorations::new(
                 &mut display,
                 conf.window_width,


### PR DESCRIPTION
See issue #343 
I run a tiling window manager, and miniquad attempts to draw a window border and titlebar. This behaviour is generally undesirable, and unneeded.

Previously pull request #385 deleted the offending code but I've instead made it configurable via a flag as discussed in the pull request.