### PR TITLE
native/macos: Re-re-implemented event loop

### DIFF
--- a/src/native/apple/frameworks.rs
+++ b/src/native/apple/frameworks.rs
@@ -75,6 +75,7 @@ extern "C" {
 extern "C" {
     pub static NSRunLoopCommonModes: ObjcId;
     pub static NSDefaultRunLoopMode: ObjcId;
+    pub static NSEventTrackingRunLoopMode: ObjcId;
     pub static NSProcessInfo: ObjcId;
     pub fn NSStringFromClass(class: ObjcId) -> ObjcId;
 
@@ -421,6 +422,8 @@ pub enum NSWindowStyleMask {
 
     NSFullSizeContentViewWindowMask = 1 << 15,
 }
+
+pub const NSWindowOcclusionStateVisible: u64 = 1 << 1;
 
 #[repr(u64)]
 #[derive(Clone, Copy, Debug, PartialEq)]


### PR DESCRIPTION
- Reverted macos.rs to this implementation: https://github.com/not-fl3/miniquad/pull/443 (it's probably better compare changes with this PR than with latest commit to understand what was added additionally)
- Now using own NSView with NSOpenGLContext instead of NSOpenGLView
- For metal backend using redraw instead setNeedsDisplay, because somehow it reduces cpu usage (Cannot find info about enabling vsync like this in MTKView docs)
- Fixed freezing on resize by drawing in draw_rect that called during "live resize"™. I don't like this approach, but it blocks main event loop while resizing, so it will not be some kind of concurency of opengl stuff i think
- Reducing CPU usage when window is occluded
- Added comments to hacky places, there are lots of them imo

Fixes:
- https://github.com/not-fl3/miniquad/issues/455
- https://github.com/not-fl3/miniquad/issues/470