### PR TITLE
MacOS: Raw mouse motion and cursor grab

### DIFF
--- a/src/native/apple/frameworks.rs
+++ b/src/native/apple/frameworks.rs
@@ -188,6 +188,8 @@ extern "C" {
     pub fn CGMainDisplayID() -> u32;
     pub fn CGDisplayPixelsHigh(display: u32) -> u64;
     pub fn CGColorCreateGenericRGB(red: f64, green: f64, blue: f64, alpha: f64) -> ObjcId;
+    pub fn CGAssociateMouseAndMouseCursorPosition(connected: bool);
+    pub fn CGWarpMouseCursorPosition(newCursorPosition: NSPoint);
 }
 
 #[link(name = "Metal", kind = "framework")]

--- a/src/native/macos.rs
+++ b/src/native/macos.rs
@@ -46,11 +46,11 @@ impl MacosDisplay {
         unsafe {
             if grab {
                 self.move_mouse_inside_window(window);
-                CGAssociateMouseAndMouseCursorPosition(NO);
+                CGAssociateMouseAndMouseCursorPosition(false);
                 let () = msg_send![class!(NSCursor), hide];
             } else {
                 let () = msg_send![class!(NSCursor), unhide];
-                CGAssociateMouseAndMouseCursorPosition(YES);
+                CGAssociateMouseAndMouseCursorPosition(true);
             }
         }
     }


### PR DESCRIPTION
When not-fl3/macroquad#181 added support for raw mouse motion events in macroquad it didn't work on MacOS because of missing `set_cursor_grab` implementation for that plaform. This PR adds support for missing MacOS features.

My work is based on [current implementation of mouse locking in sokol_app](https://github.com/floooh/sokol/blob/0d7d72e6740026c2cdd7cd0a5503596efa74cb0b/sokol_app.h#L3646).

It uses [`CGAssociateMouseAndMouseCursorPosition`](https://developer.apple.com/documentation/coregraphics/1454486-cgassociatemouseandmousecursorpo) to lock the cursor and [`CGWarpMouseCursorPosition`](https://developer.apple.com/documentation/coregraphics/1456387-cgwarpmousecursorposition) to move it inside window frame (more on this later). When the cursor is grabbed and `mouseMoved` is emitted we're calling `raw_mouse_motion` with [`deltaX`](https://developer.apple.com/documentation/appkit/nsevent/1534871-deltax) and [`deltaY`](https://developer.apple.com/documentation/appkit/nsevent/1534158-deltay) values.

One notable difference from sokol is that in my implementation when user calls `set_cursor_grab(true)` I'm moving the cursor inside window frame. Without this when the cursor is outside window frame when the `set_cursor_grab` is called, a mouse click will unfocus the window. 

Moving the cursor inside window frame is what sokol_app used to do, but it does not anymore, which is explained in their code:

> NOTE that this code doesn't warp the mouse cursor to the window center as everybody else does it. This lead to a spike in the *second* mouse-moved event after the warp happened. The mouse centering doesn't seem to be required (mouse-moved events are reported correctly even when the cursor is at an edge of the screen).

This is what that spike looks like in macroquad (using miniquad from this branch):

https://github.com/not-fl3/miniquad/assets/6249014/9f0f8ad2-03b0-4f02-8dd0-ff3df7a44013



In my opinion we should follow what sokol does. Most games are probably fullscreen anyway and when they're not - users will click on the window to focus. On the other hand this is still going to be a problem when users alt-tab to the window.

Let me know what you want to do about it - we can leave it as it is, or I will remove moving the cursor.

I've tested this change with all miniquad examples, and most importantly with macroquads `first_person` example (as seen on video below).


https://github.com/not-fl3/miniquad/assets/6249014/82b7bc2c-2ebf-4c0f-9341-1aed15e44433



If there is something specific you would like me to test - let me know.