### PR TITLE
Fixed Metal backend with high_dpi = false

### DIFF
--- a/src/native/macos.rs
+++ b/src/native/macos.rs
@@ -152,7 +152,10 @@ impl MacosDisplay {
             let dpi_scale: f64 = msg_send![self.window, backingScaleFactor];
             d.dpi_scale = dpi_scale as f32;
         } else {
-            d.dpi_scale = 1.0;
+            let bounds: NSRect = msg_send![self.view, bounds];
+            let backing_size: NSSize = msg_send![self.view, convertSizeToBacking: NSSize {width: bounds.size.width, height: bounds.size.height}];
+
+            d.dpi_scale = (backing_size.width / bounds.size.width) as f32;
         }
 
         let bounds: NSRect = msg_send![self.view, bounds];


### PR DESCRIPTION
<details><summary><b>Example code</b></summary>
<p>

```rs
use macroquad::prelude::*;

fn window_conf() -> Conf {
    Conf {
        window_title: "Heavy Metal Example".to_owned(),
        platform: miniquad::conf::Platform {
            blocking_event_loop: true,
            apple_gfx_api: miniquad::conf::AppleGfxApi::Metal,
            ..Default::default()
        },
        // high_dpi: true,
        ..Default::default()
    }
}

#[macroquad::main(window_conf)]
async fn main() {
    macroquad::miniquad::window::schedule_update();
    loop {
        clear_background(LIGHTGRAY);
        draw_line(
            0.,
            screen_height() / 2.,
            screen_width(),
            screen_height() / 2.,
            2.,
            BLACK,
        );
        draw_line(
            screen_width() / 2.,
            0.,
            screen_width() / 2.,
            screen_height(),
            2.,
            BLACK,
        );

        let rect_width = screen_width() / 2. - 2.;
        let rect_height = screen_height() / 2. - 2.;

        let font_size = 72.;
        {
            let text = "1";
            let text_size = measure_text(text, None, font_size as _, 1.0);

            draw_text(
                text,
                rect_width / 2. - text_size.width / 2.,
                rect_height / 2. + text_size.height / 2.,
                font_size,
                RED,
            );
        }
        {
            let text = "2";
            let text_size = measure_text(text, None, font_size as _, 1.0);

            draw_text(
                text,
                rect_width + rect_width / 2. - text_size.width / 2.,
                rect_height / 2. + text_size.height / 2.,
                font_size,
                GREEN,
            );
        }
        {
            let text = "3";
            let text_size = measure_text(text, None, font_size as _, 1.0);

            draw_text(
                text,
                rect_width / 2. - text_size.width / 2.,
                rect_height + rect_height / 2. + text_size.height / 2.,
                font_size,
                BLUE,
            );
        }
        {
            let text = "4";
            let text_size = measure_text(text, None, font_size as _, 1.0);

            draw_text(
                text,
                rect_width + rect_width / 2. - text_size.width / 2.,
                rect_height + rect_height / 2. + text_size.height / 2.,
                font_size,
                BLACK,
            );
        }
        next_frame().await
    }
}
```

</p>
</details> 

**For `Metal/high_dpi=false` it looked like this:**
<img width="912" alt="Screenshot 2024-06-12 at 04 09 43" src="https://github.com/not-fl3/miniquad/assets/144502197/bed4a51b-5f98-4fcf-ae17-77845a018cf8">

**For other combinations (`Opengl/high_dpi=false`, `Opengl/high_dpi=true`, `Metal/high_dpi=true`) it looked like this:**
<img width="912" alt="Screenshot 2024-06-12 at 04 07 28" src="https://github.com/not-fl3/miniquad/assets/144502197/71fc1d22-1207-4603-ae2c-ca188dfc8369">

Now it looks as above for `Metal/high_dpi=false` also