### PR TITLE
native/wasm: optional WebGL2 support

### DIFF
--- a/examples/quad.rs
+++ b/examples/quad.rs
@@ -123,6 +123,7 @@ fn main() {
     } else {
         conf::AppleGfxApi::OpenGl
     };
+    conf.platform.webgl_version = conf::WebGLVersion::WebGL2;
 
     miniquad::start(conf, move || Box::new(Stage::new()));
 }

--- a/src/conf.rs
+++ b/src/conf.rs
@@ -68,6 +68,12 @@ pub enum AppleGfxApi {
     Metal,
 }
 
+#[derive(Debug, PartialEq, Clone, Copy)]
+pub enum WebGLVersion {
+    WebGL1,
+    WebGL2
+}
+
 /// Platform specific settings.
 #[derive(Debug)]
 pub struct Platform {
@@ -83,6 +89,12 @@ pub struct Platform {
     ///
     /// Defaults to X11Only. Wayland implementation is way too unstable right now.
     pub linux_backend: LinuxBackend,
+
+    /// While miniquad itself only use webgl1 features, withing webgl2 context it
+    /// is possible to:
+    /// - use gles3 shaders
+    /// - do raw webgl2 opengl calls
+    pub webgl_version: WebGLVersion,
 
     /// Which rendering context to create, Metal or OpenGL.
     /// Miniquad always links with Metal.framework (assuming it is always present)
@@ -122,6 +134,7 @@ impl Default for Platform {
             linux_x11_gl: LinuxX11Gl::GLXWithEGLFallback,
             linux_backend: LinuxBackend::X11Only,
             apple_gfx_api: AppleGfxApi::OpenGl,
+            webgl_version: WebGLVersion::WebGL1,
             blocking_event_loop: false,
             swap_interval: None,
             framebuffer_alpha: false,

--- a/src/graphics/gl.rs
+++ b/src/graphics/gl.rs
@@ -745,7 +745,6 @@ impl RenderingBackend for GlContext {
             .to_str()
             .unwrap()
             .to_string();
-        let gles3 = gl_version_string.contains("OpenGL ES 3");
         //let gles2 = !gles3 && gl_version_string.contains("OpenGL ES");
 
         let mut glsl_support = GlslSupport::default();
@@ -760,10 +759,17 @@ impl RenderingBackend for GlContext {
         {
             // on web, miniquad always loads EXT_shader_texture_lod and OES_standard_derivatives
             glsl_support.v100_ext = true;
+
+            let webgl2 = gl_version_string.contains("WebGL 2.0");
+            if webgl2 {
+                glsl_support.v300es = true;
+            }
         }
 
         #[cfg(not(target_arch = "wasm32"))]
         {
+            let gles3 = gl_version_string.contains("OpenGL ES 3");
+
             if gles3 {
                 glsl_support.v300es = true;
             }
@@ -810,7 +816,7 @@ impl RenderingBackend for GlContext {
     }
 
     fn delete_texture(&mut self, texture: TextureId) {
-        self.cache.clear_texture_bindings();
+        //self.cache.clear_texture_bindings();
 
         let t = self.textures.get(texture);
         unsafe {


### PR DESCRIPTION
While miniquad itself only use webgl1 features, withing webgl2 context it
is possible to:
- use gles3 shaders
- do raw webgl2 opengl calls.

webgl2 context might be requested by
`conf.platform.webgl_version = conf::WebGLVersion::WebGL2;`

Note that right now there is no way to check if WebGL2 is supported, if WebGL2 context is requested on an unsupported platform (old-ish iphone safari) - everything will crash. 

In the future there should be WebGL2WithWebGL1Fallback option. 
