### PR TITLE
Allow positional buffer updates

### DIFF
--- a/src/graphics.rs
+++ b/src/graphics.rs
@@ -1201,6 +1201,7 @@ pub trait RenderingBackend {
     fn new_buffer(&mut self, type_: BufferType, usage: BufferUsage, data: BufferSource)
         -> BufferId;
     fn buffer_update(&mut self, buffer: BufferId, data: BufferSource);
+    fn buffer_update_at(&mut self, buffer: BufferId, data: BufferSource, at: usize);
 
     /// Size of buffer in bytes.
     /// For 1 element, u16 buffer this will return 2.

--- a/src/graphics/gl.rs
+++ b/src/graphics/gl.rs
@@ -1201,7 +1201,7 @@ impl RenderingBackend for GlContext {
         let gl_target = gl_buffer_target(&buffer.buffer_type);
         self.cache.store_buffer_binding(gl_target);
         self.cache
-            .bind_buffer(gl_target, buffer.gl_buf, buffer.index_type); unsafe { glBufferSubData(gl_target, (at * size) as i64, size as _, data.ptr as _) };
+            .bind_buffer(gl_target, buffer.gl_buf, buffer.index_type); unsafe { glBufferSubData(gl_target, (at * size) as _, size as _, data.ptr as _) };
         self.cache.restore_buffer_binding(gl_target);
     }
 

--- a/src/graphics/gl.rs
+++ b/src/graphics/gl.rs
@@ -1181,7 +1181,7 @@ impl RenderingBackend for GlContext {
         BufferId(self.buffers.len() - 1)
     }
 
-    fn buffer_update(&mut self, buffer: BufferId, data: BufferSource) {
+    fn buffer_update_at(&mut self, buffer: BufferId, data: BufferSource, at: usize) {
         let data = match data {
             BufferSource::Slice(data) => data,
             _ => panic!("buffer_update expects BufferSource::slice"),
@@ -1201,9 +1201,12 @@ impl RenderingBackend for GlContext {
         let gl_target = gl_buffer_target(&buffer.buffer_type);
         self.cache.store_buffer_binding(gl_target);
         self.cache
-            .bind_buffer(gl_target, buffer.gl_buf, buffer.index_type);
-        unsafe { glBufferSubData(gl_target, 0, size as _, data.ptr as _) };
+            .bind_buffer(gl_target, buffer.gl_buf, buffer.index_type); unsafe { glBufferSubData(gl_target, (at * size) as i64, size as _, data.ptr as _) };
         self.cache.restore_buffer_binding(gl_target);
+    }
+
+    fn buffer_update(&mut self, buffer: BufferId, data: BufferSource) {
+        self.buffer_update_at(buffer, data, 0);
     }
 
     /// Size of buffer in bytes


### PR DESCRIPTION
It is inefficient to stream all positional data for some use cases,

**buffer_update_at** now lets you specify a starting point:

so instead of streaming all your data at once like this example:
```
self.ctx.buffer_update(
    self.bindings.vertex_buffers[1],
    BufferSource::slice(&self.pos[..]),
);
```

you can only update the portion that has changed for instance:
```
self.ctx.buffer_update_at(
    self.bindings.vertex_buffers[1],
    BufferSource::slice(&self.pos[0..3]),
    3, // starting point
);
```

I'm aware this is error prone, and should be reviewed but I think this'll be useful for some especially those who want to dynamically change their instanced data. It so error prone in fact maybe it should not be added at all. 🤷🏻 

