### PR TITLE
Fix `target_ios` typo

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -309,7 +309,7 @@ pub mod window {
         let d = native_display().lock().unwrap();
         d.view
     }
-    #[cfg(target_ios = "ios")]
+    #[cfg(target_os = "ios")]
     pub fn apple_view_ctrl() -> crate::native::apple::frameworks::ObjcId {
         let d = native_display().lock().unwrap();
         d.view_ctrl


### PR DESCRIPTION
Fixes a simple typo: `#[cfg(target_ios = "ios")]` becomes `#[cfg(target_os = "ios")]`.