### PR TITLE
Misc fixes to get miniquad programs run on KDE Wayland

### DIFF
--- a/src/native/linux_wayland.rs
+++ b/src/native/linux_wayland.rs
@@ -678,6 +678,15 @@ where
             &mut display as *mut _ as _,
         );
 
+        let title = std::ffi::CString::new(conf.window_title.as_str()).unwrap();
+
+        wl_request!(
+            display.client,
+            display.xdg_toplevel,
+            extensions::xdg_shell::xdg_toplevel::set_title,
+            title.as_ptr()
+        );
+
         wl_request!(display.client, display.surface, WL_SURFACE_COMMIT);
         (display.client.wl_display_roundtrip)(wdisplay);
 

--- a/src/native/linux_wayland.rs
+++ b/src/native/linux_wayland.rs
@@ -397,7 +397,8 @@ unsafe extern "C" fn registry_add_object(
                 1,
             ) as _;
         }
-        "zxdg_decoration_manager" => {
+        "zxdg_decoration_manager" |
+        "zxdg_decoration_manager_v1" => {
             display.decoration_manager = display.client.wl_registry_bind(
                 registry,
                 name,

--- a/src/native/linux_wayland/extensions/xdg_shell.rs
+++ b/src/native/linux_wayland/extensions/xdg_shell.rs
@@ -49,7 +49,7 @@ wayland_interface!(
         (set_min_size, "ii", ()),
         (set_maximized, "", ()),
         (unset_maximized, "", ()),
-        (set_fullscreen, "", (wl_output_interface)),
+        (set_fullscreen, "?o", (wl_output_interface)),
         (unset_fullscreen, "", ()),
         (set_minimized, "", ())
     ],


### PR DESCRIPTION
A demonstration of server-side decoration:

![image](https://github.com/not-fl3/miniquad/assets/7030150/be57a744-e5b3-4a17-8a5b-462e3683ffda)
