### PR TITLE
Fix linux_x11 block_on_wait

### DIFF
--- a/src/native/linux_x11.rs
+++ b/src/native/linux_x11.rs
@@ -404,12 +404,12 @@ where
 
         let mut count = (display.libx11.XPending)(display.display);
         let block_on_wait = conf.platform.blocking_event_loop && !display.update_requested;
-        if block_on_wait {
+        if block_on_wait && count == 0 {
             // if there are multiple events pending, it is still desired to process
             // them all in one frame.
             // However, when there are no events in the queue, +1 hack
             // will block main thread and release the cpu until the new event.
-            count = count + 1;
+            count = 1;
         }
 
         for _ in 0..count {


### PR DESCRIPTION
Currently for the linux_x11 backend, if `block_on_wait` is true, the main thread will be blocked until the next event. So if an event in this frame requests an update, the frame will not be updated until the next event (this happens for example for the mouse_button_up event sent by the touchscreen).

I think the correct behavior should be raise the count (to 1) only if there's no event in the current frame.