### PR TITLE
Reimplemented blocking_event_loop for OSX

### DIFF
--- a/src/graphics/metal.rs
+++ b/src/graphics/metal.rs
@@ -210,13 +210,6 @@ pub struct Buffer {
     next_value: usize,
 }
 
-#[derive(Clone, Copy, Debug, PartialEq)]
-struct ShaderUniform {
-    size: u64,
-    offset: u64,
-    format: MTLVertexFormat,
-}
-
 #[derive(Debug)]
 struct ShaderInternal {
     vertex_function: ObjcId,

--- a/src/native/apple/frameworks.rs
+++ b/src/native/apple/frameworks.rs
@@ -14,10 +14,10 @@ pub use {
         class,
         declare::ClassDecl,
         msg_send,
-        runtime::{Class, Object, Protocol, Sel, BOOL, NO, YES},
+        runtime::{Class, Object, Sel, BOOL, NO, YES},
         sel, sel_impl, Encode, Encoding,
     },
-    std::{ffi::c_void, os::raw::c_ulong, ptr::NonNull},
+    std::{ffi::c_void, ptr::NonNull},
 };
 
 //use bitflags::bitflags;

--- a/src/native/ios.rs
+++ b/src/native/ios.rs
@@ -340,7 +340,10 @@ pub fn define_glk_or_mtk_view_dlg(superclass: &Class) -> *const Class {
                 d.screen_width = screen_width;
                 d.screen_height = screen_height;
             }
-            send_message(Message::Resize { width: screen_width, height: screen_height });
+            send_message(Message::Resize {
+                width: screen_width,
+                height: screen_height,
+            });
         }
 
         if let Some(ref mut event_handler) = payload.event_handler {
@@ -648,8 +651,7 @@ pub fn define_app_delegate() -> *const Class {
                                 // I hope it will work the same on the real device.
                                 if conf.platform.blocking_event_loop {
                                     msg_send_![&*view, performSelectorOnMainThread:sel!(setNeedsDisplay) withObject:nil waitUntilDone:NO];
-                                }
-                                else {
+                                } else {
                                     msg_send_![&*view, performSelectorOnMainThread:sel!(display) withObject:nil waitUntilDone:YES];
                                 }
                             }

--- a/src/native/linux_x11/keycodes.rs
+++ b/src/native/linux_x11/keycodes.rs
@@ -165,6 +165,9 @@ pub unsafe fn translate_mouse_button(button: i32) -> MouseButton {
     };
 }
 
-pub unsafe extern "C" fn keysym_to_unicode(libxkbcommon: &mut LibXkbCommon, keysym: super::libx11::KeySym) -> i32 {
-    return (libxkbcommon.xkb_keysym_to_utf32)(keysym as u32) as i32
+pub unsafe extern "C" fn keysym_to_unicode(
+    libxkbcommon: &mut LibXkbCommon,
+    keysym: super::libx11::KeySym,
+) -> i32 {
+    return (libxkbcommon.xkb_keysym_to_utf32)(keysym as u32) as i32;
 }


### PR DESCRIPTION
While solving [this problem](https://github.com/not-fl3/miniquad/issues/455), decided to take a less hacky approach

- Reverted own NSApplication run implementation
- Used same approach as for android and ios
- Catched the bug with examples/post_processing.rs turning black, checked that it existed even before own NSApplication run implementation