### PR TITLE
Fix dpi_scale() always returning 1 on Windows

### DIFF
--- a/src/native/windows.rs
+++ b/src/native/windows.rs
@@ -845,6 +845,7 @@ where
             event_handler: None,
             modal_resizing_timer: 0,
         };
+        display.init_dpi(conf.high_dpi);
 
         let (tx, rx) = std::sync::mpsc::channel();
         let clipboard = Box::new(clipboard::WindowsClipboard::new());
@@ -855,7 +856,6 @@ where
         });
 
         display.update_dimensions(wnd);
-        display.init_dpi(conf.high_dpi);
 
         let mut wgl = wgl::Wgl::new(&mut display);
         let gl_ctx = wgl.create_context(


### PR DESCRIPTION
dpi_scale() would always return 1 on Windows despite setting high_dpi to true and my dpi settings at 150%.
This is fixed by calling display.init_dpi before setting dpi_scale to display.window_scale.