### PR TITLE
graphics: Fix backwards compatibility with integer attributes

### DIFF
--- a/examples/triangle_color4b.rs
+++ b/examples/triangle_color4b.rs
@@ -60,7 +60,10 @@ impl Stage {
             &[BufferLayout::default()],
             &[
                 VertexAttribute::new("in_pos", VertexFormat::Float2),
-                VertexAttribute::new("in_color", VertexFormat::Byte4),
+                VertexAttribute {
+                    gl_pass_as_float: false,
+                    ..VertexAttribute::new("in_color", VertexFormat::Byte4)
+                },
             ],
             shader,
             PipelineParams::default(),

--- a/src/graphics.rs
+++ b/src/graphics.rs
@@ -236,6 +236,15 @@ pub struct VertexAttribute {
     pub name: &'static str,
     pub format: VertexFormat,
     pub buffer_index: usize,
+    /// This flag affects integer VertexFormats, Byte*, Short*, Int*
+    /// Taking Byte4 as an example:
+    /// On Metal, it might be received as either `float4` or `uint4`
+    /// On OpenGl and `gl_pass_as_float = true` shaders should receive it as `vec4`
+    /// With `gl_pass_as_float = false`, as `uvec4`
+    ///
+    /// Note that `uvec4` requires at least `150` glsl version
+    /// Before setting `gl_pass_as_float` to false, better check `context.info().has_integer_attributes()` and double check that shaders are at least `150`
+    pub gl_pass_as_float: bool,
 }
 
 impl VertexAttribute {
@@ -252,6 +261,7 @@ impl VertexAttribute {
             name,
             format,
             buffer_index,
+            gl_pass_as_float: true,
         }
     }
 }

--- a/src/graphics/gl.rs
+++ b/src/graphics/gl.rs
@@ -738,10 +738,6 @@ impl GlContext {
         unsafe { glColorMask(r as _, g as _, b as _, a as _) }
         self.cache.color_write = color_write;
     }
-
-    fn has_integer_attributes(&self) -> bool {
-        self.info.has_integer_attributes()
-    }
 }
 
 fn gl_info(features: Features) -> ContextInfo {
@@ -1070,6 +1066,7 @@ impl RenderingBackend for GlContext {
             name,
             format,
             buffer_index,
+            gl_pass_as_float,
         } in attributes
         {
             let buffer_data = &mut buffer_cache
@@ -1105,6 +1102,7 @@ impl RenderingBackend for GlContext {
                         stride: buffer_data.stride,
                         buffer_index: *buffer_index,
                         divisor,
+                        gl_pass_as_float: *gl_pass_as_float,
                     };
 
                     assert!(
@@ -1332,8 +1330,9 @@ impl RenderingBackend for GlContext {
                     unsafe {
                         match attribute.type_ {
                             GL_INT | GL_UNSIGNED_INT | GL_SHORT | GL_UNSIGNED_SHORT
-                            | GL_UNSIGNED_BYTE | GL_BYTE => {
-                                assert!(self.has_integer_attributes());
+                            | GL_UNSIGNED_BYTE | GL_BYTE
+                                if !attribute.gl_pass_as_float =>
+                            {
                                 glVertexAttribIPointer(
                                     attr_index as GLuint,
                                     attribute.size,

--- a/src/graphics/gl/cache.rs
+++ b/src/graphics/gl/cache.rs
@@ -9,6 +9,7 @@ pub struct VertexAttributeInternal {
     pub stride: i32,
     pub buffer_index: usize,
     pub divisor: i32,
+    pub gl_pass_as_float: bool,
 }
 
 #[derive(Default, Copy, Clone)]


### PR DESCRIPTION
Follow up on https://github.com/not-fl3/miniquad/pull/461

I can't really think of any better solution, just added a doc comment over `gl_pass_as_float`. 

cc @eloraiby @birhburh 