### PR TITLE
Add support for mouse buttons 4 & 5

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -20,6 +20,9 @@ categories = ["rendering::graphics-api"]
 # disabled by default
 log-impl = []
 
+[dependencies]
+num_enum = "0.7.3"
+
 [target.'cfg(target_os = "linux")'.dependencies]
 libc = "0.2"
 

--- a/src/event.rs
+++ b/src/event.rs
@@ -1,9 +1,13 @@
-#[derive(Debug, Copy, Clone, PartialEq, Hash, Eq)]
+use num_enum::TryFromPrimitive;
+
+#[derive(Debug, Copy, Clone, PartialEq, Hash, Eq, TryFromPrimitive)]
 #[repr(u8)]
 pub enum MouseButton {
     Left = 0,
     Middle = 1,
     Right = 2,
+    MB4 = 3,
+    MB5 = 4,
     Unknown = 255,
 }
 

--- a/src/native/windows.rs
+++ b/src/native/windows.rs
@@ -367,7 +367,7 @@ unsafe extern "system" fn win32_wndproc(
         WM_XBUTTONDOWN => {
             let mouse_x = payload.mouse_x;
             let mouse_y = payload.mouse_y;
-            let xbutton: u8 = GET_XBUTTON_WPARAM(wparam) as u8;
+            let xbutton = GET_XBUTTON_WPARAM(wparam) as u8;
             let which = MouseButton::try_from(xbutton+2);
 
             event_handler.mouse_button_down_event(which.unwrap(), mouse_x, mouse_y);
@@ -393,7 +393,7 @@ unsafe extern "system" fn win32_wndproc(
         WM_XBUTTONUP => {
             let mouse_x = payload.mouse_x;
             let mouse_y = payload.mouse_y;
-            let xbutton: u8 = GET_XBUTTON_WPARAM(wparam) as u8;
+            let xbutton = GET_XBUTTON_WPARAM(wparam) as u8;
             let which = MouseButton::try_from(xbutton+2);
 
             event_handler.mouse_button_up_event(which.unwrap(), mouse_x, mouse_y);

--- a/src/native/windows.rs
+++ b/src/native/windows.rs
@@ -1,3 +1,5 @@
+use std::convert::TryFrom;
+
 use crate::{
     conf::{Conf, Icon},
     event::{KeyMods, MouseButton},
@@ -362,6 +364,14 @@ unsafe extern "system" fn win32_wndproc(
 
             event_handler.mouse_button_down_event(MouseButton::Middle, mouse_x, mouse_y);
         }
+        WM_XBUTTONDOWN => {
+            let mouse_x = payload.mouse_x;
+            let mouse_y = payload.mouse_y;
+            let xbutton: u8 = GET_XBUTTON_WPARAM(wparam) as u8;
+            let which = MouseButton::try_from(xbutton+2);
+
+            event_handler.mouse_button_down_event(which.unwrap(), mouse_x, mouse_y);
+        }
         WM_LBUTTONUP => {
             let mouse_x = payload.mouse_x;
             let mouse_y = payload.mouse_y;
@@ -379,6 +389,14 @@ unsafe extern "system" fn win32_wndproc(
             let mouse_y = payload.mouse_y;
 
             event_handler.mouse_button_up_event(MouseButton::Middle, mouse_x, mouse_y);
+        }
+        WM_XBUTTONUP => {
+            let mouse_x = payload.mouse_x;
+            let mouse_y = payload.mouse_y;
+            let xbutton: u8 = GET_XBUTTON_WPARAM(wparam) as u8;
+            let which = MouseButton::try_from(xbutton+2);
+
+            event_handler.mouse_button_up_event(which.unwrap(), mouse_x, mouse_y);
         }
 
         WM_MOUSEMOVE => {


### PR DESCRIPTION
Trying to add support for mouse buttons 4 & 5 to [macroquad](https://github.com/not-fl3/macroquad).