### PR TITLE
Retrieve DPI scale from window instead of screen

### DIFF
--- a/src/native/macos.rs
+++ b/src/native/macos.rs
@@ -148,8 +148,7 @@ impl MacosDisplay {
     unsafe fn update_dimensions(&mut self) -> Option<(i32, i32)> {
         let mut d = native_display().lock().unwrap();
         if d.high_dpi {
-            let screen: ObjcId = msg_send![self.window, screen];
-            let dpi_scale: f64 = msg_send![screen, backingScaleFactor];
+            let dpi_scale: f64 = msg_send![self.window, backingScaleFactor];
             d.dpi_scale = dpi_scale as f32;
         } else {
             d.dpi_scale = 1.0;


### PR DESCRIPTION
Previously, DPI scale was retrieved based on the property from the screen. This PR changes this behaviour to instead retrieve it from the window. Previous behaviour on a macbook could result in a 3:2 ratio between the reported DPI scale and the window size:

WIth `high_dpi: false`:
`screen_size()` returns `(1440.0, 900.0)`
`dpi_scale()` returns `1.0`

With `high_dpi: true`:
`screen_size()` returns `(2880.0, 1800.0)`
`dpi_scale()` returns `3.0` sometimes and `2.0` somtimes.

The apple docs provide virtually no guarantees for the [`backingScaleFactor` property for `NSScreen`](https://developer.apple.com/documentation/appkit/nsscreen/1388385-backingscalefactor), while the [same documentation for `NSWindow`](https://developer.apple.com/documentation/appkit/nswindow/1419459-backingscalefactor) explicitly states the returned value is either `2.0` or `1.0`. This seems to always line up with the value returned by `screen_size`, and intuitively I would also expect the value for the window to be of more interest to `miniquad` than that of the display.