### PR TITLE
Fixed examples configs to lower the CPU consumption on MacOS

### DIFF
--- a/examples/blobs.rs
+++ b/examples/blobs.rs
@@ -158,6 +158,8 @@ fn main() {
     } else {
         conf::AppleGfxApi::OpenGl
     };
+    // mitigating high CPU consumption
+    conf.platform.blocking_event_loop = true;
 
     miniquad::start(conf, move || Box::new(Stage::new()));
 }

--- a/examples/instancing.rs
+++ b/examples/instancing.rs
@@ -179,6 +179,8 @@ fn main() {
     } else {
         conf::AppleGfxApi::OpenGl
     };
+    // mitigating high CPU consumption
+    conf.platform.blocking_event_loop = true;
 
     miniquad::start(conf, move || Box::new(Stage::new()));
 }

--- a/examples/offscreen.rs
+++ b/examples/offscreen.rs
@@ -221,6 +221,8 @@ fn main() {
     } else {
         conf::AppleGfxApi::OpenGl
     };
+    // mitigating high CPU consumption
+    conf.platform.blocking_event_loop = true;
 
     miniquad::start(conf, move || Box::new(Stage::new()));
 }

--- a/examples/quad.rs
+++ b/examples/quad.rs
@@ -124,6 +124,8 @@ fn main() {
         conf::AppleGfxApi::OpenGl
     };
     conf.platform.webgl_version = conf::WebGLVersion::WebGL2;
+    // mitigating high CPU consumption
+    conf.platform.blocking_event_loop = true;
 
     miniquad::start(conf, move || Box::new(Stage::new()));
 }

--- a/examples/triangle.rs
+++ b/examples/triangle.rs
@@ -97,6 +97,8 @@ fn main() {
     } else {
         conf::AppleGfxApi::OpenGl
     };
+    // mitigating high CPU consumption
+    conf.platform.blocking_event_loop = true;
 
     miniquad::start(conf, move || Box::new(Stage::new()));
 }

--- a/examples/triangle_color4b.rs
+++ b/examples/triangle_color4b.rs
@@ -100,6 +100,9 @@ fn main() {
     } else {
         conf::AppleGfxApi::OpenGl
     };
+    // mitigating high CPU consumption
+    conf.platform.blocking_event_loop = true;
+
     miniquad::start(conf, move || Box::new(Stage::new()));
 }
 


### PR DESCRIPTION
This PR fixes this [issue](https://github.com/not-fl3/miniquad/issues/470). It seems that `run` method of the NSApplication class was utilizing the similar `blocking_event_loop` mecanism under the hood. In the https://github.com/not-fl3/miniquad/commit/833799ec32883cdd7465a5f8ddc80e2203dbcbc4 commit `run` function uses the config value to run the blocking loop, which is `false` by default, therefore disabling the previously working functionality.