### PR TITLE
Window icon on osx

### DIFF
--- a/src/conf.rs
+++ b/src/conf.rs
@@ -153,9 +153,9 @@ pub struct Conf {
     /// Miniquad allows to change the window icon programmatically.
     /// The icon will be used as
     /// - taskbar and titlebar icons on Windows.
+    /// - dock and titlebar icon on  MacOs.
     /// - TODO: favicon on HTML5
     /// - TODO: taskbar and titlebar(highly dependent on the WM) icons on Linux
-    /// - TODO: dock and titlebar icon on  MacOs
     pub icon: Option<Icon>,
 
     /// Platform specific settings. Hints to OS for context creation, driver-specific

--- a/src/native/apple/frameworks.rs
+++ b/src/native/apple/frameworks.rs
@@ -158,6 +158,8 @@ pub const kCGEventLeftMouseUp: u32 = 2;
 pub const kCGMouseEventClickState: u32 = 1;
 //pub const kCGEventSourceStateHIDSystemState: u32 = 1;
 
+type DataReleaseCallback = unsafe extern "C" fn(info: *mut &[u8], data: *const c_void, size: usize);
+
 #[link(name = "CoreGraphics", kind = "framework")]
 extern "C" {
     pub fn CGEventSourceCreate(state_id: u32) -> ObjcId;
@@ -190,7 +192,37 @@ extern "C" {
     pub fn CGColorCreateGenericRGB(red: f64, green: f64, blue: f64, alpha: f64) -> ObjcId;
     pub fn CGAssociateMouseAndMouseCursorPosition(connected: bool);
     pub fn CGWarpMouseCursorPosition(newCursorPosition: NSPoint);
+
+    pub fn CGImageCreate(
+        width: usize,
+        height: usize,
+        bpc: usize,
+        bpp: usize,
+        bpr: usize,
+        colorspace: *const ObjcId,
+        bitmap_info: u32,
+        provider: *const ObjcId,
+        decode: *const c_void,
+        interpolate: bool,
+        intent: u32,
+    ) -> *const ObjcId;
+    pub fn CGImageRelease(image: *const ObjcId);
+
+    pub fn CGDataProviderCreateWithData(
+        info: *mut &[u8],
+        data: *const u8,
+        size: usize,
+        callback: DataReleaseCallback,
+    ) -> *const ObjcId;
+    pub fn CGDataProviderRelease(provider: *const ObjcId);
+
+    pub fn CGColorSpaceCreateDeviceRGB() -> *const ObjcId;
+    pub fn CGColorSpaceRelease(space: *const ObjcId);
 }
+
+pub const kCGBitmapByteOrderDefault: u32 = (0 << 12);
+pub const kCGImageAlphaLast: u32 = 3;
+pub const kCGRenderingIntentDefault: u32 = 0;
 
 #[link(name = "Metal", kind = "framework")]
 extern "C" {


### PR DESCRIPTION
Before:
<img width="83" alt="image" src="https://github.com/not-fl3/miniquad/assets/144502197/20119891-66cd-4838-913a-f322dcec1645">
After:
<img width="84" alt="image" src="https://github.com/not-fl3/miniquad/assets/144502197/401b6646-a6f2-4c7d-bce9-052f3f92d91b">
Tested on:
```
neofetch --off --disable cols packages title
 
OS: macOS 12.7.4 21H1123 x86_64 
Host: MacBookPro11,4 
Kernel: 21.6.0 
Uptime: 9 days, 33 mins 
Shell: zsh 5.8.1 
Resolution: 1440x900 
DE: Aqua 
WM: Quartz Compositor 
WM Theme: Blue (Dark) 
Terminal: Apple_Terminal 
Terminal Font: SFMono-Regular 
CPU: Intel i7-4770HQ (8) @ 2.20GHz 
GPU: Intel Iris Pro 
Memory: 9730MiB / 16384MiB 
```

Tried to test it on IOS emulator, to see if anything is broken, because I changed frameworks.rs
But I can't launch IOS app on emulator and not sure what I should do for it (probably something related to signing, but I have not found right commands)