### PR TITLE
[GL] Add support for glVertexAttribIPointer (support signed/unsigned byte, short, int attributes)

### DIFF
--- a/examples/triangle_color4b.rs
+++ b/examples/triangle_color4b.rs
@@ -91,15 +91,19 @@ impl EventHandler for Stage {
 
 fn main() {
     let mut conf = conf::Conf::default();
-    conf.platform.apple_gfx_api = conf::AppleGfxApi::Metal;
-
+    let metal = std::env::args().nth(1).as_deref() == Some("metal");
+    conf.platform.apple_gfx_api = if metal {
+        conf::AppleGfxApi::Metal
+    } else {
+        conf::AppleGfxApi::OpenGl
+    };
     miniquad::start(conf, move || Box::new(Stage::new()));
 }
 
 mod shader {
     use miniquad::*;
 
-    pub const VERTEX: &str = r#"#version 300 es
+    pub const VERTEX: &str = r#"#version 150
     in vec2 in_pos;
     in lowp uvec4 in_color;
 
@@ -110,11 +114,12 @@ mod shader {
         color = vec4(in_color) / 255.0;
     }"#;
 
-    pub const FRAGMENT: &str = r#"#version 300 es
+    pub const FRAGMENT: &str = r#"#version 150
     in lowp vec4 color;
+    out vec4 frag_color;
 
     void main() {
-        gl_FragColor = color;
+        frag_color = color;
     }"#;
 
     pub const METAL: &str = r#"

--- a/examples/triangle_color4b.rs
+++ b/examples/triangle_color4b.rs
@@ -144,7 +144,7 @@ mod shader {
         RasterizerData out;
 
         out.position = float4(v.in_pos.xy, 0.0, 1.0);
-        out.color = float4(v.in_color);
+        out.color = float4(v.in_color) / 255.0;
 
         return out;
     }

--- a/examples/triangle_color4b.rs
+++ b/examples/triangle_color4b.rs
@@ -1,0 +1,163 @@
+use miniquad::*;
+
+#[repr(C)]
+struct Vertex {
+    pos: [f32; 2],
+    color: [u8; 4],
+}
+
+struct Stage {
+    pipeline: Pipeline,
+    bindings: Bindings,
+    ctx: Box<dyn RenderingBackend>,
+}
+
+impl Stage {
+    pub fn new() -> Stage {
+        let mut ctx: Box<dyn RenderingBackend> = window::new_rendering_backend();
+
+        #[rustfmt::skip]
+        let vertices: [Vertex; 3] = [
+            Vertex { pos : [ -0.5, -0.5 ], color: [0xFF, 0, 0, 0xFF] },
+            Vertex { pos : [  0.5, -0.5 ], color: [0, 0xFF, 0, 0xFF] },
+            Vertex { pos : [  0.0,  0.5 ], color: [0, 0, 0xFF, 0xFF] },
+        ];
+        let vertex_buffer = ctx.new_buffer(
+            BufferType::VertexBuffer,
+            BufferUsage::Immutable,
+            BufferSource::slice(&vertices),
+        );
+
+        let indices: [u16; 3] = [0, 1, 2];
+        let index_buffer = ctx.new_buffer(
+            BufferType::IndexBuffer,
+            BufferUsage::Immutable,
+            BufferSource::slice(&indices),
+        );
+
+        let bindings = Bindings {
+            vertex_buffers: vec![vertex_buffer],
+            index_buffer: index_buffer,
+            images: vec![],
+        };
+
+        let shader = ctx
+            .new_shader(
+                match ctx.info().backend {
+                    Backend::OpenGl => ShaderSource::Glsl {
+                        vertex: shader::VERTEX,
+                        fragment: shader::FRAGMENT,
+                    },
+                    Backend::Metal => ShaderSource::Msl {
+                        program: shader::METAL,
+                    },
+                },
+                shader::meta(),
+            )
+            .unwrap();
+
+        let pipeline = ctx.new_pipeline(
+            &[BufferLayout::default()],
+            &[
+                VertexAttribute::new("in_pos", VertexFormat::Float2),
+                VertexAttribute::new("in_color", VertexFormat::Byte4),
+            ],
+            shader,
+            PipelineParams::default(),
+        );
+
+        Stage {
+            pipeline,
+            bindings,
+            ctx,
+        }
+    }
+}
+
+impl EventHandler for Stage {
+    fn update(&mut self) {}
+
+    fn draw(&mut self) {
+        self.ctx.begin_default_pass(Default::default());
+
+        self.ctx.apply_pipeline(&self.pipeline);
+        self.ctx.apply_bindings(&self.bindings);
+        self.ctx.draw(0, 3, 1);
+        self.ctx.end_render_pass();
+
+        self.ctx.commit_frame();
+    }
+}
+
+fn main() {
+    let mut conf = conf::Conf::default();
+    let metal = std::env::args().nth(1).as_deref() == Some("metal");
+    conf.platform.apple_gfx_api = if metal {
+        conf::AppleGfxApi::Metal
+    } else {
+        conf::AppleGfxApi::OpenGl
+    };
+
+    miniquad::start(conf, move || Box::new(Stage::new()));
+}
+
+mod shader {
+    use miniquad::*;
+
+    pub const VERTEX: &str = r#"#version 300 es
+    in vec2 in_pos;
+    in lowp uvec4 in_color;
+
+    out lowp vec4 color;
+
+    void main() {
+        gl_Position = vec4(in_pos, 0, 1);
+        color = vec4(in_color) / 255.0;
+    }"#;
+
+    pub const FRAGMENT: &str = r#"#version 300 es
+    in lowp vec4 color;
+
+    void main() {
+        gl_FragColor = color;
+    }"#;
+
+    pub const METAL: &str = r#"
+    #include <metal_stdlib>
+
+    using namespace metal;
+
+    struct Vertex
+    {
+        float2 in_pos   [[attribute(0)]];
+        uint4 in_color  [[attribute(1)]];
+    };
+
+    struct RasterizerData
+    {
+        float4 position [[position]];
+        float4 color [[user(locn0)]];
+    };
+
+    vertex RasterizerData vertexShader(Vertex v [[stage_in]])
+    {
+        RasterizerData out;
+
+        out.position = float4(v.in_pos.xy, 0.0, 1.0);
+        out.color = float4(v.in_color);
+
+        return out;
+    }
+
+    fragment float4 fragmentShader(RasterizerData in [[stage_in]])
+    {
+        return in.color;
+    }"#;
+
+    pub fn meta() -> ShaderMeta {
+        ShaderMeta {
+            images: vec![],
+            uniforms: UniformBlockLayout { uniforms: vec![] },
+        }
+    }
+}

--- a/examples/triangle_color4b.rs
+++ b/examples/triangle_color4b.rs
@@ -91,12 +91,7 @@ impl EventHandler for Stage {
 
 fn main() {
     let mut conf = conf::Conf::default();
-    let metal = std::env::args().nth(1).as_deref() == Some("metal");
-    conf.platform.apple_gfx_api = if metal {
-        conf::AppleGfxApi::Metal
-    } else {
-        conf::AppleGfxApi::OpenGl
-    };
+    conf.platform.apple_gfx_api = conf::AppleGfxApi::Metal;
 
     miniquad::start(conf, move || Box::new(Stage::new()));
 }

--- a/js/gl.js
+++ b/js/gl.js
@@ -781,6 +781,9 @@ var importObject = {
         glVertexAttribPointer: function (index, size, type, normalized, stride, ptr) {
             gl.vertexAttribPointer(index, size, type, !!normalized, stride, ptr);
         },
+        glVertexAttribIPointer: function (index, size, type, stride, ptr) {
+            gl.vertexAttribIPointer(index, size, type, stride, ptr);
+        },
         glGetUniformLocation: function (program, name) {
             GL.validateGLObjectID(GL.programs, program, 'glGetUniformLocation', 'program');
             name = UTF8ToString(name);

--- a/src/graphics.rs
+++ b/src/graphics.rs
@@ -1021,6 +1021,7 @@ unsafe impl Sync for RawId {}
 #[derive(Clone, Debug, Default)]
 pub struct GlslSupport {
     pub v130: bool,
+    pub v150: bool,
     pub v330: bool,
     pub v300es: bool,
     pub v100_ext: bool,
@@ -1048,6 +1049,17 @@ pub struct ContextInfo {
     /// List of platform-dependent features that miniquad failed to make cross-platforms
     /// and therefore they might be missing.
     pub features: Features,
+}
+
+impl ContextInfo {
+    pub fn has_integer_attributes(&self) -> bool {
+        match self.backend {
+            Backend::Metal => true,
+            Backend::OpenGl => {
+                self.glsl_support.v150 | self.glsl_support.v300es | self.glsl_support.v330
+            }
+        }
+    }
 }
 
 pub trait RenderingBackend {

--- a/src/graphics/gl.rs
+++ b/src/graphics/gl.rs
@@ -1317,14 +1317,24 @@ impl RenderingBackend for GlContext {
                         .bind_buffer(GL_ARRAY_BUFFER, vb.gl_buf, vb.index_type);
 
                     unsafe {
-                        glVertexAttribPointer(
-                            attr_index as GLuint,
-                            attribute.size,
-                            attribute.type_,
-                            GL_FALSE as u8,
-                            attribute.stride,
-                            attribute.offset as *mut _,
-                        );
+                        match attribute.type_ {
+                            GL_INT | GL_UNSIGNED_INT | GL_SHORT | GL_UNSIGNED_SHORT
+                            | GL_UNSIGNED_BYTE | GL_BYTE => glVertexAttribIPointer(
+                                attr_index as GLuint,
+                                attribute.size,
+                                attribute.type_,
+                                attribute.stride,
+                                attribute.offset as *mut _,
+                            ),
+                            _ => glVertexAttribPointer(
+                                attr_index as GLuint,
+                                attribute.size,
+                                attribute.type_,
+                                GL_FALSE as u8,
+                                attribute.stride,
+                                attribute.offset as *mut _,
+                            ),
+                        }
                         if self.features.instancing {
                             glVertexAttribDivisor(attr_index as GLuint, attribute.divisor as u32);
                         }

--- a/src/native/gl.rs
+++ b/src/native/gl.rs
@@ -541,6 +541,13 @@ gl_loader!(
         stride: GLsizei,
         pointer: *const ::std::os::raw::c_void
     ) -> (),
+    fn glVertexAttribIPointer(
+        index: GLuint,
+        size: GLint,
+        type_: GLenum,
+        stride: GLsizei,
+        pointer: *const ::std::os::raw::c_void
+    ) -> (),
     fn glDisable(cap: GLenum) -> (),
     fn glColorMask(red: GLboolean, green: GLboolean, blue: GLboolean, alpha: GLboolean) -> (),
     fn glBindBuffer(target: GLenum, buffer: GLuint) -> (),

--- a/src/native/wasm/webgl.rs
+++ b/src/native/wasm/webgl.rs
@@ -919,6 +919,15 @@ extern "C" {
     );
 }
 extern "C" {
+    pub fn glVertexAttribIPointer(
+        index: GLuint,
+        size: GLint,
+        type_: GLenum,
+        stride: GLsizei,
+        pointer: *const ::std::os::raw::c_void,
+    );
+}
+extern "C" {
     pub fn glViewport(x: GLint, y: GLint, width: GLsizei, height: GLsizei);
 }
 extern "C" {

--- a/src/native/wasm/webgl.rs
+++ b/src/native/wasm/webgl.rs
@@ -1197,15 +1197,6 @@ extern "C" {
     );
 }
 extern "C" {
-    pub fn glVertexAttribIPointer(
-        index: GLuint,
-        size: GLint,
-        type_: GLenum,
-        stride: GLsizei,
-        pointer: *const ::std::os::raw::c_void,
-    );
-}
-extern "C" {
     pub fn glGetVertexAttribIiv(index: GLuint, pname: GLenum, params: *mut GLint);
 }
 extern "C" {


### PR DESCRIPTION
Add support for glVertexAttribIPointer (support signed/unsigned byte, short, int attributes).
Add new example that shows support for glVertexAttribIPointer (es3/webgl2/opengl 3+) but needs GLSL 150 to use  OpenGL in MacOS.
