### PR TITLE
Add a quit shortcut to the osx menu bar 

### DIFF
--- a/src/native/macos.rs
+++ b/src/native/macos.rs
@@ -907,31 +907,31 @@ unsafe fn initialize_menu_bar(ns_app: ObjcId) {
     // Adapted from Winit `menu::initialize`
 
     // System menu bar
-    let menu_bar: ObjcId = msg_send![class!(NSMenu), new];
+    let menu_bar = msg_send_![class!(NSMenu), new];
     // Entry for the app menu dropdown in the menu bar
-    let app_menu_item: ObjcId = msg_send![class!(NSMenuItem), new];
-    let app_menu: ObjcId = msg_send![class!(NSMenu), new];
+    let app_menu_item = msg_send_![class!(NSMenuItem), new];
+    let app_menu = msg_send_![class!(NSMenu), new];
 
     // Hook up the menu components to the application
-    let () = msg_send![app_menu_item, setSubmenu: app_menu];
-    let () = msg_send![menu_bar, addItem: app_menu_item];
-    let () = msg_send![ns_app, setMainMenu: menu_bar];
+    msg_send_![app_menu_item, setSubmenu: app_menu];
+    msg_send_![menu_bar, addItem: app_menu_item];
+    msg_send_![ns_app, setMainMenu: menu_bar];
 
     // Add quit menu entry with shortcut command-q
     // It uses NSRunningApplication.localizedName, which will try to use the localized name,
     //  and will go through a chain of fallbacks based on what name strings are set in
     //  the Application bundle files, ending with the executable name.
-    let running_application: ObjcId = msg_send![class!(NSRunningApplication), currentApplication];
-    let application_name: ObjcId = msg_send![running_application, localizedName];
+    let running_application = msg_send_![class!(NSRunningApplication), currentApplication];
+    let application_name = msg_send_![running_application, localizedName];
     let quit_item_title = str_to_nsstring(&format!("Quit {}", nsstring_to_string(application_name)));
-    let quit_item: ObjcId = msg_send![class!(NSMenuItem), alloc];
-    let quit_item: ObjcId = msg_send![
+    let quit_item = msg_send_![class!(NSMenuItem), alloc];
+    let quit_item = msg_send_![
         quit_item,
         initWithTitle: quit_item_title
         action: sel!(terminate:)
         keyEquivalent: str_to_nsstring("q")
     ];
-    () = msg_send![app_menu, addItem: quit_item];
+    msg_send_![app_menu, addItem: quit_item];
 }
 
 pub unsafe fn run<F>(conf: crate::conf::Conf, f: F)

--- a/src/native/macos.rs
+++ b/src/native/macos.rs
@@ -903,7 +903,6 @@ unsafe fn set_icon(ns_app: ObjcId, icon: &Icon) {
 
 /// Initialize the system menu bar for this application
 /// - ns_app: This NSApplication
-#[no_mangle]
 unsafe fn initialize_menu_bar(ns_app: ObjcId) {
     // Adapted from Winit `menu::initialize`
 

--- a/src/native/macos.rs
+++ b/src/native/macos.rs
@@ -919,9 +919,12 @@ unsafe fn initialize_menu_bar(ns_app: ObjcId) {
     let () = msg_send![ns_app, setMainMenu: menu_bar];
 
     // Add quit menu entry with shortcut command-q
-    let process_info: ObjcId = msg_send![class!(NSProcessInfo), processInfo];
-    let process_name: ObjcId = msg_send![process_info, processName];
-    let quit_item_title = str_to_nsstring(&format!("Quit {}", nsstring_to_string(process_name)));
+    // It uses NSRunningApplication.localizedName, which will try to use the localized name,
+    //  and will go through a chain of fallbacks based on what name strings are set in
+    //  the Application bundle files, ending with the executable name.
+    let running_application: ObjcId = msg_send![class!(NSRunningApplication), currentApplication];
+    let application_name: ObjcId = msg_send![running_application, localizedName];
+    let quit_item_title = str_to_nsstring(&format!("Quit {}", nsstring_to_string(application_name)));
     let quit_item: ObjcId = msg_send![class!(NSMenuItem), alloc];
     let quit_item: ObjcId = msg_send![
         quit_item,


### PR DESCRIPTION
Adds Command+Q functionality by adding a "Quit AppName" entry to the top menu bar. This is the normal way to implement the command-q shortcut on osx, and lets you rebind it in system keyboard settings.

Fixes not-fl3/macroquad#649

Note that on osx on master, clicking on a menu bar item currently freezes the window. This is due to #455.