### PR TITLE
Added PrimitiveType::TriangleStrip

### DIFF
--- a/src/graphics.rs
+++ b/src/graphics.rs
@@ -392,7 +392,7 @@ pub struct TextureParams {
     /// On OpenGL, for a `sample_count > 1` render texture, render buffer object will
     /// be created instead of a regulat texture.
     ///
-    /// The only way to use 
+    /// The only way to use
     pub sample_count: i32,
 }
 
@@ -662,6 +662,7 @@ impl Default for Equation {
 
 #[derive(Debug, PartialEq, Clone, Copy)]
 pub enum PrimitiveType {
+    TriangleStrip,
     Triangles,
     Lines,
     Points,
@@ -670,6 +671,7 @@ pub enum PrimitiveType {
 impl From<PrimitiveType> for GLenum {
     fn from(primitive_type: PrimitiveType) -> Self {
         match primitive_type {
+            PrimitiveType::TriangleStrip => GL_TRIANGLE_STRIP,
             PrimitiveType::Triangles => GL_TRIANGLES,
             PrimitiveType::Lines => GL_LINES,
             PrimitiveType::Points => GL_POINTS,
@@ -1203,7 +1205,7 @@ pub trait RenderingBackend {
     /// Same as "new_render_pass", but allows multiple color attachments.
     /// if `resolve_img` is set, MSAA-resolve operation will happen in `end_render_pass`
     /// this operation require `color_img` to have sample_count > 1,resolve_img have
-    /// sample_count == 1, and color_img.len() should be equal to resolve_img.len() 
+    /// sample_count == 1, and color_img.len() should be equal to resolve_img.len()
     fn new_render_pass_mrt(
         &mut self,
         color_img: &[TextureId],

--- a/src/graphics/metal.rs
+++ b/src/graphics/metal.rs
@@ -233,7 +233,7 @@ struct PipelineInternal {
     //layout: Vec<BufferLayout>,
     //attributes: Vec<VertexAttributeInternal>,
     _shader: ShaderId,
-    //params: PipelineParams,
+    params: PipelineParams,
 }
 
 #[derive(Clone, Copy)]
@@ -1018,7 +1018,7 @@ impl RenderingBackend for MetalContext {
                 //layout: buffer_layout.to_vec(),
                 //attributes: vertex_layout,
                 _shader: shader,
-                //params,
+                params,
             };
 
             self.pipelines.push(pipeline);
@@ -1232,10 +1232,12 @@ impl RenderingBackend for MetalContext {
         let render_encoder = self.render_encoder.unwrap();
         assert!(self.index_buffer.is_some());
         let index_buffer = self.index_buffer.unwrap();
+        let pip = &self.pipelines[self.current_pipeline.unwrap().0];
+        let primitive_type: MTLPrimitiveType = pip.params.primitive_type.into();
 
         assert!(base_element == 0); // TODO: figure indexBufferOffset/baseVertex
         unsafe {
-            msg_send_![render_encoder, drawIndexedPrimitives:MTLPrimitiveType::Triangle
+            msg_send_![render_encoder, drawIndexedPrimitives:primitive_type
                        indexCount:num_elements as u64
                        indexType:MTLIndexType::UInt16
                        indexBuffer:index_buffer

--- a/src/graphics/metal.rs
+++ b/src/graphics/metal.rs
@@ -148,6 +148,7 @@ impl From<VertexStep> for MTLVertexStepFunction {
 impl From<PrimitiveType> for MTLPrimitiveType {
     fn from(primitive_type: PrimitiveType) -> Self {
         match primitive_type {
+            PrimitiveType::TriangleStrip => MTLPrimitiveType::TriangleStrip,
             PrimitiveType::Triangles => MTLPrimitiveType::Triangle,
             PrimitiveType::Lines => MTLPrimitiveType::Line,
             PrimitiveType::Points => MTLPrimitiveType::Point,


### PR DESCRIPTION
I'm [porting](https://github.com/birhburh/macroquad_tamagotchi/commit/e8055253c5571668e3b9dbf80adf7a97ba9364dc) some parts of [contrast_renderer](https://github.com/Lichtso/contrast_renderer) to miniquad/macroquad and it uses output in GL_TRIANGLE_STRIP format
I can maybe change format to GL_TRIANGLES later but for now I think this is the small change that won't break anything
And Metal and WebGL have it too