### PR TITLE
native/linux_x11: Better error handling

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -349,7 +349,8 @@ where
                 native::linux_wayland::run(&conf, f).expect("Wayland backend failed")
             }
             conf::LinuxBackend::X11WithWaylandFallback => {
-                if native::linux_x11::run(&conf, f).is_none() {
+                if let Err(err) = native::linux_x11::run(&conf, f) {
+                    eprintln!("{err:?}");
                     eprintln!("Failed to initialize through X11! Trying wayland instead");
                     native::linux_wayland::run(&conf, f);
                 }
@@ -357,7 +358,7 @@ where
             conf::LinuxBackend::WaylandWithX11Fallback => {
                 if native::linux_wayland::run(&conf, f).is_none() {
                     eprintln!("Failed to initialize through wayland! Trying X11 instead");
-                    native::linux_x11::run(&conf, f);
+                    native::linux_x11::run(&conf, f).unwrap()
                 }
             }
         }

--- a/src/native/linux_x11/libx11.rs
+++ b/src/native/linux_x11/libx11.rs
@@ -1041,7 +1041,7 @@ pub struct LibX11 {
 }
 
 impl LibX11 {
-    pub fn try_load() -> Option<LibX11> {
+    pub fn try_load() -> Result<LibX11, module::Error> {
         crate::native::module::Module::load("libX11.so")
             .or_else(|_| crate::native::module::Module::load("libX11.so.6"))
             .map(|module| LibX11 {
@@ -1095,7 +1095,6 @@ impl LibX11 {
                 extensions: X11Extensions::default(),
                 module: std::rc::Rc::new(module),
             })
-            .ok()
     }
 
     pub unsafe fn load_extensions(&mut self, display: *mut Display) {
@@ -1143,14 +1142,14 @@ pub struct LibXkbCommon {
 }
 
 impl LibXkbCommon {
-    pub fn try_load() -> Option<Self> {
+    pub fn try_load() -> Result<Self, module::Error> {
         crate::native::module::Module::load("libxkbcommon.so")
             .or_else(|_| crate::native::module::Module::load("libxkbcommon.so.0"))
+            .or_else(|_| crate::native::module::Module::load("libxkbcommon.so.0.0.0"))
             .or_else(|_| crate::native::module::Module::load("libxkbcommon.so.0.0.0.0"))
             .map(|module| LibXkbCommon {
                 xkb_keysym_to_utf32: module.get_symbol("xkb_keysym_to_utf32").unwrap(),
                 module: std::rc::Rc::new(module),
             })
-            .ok()
     }
 }

--- a/src/native/linux_x11/xi_input.rs
+++ b/src/native/linux_x11/xi_input.rs
@@ -1,5 +1,6 @@
 #![allow(non_upper_case_globals, non_snake_case)]
 
+use crate::native::module;
 use super::{
     libx11::{self, Display, Window, _XPrivDisplay},
     xi_input,
@@ -64,7 +65,7 @@ type XFreeEventData = fn(_: *mut Display, _: *mut libx11::XGenericEventCookie);
 
 #[derive(Clone)]
 pub struct LibXi {
-    _module: std::rc::Rc<crate::native::module::Module>,
+    _module: std::rc::Rc<module::Module>,
     _XQueryExtension: XQueryExtension,
     XIQueryVersion: XIQueryVersion,
     XISelectEvents: XISelectEvents,
@@ -74,9 +75,9 @@ pub struct LibXi {
 }
 
 impl LibXi {
-    pub fn try_load() -> Option<LibXi> {
-        crate::native::module::Module::load("libXi.so")
-            .or_else(|_| crate::native::module::Module::load("libXi.so.6"))
+    pub fn try_load() -> Result<LibXi, module::Error> {
+        module::Module::load("libXi.so")
+            .or_else(|_| module::Module::load("libXi.so.6"))
             .map(|module| LibXi {
                 _XQueryExtension: module.get_symbol("XQueryExtension").unwrap(),
                 XIQueryVersion: module.get_symbol("XIQueryVersion").unwrap(),
@@ -86,7 +87,6 @@ impl LibXi {
                 xi_extension_opcode: None,
                 _module: std::rc::Rc::new(module),
             })
-            .ok()
     }
 
     pub unsafe fn query_xi_extension(

--- a/src/native/module.rs
+++ b/src/native/module.rs
@@ -1,7 +1,7 @@
-#[derive(Debug)]
+#[derive(Debug, PartialEq, Eq, Clone)]
 pub enum Error {
-    DlOpenError,
-    DlSymError,
+    DlOpenError(String),
+    DlSymError(String),
 }
 
 #[cfg(any(target_os = "linux", target_os = "android"))]
@@ -17,25 +17,21 @@ pub mod linux {
 
     impl Module {
         pub fn load(path: &str) -> Result<Self, Error> {
-            let path = CString::new(path).unwrap();
-
-            let module = unsafe { dlopen(path.as_ptr(), RTLD_LAZY | RTLD_LOCAL) };
+            let cpath = CString::new(path).unwrap();
+            let module = unsafe { dlopen(cpath.as_ptr(), RTLD_LAZY | RTLD_LOCAL) };
             if module.is_null() {
-                Err(Error::DlOpenError)
+                Err(Error::DlOpenError(path.to_string()))
             } else {
                 Ok(Module(unsafe { NonNull::new_unchecked(module) }))
             }
         }
 
         pub fn get_symbol<F: Sized>(&self, name: &str) -> Result<F, Error> {
-            let name = CString::new(name).unwrap();
-
-            let symbol = unsafe { dlsym(self.0.as_ptr(), name.as_ptr()) };
-
+            let cname = CString::new(name).unwrap();
+            let symbol = unsafe { dlsym(self.0.as_ptr(), cname.as_ptr()) };
             if symbol.is_null() {
-                return Err(Error::DlSymError);
+                return Err(Error::DlSymError(name.to_string()));
             }
-
             Ok(unsafe { std::mem::transmute_copy::<_, F>(&symbol) })
         }
     }
@@ -59,20 +55,18 @@ mod windows {
 
     impl Module {
         pub fn load(path: &str) -> Result<Self, Error> {
-            let path = std::ffi::CString::new(path).unwrap();
-            let library = unsafe { LoadLibraryA(path.as_ptr()) };
-
+            let cpath = std::ffi::CString::new(path).unwrap();
+            let library = unsafe { LoadLibraryA(cpath.as_ptr()) };
             if library.is_null() {
-                return Err(Error::DlOpenError);
+                return Err(Error::DlOpenError(path.to_string()));
             }
             Ok(Self(library))
         }
         pub fn get_symbol<F: Sized>(&self, name: &str) -> Result<F, Error> {
-            let name = std::ffi::CString::new(name).unwrap();
-            let proc = unsafe { GetProcAddress(self.0, name.as_ptr() as *const _) };
-
+            let cname = std::ffi::CString::new(name).unwrap();
+            let proc = unsafe { GetProcAddress(self.0, cname.as_ptr() as *const _) };
             if proc.is_null() {
-                return Err(Error::DlSymError);
+                return Err(Error::DlSymError(name.to_string()));
             }
             return Ok(unsafe { std::mem::transmute_copy(&proc) });
         }


### PR DESCRIPTION
no more `fn run() -> Option<()>`! 

Before: 
```
thread 'main' panicked at /home/fl3/fun/miniquad/src/lib.rs:346:50:
X11 backend failed
```
After: 
```
thread 'main' panicked at /home/fl3/fun/miniquad/src/lib.rs:346:50:
X11 backend failed: LibraryNotFound(DlOpenError("libxkbcommon.so.0"))
```
