### PR TITLE
Fixes linux to osx cross compilation

### DIFF
--- a/src/native/apple/frameworks.rs
+++ b/src/native/apple/frameworks.rs
@@ -231,12 +231,6 @@ extern "C" {
     pub fn MTLCopyAllDevices() -> ObjcId; //TODO: Array
 }
 
-#[link(name = "AVFoundation", kind = "framework")]
-extern "C" {
-    pub static AVAudioUnitComponentManager: ObjcId;
-    pub static AVAudioUnit: ObjcId;
-}
-
 // Foundation
 
 #[repr(C)]
@@ -1283,57 +1277,6 @@ pub struct MIDIEventPacket {
     pub timeStamp: MIDITimeStamp,
     pub wordCount: u32,
     pub words: [u32; 64usize],
-}
-
-#[link(name = "CoreMidi", kind = "framework")]
-extern "C" {
-    pub static kMIDIPropertyManufacturer: CFStringRef;
-    pub static kMIDIPropertyDisplayName: CFStringRef;
-    pub static kMIDIPropertyUniqueID: CFStringRef;
-
-    pub fn MIDIGetNumberOfSources() -> ItemCount;
-    pub fn MIDIGetSource(sourceIndex0: ItemCount) -> MIDIEndpointRef;
-
-    pub fn MIDIGetNumberOfDestinations() -> ItemCount;
-    pub fn MIDIGetDestination(sourceIndex0: ItemCount) -> MIDIEndpointRef;
-
-    pub fn MIDIClientCreateWithBlock(
-        name: CFStringRef,
-        outClient: *mut MIDIClientRef,
-        notifyBlock: ObjcId,
-    ) -> OSStatus;
-
-    pub fn MIDIInputPortCreateWithProtocol(
-        client: MIDIClientRef,
-        portName: CFStringRef,
-        protocol: MIDIProtocolID,
-        outPort: *mut MIDIPortRef,
-        receiveBlock: ObjcId,
-    ) -> OSStatus;
-
-    pub fn MIDIOutputPortCreate(
-        client: MIDIClientRef,
-        portName: CFStringRef,
-        outPort: *mut MIDIPortRef,
-    ) -> OSStatus;
-
-    pub fn MIDIObjectGetStringProperty(
-        obj: MIDIObjectRef,
-        propertyID: CFStringRef,
-        str_: *mut CFStringRef,
-    ) -> OSStatus;
-
-    pub fn MIDIObjectGetIntegerProperty(
-        obj: MIDIObjectRef,
-        propertyID: CFStringRef,
-        outValue: *mut i32,
-    ) -> OSStatus;
-
-    pub fn MIDIPortConnectSource(
-        port: MIDIPortRef,
-        source: MIDIEndpointRef,
-        connRefCon: *mut ::std::os::raw::c_void,
-    ) -> OSStatus;
 }
 
 pub const NSOpenGLContextParameterSwapInterval: i32 = 222;

--- a/src/native/ios.rs
+++ b/src/native/ios.rs
@@ -668,12 +668,6 @@ pub fn define_app_delegate() -> *const Class {
         YES
     }
 
-    #[cfg(target_os = "ios")]
-    #[link(name = "UIKit", kind = "framework")]
-    extern "C" {
-        pub static UIWindowSceneSessionRoleApplication: ObjcId;
-    }
-
     extern "C" fn application_did_become_active(_: &Object, _: Sel, _: ObjcId) {
         send_message(Message::Resume);
     }


### PR DESCRIPTION
So it can be build like this (adding for historic purpose):

```bash
rustup target add x86_64-apple-darwin
curl -L https://github.com/roblabla/MacOSX-SDKs/releases/download/13.1/MacOSX13.1.sdk.tar.xz | tar xJ
cargo install --locked cargo-zigbuild

# https://github.com/ziglang/zig/wiki/Install-Zig-from-a-Package-Manager
snap install zig --classic --beta 

export SDKROOT=$(pwd)/MacOSX13.1.sdk/

cargo zigbuild --release --target x86_64-apple-darwin 
```

# It was an error:
```
note: error: unable to find framework 'CoreMidi'. searched paths: 
     .../MacOSX13.1.sdk/System/Library/Frameworks/CoreMidi.framework/CoreMidi.tbd
     .../MacOSX13.1.sdk/System/Library/Frameworks/CoreMidi.framework/CoreMidi.dylib
     .../MacOSX13.1.sdk/System/Library/Frameworks/CoreMidi.framework/CoreMidi
```

## Tested on:
### Linux:
```
uname -a
Linux vagrant 5.4.0-176-generic #196-Ubuntu SMP Fri Mar 22 16:46:39 UTC 2024 x86_64 x86_64 x86_64 GNU/Linux

lsb_release -a
No LSB modules are available.
Distributor ID:	Ubuntu
Description:	Ubuntu 20.04.6 LTS
Release:	20.04
Codename:	focal
```

### MacOS:
```
uname -mprsv
Darwin 21.6.0 Darwin Kernel Version 21.6.0: Wed Apr 24 06:02:02 PDT 2024; root:xnu-8020.240.18.708.4~1/RELEASE_X86_64 x86_64 i386

sw_vers
ProductName:	macOS
ProductVersion:	12.7.5
BuildVersion:	21H1222
```