### PR TITLE
native/wasm: New JS versioning scheme

### DIFF
--- a/js/gl.js
+++ b/js/gl.js
@@ -8,7 +8,7 @@
 
 "use strict";
 
-const version = "0.3.12";
+const version = 1;
 
 const canvas = document.querySelector("#glcanvas");
 const gl = canvas.getContext("webgl");
@@ -1403,14 +1403,6 @@ function register_plugins(plugins) {
     }
 }
 
-function u32_to_semver(crate_version) {
-    let major_version = (crate_version >> 24) & 0xff;
-    let minor_version = (crate_version >> 16) & 0xff;
-    let patch_version = crate_version & 0xffff;
-
-    return major_version + "." + minor_version + "." + patch_version;
-}
-
 function init_plugins(plugins) {
     if (plugins == undefined)
         return;
@@ -1429,7 +1421,7 @@ function init_plugins(plugins) {
             if (wasm_exports[version_func] == undefined) {
                 console.log("Plugin " + plugins[i].name + " is present in JS bundle, but is not used in the rust code.");
             } else {
-                var crate_version = u32_to_semver(wasm_exports[version_func]());
+                var crate_version = wasm_exports[version_func]();
 
                 if (plugins[i].version != crate_version) {
                     console.error("Plugin " + plugins[i].name + " version mismatch" +
@@ -1477,7 +1469,7 @@ function load(wasm_path) {
                     wasm_memory = obj.exports.memory;
                     wasm_exports = obj.exports;
 
-                    var crate_version = u32_to_semver(wasm_exports.crate_version());
+                    var crate_version = wasm_exports.crate_version();
                     if (version != crate_version) {
                         console.error(
                             "Version mismatch: gl.js version is: " + version +
@@ -1487,7 +1479,6 @@ function load(wasm_path) {
                     obj.exports.main();
                 })
             .catch(err => {
-                console.error("WASM failed to load, probably incompatible gl.js version");
                 console.error(err);
             })
     } else {
@@ -1502,7 +1493,7 @@ function load(wasm_path) {
                 wasm_memory = obj.exports.memory;
                 wasm_exports = obj.exports;
 
-                var crate_version = u32_to_semver(wasm_exports.crate_version());
+                var crate_version = wasm_exports.crate_version();
                 if (version != crate_version) {
                     console.error(
                         "Version mismatch: gl.js version is: " + version +

--- a/src/native/wasm.rs
+++ b/src/native/wasm.rs
@@ -168,13 +168,11 @@ pub unsafe fn update_cursor() {
     sapp_set_cursor(css_name.as_ptr(), css_name.len());
 }
 
+// gl.js version required to be shipped alongside this rust code.
+// "crate_version" is a misleading, but it can't be changed for legacy reasons.
 #[no_mangle]
 pub extern "C" fn crate_version() -> u32 {
-    let major = env!("CARGO_PKG_VERSION_MAJOR").parse::<u32>().unwrap();
-    let minor = env!("CARGO_PKG_VERSION_MINOR").parse::<u32>().unwrap();
-    let patch = env!("CARGO_PKG_VERSION_PATCH").parse::<u32>().unwrap();
-
-    (major << 24) + (minor << 16) + patch
+    1
 }
 
 #[no_mangle]


### PR DESCRIPTION
This change uncouple crate version with JS file version.

Now each plugin should export a "crate_version" function, specifying an expected JS file version. 

This is a breaking change.
However, this PR was tested againt both updated gl.js vs old un-updated rust crates and updated rust crates vs new, updated gl.js. The only issue is a "version missmatch" warning, but everything keeps working fine - just like it used to be before, except with the new versioning this warning is fixable. 

_Historical reference: originally, miniquad used to have a separate `sapp-wasm` crate and it was natural to update js file on each crates.io update. Now, with plugins system and JS being only one of the multiple targets for any given crate, having JS coupled with rust crate version is very unreasonable and very hard to maintain._