### PR TITLE
Fix MSAA on linux-wayland (and other EGL backends)

### DIFF
--- a/src/native/android.rs
+++ b/src/native/android.rs
@@ -395,6 +395,7 @@ where
             &mut libegl,
             std::ptr::null_mut(), /* EGL_DEFAULT_DISPLAY */
             conf.platform.framebuffer_alpha,
+            conf.sample_count,
         )
         .expect("Cant create EGL context");
 

--- a/src/native/egl.rs
+++ b/src/native/egl.rs
@@ -28,6 +28,7 @@ pub const EGL_GREEN_SIZE: u32 = 12323;
 pub const EGL_RED_SIZE: u32 = 12324;
 pub const EGL_DEPTH_SIZE: u32 = 12325;
 pub const EGL_STENCIL_SIZE: u32 = 12326;
+pub const EGL_SAMPLES: u32 = 12337;
 pub const EGL_NATIVE_VISUAL_ID: u32 = 12334;
 pub const EGL_WIDTH: u32 = 12375;
 pub const EGL_HEIGHT: u32 = 12374;
@@ -261,6 +262,7 @@ pub unsafe fn create_egl_context(
     egl: &mut LibEgl,
     display: *mut std::ffi::c_void,
     alpha: bool,
+    sample_count: i32,
 ) -> Result<(EGLContext, EGLConfig, EGLDisplay), EglError> {
     let display = (egl.eglGetDisplay.unwrap())(display as _);
     if display == /* EGL_NO_DISPLAY */ null_mut() {
@@ -281,6 +283,7 @@ pub unsafe fn create_egl_context(
         EGL_ALPHA_SIZE, alpha_size,
         EGL_DEPTH_SIZE, 16,
         EGL_STENCIL_SIZE, 0,
+        EGL_SAMPLES, sample_count as u32,
         EGL_NONE,
     ];
     let mut available_cfgs: Vec<EGLConfig> = vec![null_mut(); 32];

--- a/src/native/linux_wayland.rs
+++ b/src/native/linux_wayland.rs
@@ -629,6 +629,7 @@ where
             &mut libegl,
             wdisplay as *mut _,
             conf.platform.framebuffer_alpha,
+            conf.sample_count,
         )
         .unwrap();
 

--- a/src/native/linux_x11.rs
+++ b/src/native/linux_x11.rs
@@ -437,6 +437,7 @@ where
         &mut egl_lib,
         display.display as *mut _,
         conf.platform.framebuffer_alpha,
+        conf.sample_count,
     )
     .unwrap();
 


### PR DESCRIPTION
Currently, setting the `sample_count` window configuration on EGL backends has no effect.

This fixes passing down the sample count to the EGL configuration.

Edit:
Made title and description more specific.