### PR TITLE
Fix build on Windows arm64

### DIFF
--- a/src/native/windows.rs
+++ b/src/native/windows.rs
@@ -266,12 +266,12 @@ unsafe extern "system" fn win32_wndproc(
 ) -> LRESULT {
     let display_ptr: isize;
 
-    #[cfg(target_arch = "x86_64")]
+    #[cfg(target_pointer_width = "64")]
     {
         display_ptr = GetWindowLongPtrA(hwnd, GWLP_USERDATA)
     }
 
-    #[cfg(target_arch = "i686")]
+    #[cfg(target_pointer_width = "32")]
     {
         display_ptr = GetWindowLong(hwnd, GWLP_USERDATA)
     }


### PR DESCRIPTION
Building on a Windows Arm machine results in this error:

```
error[E0381]: used binding `display_ptr` isn't initialized
   --> src\native\windows.rs:279:8
    |
267 |     let display_ptr: isize;
    |         ----------- binding declared here but left uninitialized
...
279 |     if display_ptr == 0 {
    |        ^^^^^^^^^^^ `display_ptr` used here but it isn't initialized
    |
help: consider assigning a value
    |
267 |     let display_ptr: isize = 42;
    |                            ++++
```

Since the code seems to be using `target_arch` to conditionally compile based on 32/64-bit arch I changed it to use `target_pointer_width` instead. After this change I can run the examples:

![image](https://github.com/user-attachments/assets/35c5feb9-3d6d-4298-ae93-af8395e0d6a8)
