### PR TITLE
Add get/set_window_position for Linux X11

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -253,7 +253,7 @@ pub mod window {
 
     /// Get the position of the window.
     /// TODO: implement for other platforms
-    #[cfg(target_os = "windows")]
+    #[cfg(any(target_os = "windows", target_os = "linux"))]
     pub fn get_window_position() -> (u32, u32) {
         let d = native_display().lock().unwrap();
         d.screen_position

--- a/src/native/linux_x11/libx11.rs
+++ b/src/native/linux_x11/libx11.rs
@@ -858,6 +858,8 @@ pub type XLowerWindow = unsafe extern "C" fn(_: *mut Display, _: Window) -> libc
 pub type XRaiseWindow = unsafe extern "C" fn(_: *mut Display, _: Window) -> libc::c_int;
 pub type XResizeWindow =
     unsafe extern "C" fn(_: *mut Display, _: Window, _: libc::c_int, _: libc::c_int) -> libc::c_int;
+pub type XMoveWindow =
+    unsafe extern "C" fn(_: *mut Display, _: Window, _: libc::c_int, _: libc::c_int) -> libc::c_int;
 pub type XPending = unsafe extern "C" fn(_: *mut Display) -> libc::c_int;
 pub type XNextEvent = unsafe extern "C" fn(_: *mut Display, _: *mut XEvent) -> libc::c_int;
 pub type XGetKeyboardMapping = unsafe extern "C" fn(
@@ -1013,6 +1015,7 @@ pub struct LibX11 {
     pub XLowerWindow: XLowerWindow,
     pub XRaiseWindow: XRaiseWindow,
     pub XResizeWindow: XResizeWindow,
+    pub XMoveWindow: XMoveWindow,
     pub XPending: XPending,
     pub XNextEvent: XNextEvent,
     pub XGetKeyboardMapping: XGetKeyboardMapping,
@@ -1065,6 +1068,7 @@ impl LibX11 {
                 XLowerWindow: module.get_symbol("XLowerWindow").unwrap(),
                 XRaiseWindow: module.get_symbol("XRaiseWindow").unwrap(),
                 XResizeWindow: module.get_symbol("XResizeWindow").unwrap(),
+                XMoveWindow: module.get_symbol("XMoveWindow").unwrap(),
                 XPending: module.get_symbol("XPending").unwrap(),
                 XNextEvent: module.get_symbol("XNextEvent").unwrap(),
                 XGetKeyboardMapping: module.get_symbol("XGetKeyboardMapping").unwrap(),


### PR DESCRIPTION
Adds functionality to `get_window_position` and `set_window_position` functions for Linux X11, which was left out on #434.