### PR TITLE
Add support for PrimitiveType::Points

### DIFF
--- a/src/graphics.rs
+++ b/src/graphics.rs
@@ -646,6 +646,7 @@ impl Default for Equation {
 pub enum PrimitiveType {
     Triangles,
     Lines,
+    Points,
 }
 
 impl From<PrimitiveType> for GLenum {
@@ -653,6 +654,7 @@ impl From<PrimitiveType> for GLenum {
         match primitive_type {
             PrimitiveType::Triangles => GL_TRIANGLES,
             PrimitiveType::Lines => GL_LINES,
+            PrimitiveType::Points => GL_POINTS,
         }
     }
 }

--- a/src/graphics/metal.rs
+++ b/src/graphics/metal.rs
@@ -150,6 +150,7 @@ impl From<PrimitiveType> for MTLPrimitiveType {
         match primitive_type {
             PrimitiveType::Triangles => MTLPrimitiveType::Triangle,
             PrimitiveType::Lines => MTLPrimitiveType::Line,
+            PrimitiveType::Points => MTLPrimitiveType::Point,
         }
     }
 }


### PR DESCRIPTION
This will allow using PrimitiveType::Points when creating a new Material in macroquad, like so:
```rust
let material = load_material(
    ShaderSource::Glsl {
        vertex: VERTEX_SHADER,
        fragment: FRAGMENT_SHADER,
    },
    MaterialParams {
        pipeline_params: PipelineParams {
            // Added PrimitiveType::Points can be used in PipelineParams to render points rather than
            // lines or triangles.
            primitive_type: miniquad::PrimitiveType::Points,
            color_blend: Some(blend_mode),
            alpha_blend: Some(BlendState::new(
                miniquad::Equation::Add,
                miniquad::BlendFactor::Zero,
                miniquad::BlendFactor::One,
            )),
            ..Default::default()
        },
        ..Default::default()
    },
)
```
and is useful for various particle effects.