### PR TITLE
replace usage of the `std::os::raw` module with `core::ffi`

### DIFF
--- a/src/native/android.rs
+++ b/src/native/android.rs
@@ -86,7 +86,7 @@ fn send_message(message: Message) {
 static mut ACTIVITY: ndk_sys::jobject = std::ptr::null_mut();
 static mut VM: *mut ndk_sys::JavaVM = std::ptr::null_mut();
 
-pub unsafe fn console_debug(msg: *const ::std::os::raw::c_char) {
+pub unsafe fn console_debug(msg: *const ::core::ffi::c_char) {
     ndk_sys::__android_log_write(
         ndk_sys::android_LogPriority_ANDROID_LOG_DEBUG as _,
         b"SAPP\0".as_ptr() as _,
@@ -94,7 +94,7 @@ pub unsafe fn console_debug(msg: *const ::std::os::raw::c_char) {
     );
 }
 
-pub unsafe fn console_info(msg: *const ::std::os::raw::c_char) {
+pub unsafe fn console_info(msg: *const ::core::ffi::c_char) {
     ndk_sys::__android_log_write(
         ndk_sys::android_LogPriority_ANDROID_LOG_INFO as _,
         b"SAPP\0".as_ptr() as _,
@@ -102,7 +102,7 @@ pub unsafe fn console_info(msg: *const ::std::os::raw::c_char) {
     );
 }
 
-pub unsafe fn console_warn(msg: *const ::std::os::raw::c_char) {
+pub unsafe fn console_warn(msg: *const ::core::ffi::c_char) {
     ndk_sys::__android_log_write(
         ndk_sys::android_LogPriority_ANDROID_LOG_WARN as _,
         b"SAPP\0".as_ptr() as _,
@@ -110,7 +110,7 @@ pub unsafe fn console_warn(msg: *const ::std::os::raw::c_char) {
     );
 }
 
-pub unsafe fn console_error(msg: *const ::std::os::raw::c_char) {
+pub unsafe fn console_error(msg: *const ::core::ffi::c_char) {
     ndk_sys::__android_log_write(
         ndk_sys::android_LogPriority_ANDROID_LOG_ERROR as _,
         b"SAPP\0".as_ptr() as _,
@@ -631,8 +631,8 @@ unsafe fn set_full_screen(env: *mut ndk_sys::JNIEnv, fullscreen: bool) {
 #[repr(C)]
 #[derive(Debug, Copy, Clone)]
 pub struct android_asset {
-    pub content: *mut ::std::os::raw::c_char,
-    pub content_length: ::std::os::raw::c_int,
+    pub content: *mut ::core::ffi::c_char,
+    pub content_length: ::core::ffi::c_int,
 }
 
 // According to documentation, AAssetManager_fromJava is as available as an
@@ -645,7 +645,7 @@ extern "C" {
     ) -> *mut ndk_sys::AAssetManager;
 }
 
-pub(crate) unsafe fn load_asset(filepath: *const ::std::os::raw::c_char, out: *mut android_asset) {
+pub(crate) unsafe fn load_asset(filepath: *const ::core::ffi::c_char, out: *mut android_asset) {
     let env = attach_jni_env();
 
     let get_method_id = (**env).GetMethodID.unwrap();

--- a/src/native/apple/apple_util.rs
+++ b/src/native/apple/apple_util.rs
@@ -12,7 +12,7 @@ use crate::{
 
 pub fn nsstring_to_string(string: ObjcId) -> String {
     unsafe {
-        let utf8_string: *const std::os::raw::c_uchar = msg_send![string, UTF8String];
+        let utf8_string: *const core::ffi::c_uchar = msg_send![string, UTF8String];
         let utf8_len: usize = msg_send![string, lengthOfBytesUsingEncoding: UTF8_ENCODING];
         let slice = std::slice::from_raw_parts(utf8_string, utf8_len);
         std::str::from_utf8_unchecked(slice).to_owned()
@@ -51,7 +51,7 @@ pub fn load_undocumented_cursor(cursor_name: &str) -> ObjcId {
 
 pub unsafe fn ccfstr_from_str(inp: &str) -> CFStringRef {
     let null = format!("{}\0", inp);
-    __CFStringMakeConstantString(null.as_ptr() as *const ::std::os::raw::c_char)
+    __CFStringMakeConstantString(null.as_ptr() as *const ::core::ffi::c_char)
 }
 
 pub unsafe fn cfstring_ref_to_string(cfstring: CFStringRef) -> String {
@@ -155,7 +155,7 @@ pub fn get_event_key_modifier(event: ObjcId) -> KeyMods {
 }
 
 pub fn get_event_keycode(event: ObjcId) -> Option<KeyCode> {
-    let scan_code: std::os::raw::c_ushort = unsafe { msg_send![event, keyCode] };
+    let scan_code: core::ffi::c_ushort = unsafe { msg_send![event, keyCode] };
 
     Some(match scan_code {
         0x00 => KeyCode::A,
@@ -468,21 +468,21 @@ pub fn load_mouse_cursor(cursor: CursorIcon) -> ObjcId {
 //         {
 //             #[repr(C)]
 //             struct BlockDescriptor {
-//                 reserved: std::os::raw::c_ulong,
-//                 size: std::os::raw::c_ulong,
-//                 copy_helper: extern "C" fn(*mut std::os::raw::c_void, *const std::os::raw::c_void),
-//                 dispose_helper: extern "C" fn(*mut std::os::raw::c_void),
+//                 reserved: core::ffi::c_ulong,
+//                 size: core::ffi::c_ulong,
+//                 copy_helper: extern "C" fn(*mut core::ffi::c_void, *const core::ffi::c_void),
+//                 dispose_helper: extern "C" fn(*mut core::ffi::c_void),
 //             }
 
 //             static DESCRIPTOR: BlockDescriptor = BlockDescriptor {
 //                 reserved: 0,
-//                 size: mem::size_of::<BlockLiteral>() as std::os::raw::c_ulong,
+//                 size: mem::size_of::<BlockLiteral>() as core::ffi::c_ulong,
 //                 copy_helper,
 //                 dispose_helper,
 //             };
 
 //             #[allow(unused_unsafe)]
-//             extern "C" fn copy_helper(dst: *mut std::os::raw::c_void, src: *const std::os::raw::c_void) {
+//             extern "C" fn copy_helper(dst: *mut core::ffi::c_void, src: *const core::ffi::c_void) {
 //                 unsafe {
 //                     ptr::write(
 //                         &mut (*(dst as *mut BlockLiteral)).inner as *mut _,
@@ -492,7 +492,7 @@ pub fn load_mouse_cursor(cursor: CursorIcon) -> ObjcId {
 //             }
 
 //             #[allow(unused_unsafe)]
-//             extern "C" fn dispose_helper(src: *mut std::os::raw::c_void) {
+//             extern "C" fn dispose_helper(src: *mut core::ffi::c_void) {
 //                 unsafe {
 //                     ptr::drop_in_place(src as *mut BlockLiteral);
 //                 }
@@ -506,9 +506,9 @@ pub fn load_mouse_cursor(cursor: CursorIcon) -> ObjcId {
 
 //             #[repr(C)]
 //             struct BlockLiteral {
-//                 isa: *const std::os::raw::c_void,
-//                 flags: std::os::raw::c_int,
-//                 reserved: std::os::raw::c_int,
+//                 isa: *const core::ffi::c_void,
+//                 flags: core::ffi::c_int,
+//                 reserved: core::ffi::c_int,
 //                 invoke: extern "C" fn(*mut BlockLiteral, $ ( $ arg_ty), *) $ ( -> $ return_ty) ?,
 //                 descriptor: *const BlockDescriptor,
 //                 inner: ::std::sync::Arc<::std::sync::Mutex<dyn Fn( $ ( $ arg_ty), *) $ ( -> $ return_ty) ? >>,
@@ -516,7 +516,7 @@ pub fn load_mouse_cursor(cursor: CursorIcon) -> ObjcId {
 
 //             #[allow(unused_unsafe)]
 //             BlockLiteral {
-//                 isa: unsafe {_NSConcreteStackBlock.as_ptr() as *const std::os::raw::c_void},
+//                 isa: unsafe {_NSConcreteStackBlock.as_ptr() as *const core::ffi::c_void},
 //                 flags: 1 << 25,
 //                 reserved: 0,
 //                 invoke,
@@ -534,9 +534,9 @@ pub fn load_mouse_cursor(cursor: CursorIcon) -> ObjcId {
 //         {
 //             #[repr(C)]
 //             struct BlockLiteral {
-//                 isa: *const std::os::raw::c_void,
-//                 flags: std::os::raw::c_int,
-//                 reserved: std::os::raw::c_int,
+//                 isa: *const core::ffi::c_void,
+//                 flags: core::ffi::c_int,
+//                 reserved: core::ffi::c_int,
 //                 invoke: extern "C" fn(*mut BlockLiteral, $ ( $ arg_ty), *) $ ( -> $ return_ty) ?,
 //             }
 

--- a/src/native/apple/frameworks.rs
+++ b/src/native/apple/frameworks.rs
@@ -79,7 +79,7 @@ extern "C" {
     pub static NSProcessInfo: ObjcId;
     pub fn NSStringFromClass(class: ObjcId) -> ObjcId;
 
-    pub fn __CFStringMakeConstantString(cStr: *const ::std::os::raw::c_char) -> CFStringRef;
+    pub fn __CFStringMakeConstantString(cStr: *const ::core::ffi::c_char) -> CFStringRef;
 
     pub fn CFStringGetLength(theString: CFStringRef) -> u64;
     pub fn CFStringGetBytes(
@@ -1039,7 +1039,7 @@ pub struct SMPTETime {
 pub struct _AudioBuffer {
     pub mNumberChannels: u32,
     pub mDataByteSize: u32,
-    pub mData: *mut ::std::os::raw::c_void,
+    pub mData: *mut ::core::ffi::c_void,
 }
 
 pub const MAX_AUDIO_BUFFERS: usize = 8;

--- a/src/native/egl.rs
+++ b/src/native/egl.rs
@@ -12,9 +12,9 @@ pub type EGLNativeWindowType = crate::native::linux_x11::libx11::Window;
 #[cfg(target_os = "android")]
 pub type EGLNativeDisplayType = *mut ();
 #[cfg(target_os = "android")]
-pub type EGLNativePixmapType = ::std::os::raw::c_ulong;
+pub type EGLNativePixmapType = ::core::ffi::c_ulong;
 #[cfg(target_os = "android")]
-pub type EGLNativeWindowType = ::std::os::raw::c_ulong;
+pub type EGLNativeWindowType = ::core::ffi::c_ulong;
 
 pub use core::ptr::null_mut;
 
@@ -40,11 +40,11 @@ pub type NativeDisplayType = EGLNativeDisplayType;
 pub type NativePixmapType = EGLNativePixmapType;
 pub type NativeWindowType = EGLNativeWindowType;
 pub type EGLint = i32;
-pub type EGLBoolean = ::std::os::raw::c_uint;
-pub type EGLDisplay = *mut ::std::os::raw::c_void;
-pub type EGLConfig = *mut ::std::os::raw::c_void;
-pub type EGLSurface = *mut ::std::os::raw::c_void;
-pub type EGLContext = *mut ::std::os::raw::c_void;
+pub type EGLBoolean = ::core::ffi::c_uint;
+pub type EGLDisplay = *mut ::core::ffi::c_void;
+pub type EGLConfig = *mut ::core::ffi::c_void;
+pub type EGLSurface = *mut ::core::ffi::c_void;
+pub type EGLContext = *mut ::core::ffi::c_void;
 pub type __eglMustCastToProperFunctionPointerType = ::std::option::Option<unsafe extern "C" fn()>;
 pub type PFNEGLCHOOSECONFIGPROC = ::std::option::Option<
     unsafe extern "C" fn(
@@ -121,7 +121,7 @@ pub type PFNEGLGETDISPLAYPROC =
 pub type PFNEGLGETERRORPROC = ::std::option::Option<unsafe extern "C" fn() -> EGLint>;
 pub type PFNEGLGETPROCADDRESSPROC = ::std::option::Option<
     unsafe extern "C" fn(
-        procname: *const ::std::os::raw::c_char,
+        procname: *const ::core::ffi::c_char,
     ) -> __eglMustCastToProperFunctionPointerType,
 >;
 pub type PFNEGLINITIALIZEPROC = ::std::option::Option<
@@ -144,7 +144,7 @@ pub type PFNEGLQUERYCONTEXTPROC = ::std::option::Option<
     ) -> EGLBoolean,
 >;
 pub type PFNEGLQUERYSTRINGPROC = ::std::option::Option<
-    unsafe extern "C" fn(dpy: EGLDisplay, name: EGLint) -> *const ::std::os::raw::c_char,
+    unsafe extern "C" fn(dpy: EGLDisplay, name: EGLint) -> *const ::core::ffi::c_char,
 >;
 pub type PFNEGLQUERYSURFACEPROC = ::std::option::Option<
     unsafe extern "C" fn(

--- a/src/native/gl.rs
+++ b/src/native/gl.rs
@@ -1,22 +1,22 @@
 #![allow(non_camel_case_types, non_snake_case, non_upper_case_globals)]
 
-pub type GLenum = ::std::os::raw::c_uint;
-pub type GLboolean = ::std::os::raw::c_uchar;
-pub type GLbitfield = ::std::os::raw::c_uint;
-pub type GLvoid = ::std::os::raw::c_void;
-pub type GLbyte = ::std::os::raw::c_schar;
-pub type GLshort = ::std::os::raw::c_short;
-pub type GLint = ::std::os::raw::c_int;
-pub type GLubyte = ::std::os::raw::c_uchar;
-pub type GLushort = ::std::os::raw::c_ushort;
-pub type GLuint = ::std::os::raw::c_uint;
-pub type GLuint64 = ::std::os::raw::c_ulonglong;
-pub type GLsizei = ::std::os::raw::c_int;
-pub type GLchar = ::std::os::raw::c_char;
+pub type GLenum = ::core::ffi::c_uint;
+pub type GLboolean = ::core::ffi::c_uchar;
+pub type GLbitfield = ::core::ffi::c_uint;
+pub type GLvoid = ::core::ffi::c_void;
+pub type GLbyte = ::core::ffi::c_schar;
+pub type GLshort = ::core::ffi::c_short;
+pub type GLint = ::core::ffi::c_int;
+pub type GLubyte = ::core::ffi::c_uchar;
+pub type GLushort = ::core::ffi::c_ushort;
+pub type GLuint = ::core::ffi::c_uint;
+pub type GLuint64 = ::core::ffi::c_ulonglong;
+pub type GLsizei = ::core::ffi::c_int;
+pub type GLchar = ::core::ffi::c_char;
 
-pub type khronos_ssize_t = ::std::os::raw::c_long;
-pub type khronos_usize_t = ::std::os::raw::c_ulong;
-pub type khronos_intptr_t = ::std::os::raw::c_long;
+pub type khronos_ssize_t = ::core::ffi::c_long;
+pub type khronos_usize_t = ::core::ffi::c_ulong;
+pub type khronos_intptr_t = ::core::ffi::c_long;
 
 pub type GLsizeiptr = khronos_ssize_t;
 pub type GLintptr = khronos_intptr_t;
@@ -405,7 +405,7 @@ gl_loader!(
         target: GLenum,
         offset: GLintptr,
         size: GLsizeiptr,
-        data: *const ::std::os::raw::c_void
+        data: *const ::core::ffi::c_void
     ) -> (),
     fn glGenBuffers(n: GLsizei, buffers: *mut GLuint) -> (),
     fn glCheckFramebufferStatus(target: GLenum) -> GLenum,
@@ -532,7 +532,7 @@ gl_loader!(
         mode: GLenum,
         count: GLsizei,
         type_: GLenum,
-        indices: *const ::std::os::raw::c_void,
+        indices: *const ::core::ffi::c_void,
         instancecount: GLsizei
     ) -> (),
     fn glVertexAttribPointer(
@@ -541,14 +541,14 @@ gl_loader!(
         type_: GLenum,
         normalized: GLboolean,
         stride: GLsizei,
-        pointer: *const ::std::os::raw::c_void
+        pointer: *const ::core::ffi::c_void
     ) -> (),
     fn glVertexAttribIPointer(
         index: GLuint,
         size: GLint,
         type_: GLenum,
         stride: GLsizei,
-        pointer: *const ::std::os::raw::c_void
+        pointer: *const ::core::ffi::c_void
     ) -> (),
     fn glDisable(cap: GLenum) -> (),
     fn glColorMask(red: GLboolean, green: GLboolean, blue: GLboolean, alpha: GLboolean) -> (),
@@ -568,7 +568,7 @@ gl_loader!(
     fn glBufferData(
         target: GLenum,
         size: GLsizeiptr,
-        data: *const ::std::os::raw::c_void,
+        data: *const ::core::ffi::c_void,
         usage: GLenum
     ) -> (),
     fn glBlendFuncSeparate(

--- a/src/native/linux_wayland.rs
+++ b/src/native/linux_wayland.rs
@@ -149,7 +149,7 @@ static mut KEYBOARD_LISTENER: wl_keyboard_listener = wl_keyboard_listener {
 };
 
 unsafe extern "C" fn keyboard_handle_keymap(
-    data: *mut ::std::os::raw::c_void,
+    data: *mut ::core::ffi::c_void,
     _wl_keyboard: *mut wl_keyboard,
     _format: u32,
     fd: i32,
@@ -178,7 +178,7 @@ unsafe extern "C" fn keyboard_handle_keymap(
     display.xkb_state = (display.xkb.xkb_state_new)(display.keymap);
 }
 unsafe extern "C" fn keyboard_handle_enter(
-    _data: *mut ::std::os::raw::c_void,
+    _data: *mut ::core::ffi::c_void,
     _wl_keyboard: *mut wl_keyboard,
     _serial: u32,
     _surface: *mut wl_surface,
@@ -186,14 +186,14 @@ unsafe extern "C" fn keyboard_handle_enter(
 ) {
 }
 unsafe extern "C" fn keyboard_handle_leave(
-    _data: *mut ::std::os::raw::c_void,
+    _data: *mut ::core::ffi::c_void,
     _wl_keyboard: *mut wl_keyboard,
     _serial: u32,
     _surface: *mut wl_surface,
 ) {
 }
 unsafe extern "C" fn keyboard_handle_key(
-    data: *mut ::std::os::raw::c_void,
+    data: *mut ::core::ffi::c_void,
     _wl_keyboard: *mut wl_keyboard,
     _serial: u32,
     _time: u32,
@@ -207,7 +207,7 @@ unsafe extern "C" fn keyboard_handle_key(
     EVENTS.push(WaylandEvent::KeyboardKey(keysym, state == 1));
 }
 unsafe extern "C" fn keyboard_handle_modifiers(
-    data: *mut ::std::os::raw::c_void,
+    data: *mut ::core::ffi::c_void,
     _wl_keyboard: *mut wl_keyboard,
     _serial: u32,
     mods_depressed: u32,
@@ -227,7 +227,7 @@ unsafe extern "C" fn keyboard_handle_modifiers(
     );
 }
 unsafe extern "C" fn keyboard_handle_repeat_info(
-    _data: *mut ::std::os::raw::c_void,
+    _data: *mut ::core::ffi::c_void,
     _wl_keyboard: *mut wl_keyboard,
     _rate: i32,
     _delay: i32,
@@ -249,7 +249,7 @@ static mut POINTER_LISTENER: wl_pointer_listener = wl_pointer_listener {
 };
 
 unsafe extern "C" fn pointer_handle_enter(
-    _data: *mut ::std::os::raw::c_void,
+    _data: *mut ::core::ffi::c_void,
     _wl_pointer: *mut wl_pointer,
     _serial: u32,
     _surface: *mut wl_surface,
@@ -258,14 +258,14 @@ unsafe extern "C" fn pointer_handle_enter(
 ) {
 }
 unsafe extern "C" fn pointer_handle_leave(
-    _data: *mut ::std::os::raw::c_void,
+    _data: *mut ::core::ffi::c_void,
     _wl_pointer: *mut wl_pointer,
     _serial: u32,
     _surface: *mut wl_surface,
 ) {
 }
 unsafe extern "C" fn pointer_handle_motion(
-    _data: *mut ::std::os::raw::c_void,
+    _data: *mut ::core::ffi::c_void,
     _wl_pointer: *mut wl_pointer,
     _time: u32,
     surface_x: i32,
@@ -276,7 +276,7 @@ unsafe extern "C" fn pointer_handle_motion(
     EVENTS.push(WaylandEvent::PointerMotion(x, y));
 }
 unsafe extern "C" fn pointer_handle_button(
-    _data: *mut ::std::os::raw::c_void,
+    _data: *mut ::core::ffi::c_void,
     _wl_pointer: *mut wl_pointer,
     _serial: u32,
     _time: u32,
@@ -293,7 +293,7 @@ unsafe extern "C" fn pointer_handle_button(
     EVENTS.push(WaylandEvent::PointerButton(button, state == 1));
 }
 unsafe extern "C" fn pointer_handle_axis(
-    _data: *mut ::std::os::raw::c_void,
+    _data: *mut ::core::ffi::c_void,
     _wl_pointer: *mut wl_pointer,
     _time: u32,
     axis: u32,
@@ -315,39 +315,39 @@ unsafe extern "C" fn pointer_handle_axis(
     }
 }
 unsafe extern "C" fn pointer_handle_frame(
-    _data: *mut ::std::os::raw::c_void,
+    _data: *mut ::core::ffi::c_void,
     _wl_pointer: *mut wl_pointer,
 ) {
 }
 unsafe extern "C" fn pointer_handle_axis_source(
-    _data: *mut ::std::os::raw::c_void,
+    _data: *mut ::core::ffi::c_void,
     _wl_pointer: *mut wl_pointer,
     _axis_source: u32,
 ) {
 }
 unsafe extern "C" fn pointer_handle_axis_stop(
-    _data: *mut ::std::os::raw::c_void,
+    _data: *mut ::core::ffi::c_void,
     _wl_pointer: *mut wl_pointer,
     _time: u32,
     _axis: u32,
 ) {
 }
 unsafe extern "C" fn pointer_handle_axis_discrete(
-    _data: *mut ::std::os::raw::c_void,
+    _data: *mut ::core::ffi::c_void,
     _wl_pointer: *mut wl_pointer,
     _axis: u32,
     _discrete: i32,
 ) {
 }
 unsafe extern "C" fn pointer_handle_axis_value120(
-    _data: *mut ::std::os::raw::c_void,
+    _data: *mut ::core::ffi::c_void,
     _wl_pointer: *mut wl_pointer,
     _axis: u32,
     _value120: i32,
 ) {
 }
 unsafe extern "C" fn pointer_handle_axis_relative_direction(
-    _data: *mut ::std::os::raw::c_void,
+    _data: *mut ::core::ffi::c_void,
     _wl_pointer: *mut wl_pointer,
     _axis: u32,
     _direction: u32,
@@ -357,7 +357,7 @@ unsafe extern "C" fn pointer_handle_axis_relative_direction(
 extern "C" fn seat_handle_name(
     _data: *mut std::ffi::c_void,
     _seat: *mut wl_seat,
-    _name: *const ::std::os::raw::c_char,
+    _name: *const ::core::ffi::c_char,
 ) {
 }
 
@@ -365,7 +365,7 @@ unsafe extern "C" fn registry_add_object(
     data: *mut std::ffi::c_void,
     registry: *mut wl_registry,
     name: u32,
-    interface: *const ::std::os::raw::c_char,
+    interface: *const ::core::ffi::c_char,
     version: u32,
 ) {
     let display: &mut WaylandPayload = &mut *(data as *mut _);

--- a/src/native/linux_wayland/libwayland_client.rs
+++ b/src/native/linux_wayland/libwayland_client.rs
@@ -185,7 +185,7 @@ pub const WL_SUBSURFACE_PLACE_BELOW_SINCE_VERSION: u32 = 1;
 pub const WL_SUBSURFACE_SET_SYNC_SINCE_VERSION: u32 = 1;
 pub const WL_SUBSURFACE_SET_DESYNC_SINCE_VERSION: u32 = 1;
 
-pub type wl_shm_format = ::std::os::raw::c_uint;
+pub type wl_shm_format = ::core::ffi::c_uint;
 
 pub const wl_shm_format_WL_SHM_FORMAT_ARGB8888: wl_shm_format = 0;
 
@@ -202,7 +202,7 @@ pub struct wl_object {
 pub struct wl_array {
     pub size: libc::size_t,
     pub alloc: libc::size_t,
-    pub data: *mut ::std::os::raw::c_void,
+    pub data: *mut ::core::ffi::c_void,
 }
 #[repr(C)]
 #[derive(Copy, Clone)]
@@ -210,7 +210,7 @@ pub union wl_argument {
     pub i: i32,
     pub u: u32,
     pub f: wl_fixed_t,
-    pub s: *const ::std::os::raw::c_char,
+    pub s: *const ::core::ffi::c_char,
     pub o: *mut wl_object,
     pub n: u32,
     pub a: *mut wl_array,
@@ -341,19 +341,19 @@ pub struct wl_touch {
 #[repr(C)]
 #[derive(Debug, Copy, Clone)]
 pub struct wl_message {
-    pub name: *const ::std::os::raw::c_char,
-    pub signature: *const ::std::os::raw::c_char,
+    pub name: *const ::core::ffi::c_char,
+    pub signature: *const ::core::ffi::c_char,
     pub types: *mut *const wl_interface,
 }
 
 #[repr(C)]
 #[derive(Debug, Copy, Clone)]
 pub struct wl_interface {
-    pub name: *const ::std::os::raw::c_char,
-    pub version: ::std::os::raw::c_int,
-    pub method_count: ::std::os::raw::c_int,
+    pub name: *const ::core::ffi::c_char,
+    pub version: ::core::ffi::c_int,
+    pub method_count: ::core::ffi::c_int,
     pub methods: *const wl_message,
-    pub event_count: ::std::os::raw::c_int,
+    pub event_count: ::core::ffi::c_int,
     pub events: *const wl_message,
 }
 
@@ -362,16 +362,16 @@ pub struct wl_interface {
 pub struct wl_registry_listener {
     pub global: ::std::option::Option<
         unsafe extern "C" fn(
-            data: *mut ::std::os::raw::c_void,
+            data: *mut ::core::ffi::c_void,
             wl_registry: *mut wl_registry,
             name: u32,
-            interface: *const ::std::os::raw::c_char,
+            interface: *const ::core::ffi::c_char,
             version: u32,
         ),
     >,
     pub global_remove: ::std::option::Option<
         unsafe extern "C" fn(
-            data: *mut ::std::os::raw::c_void,
+            data: *mut ::core::ffi::c_void,
             wl_registry: *mut wl_registry,
             name: u32,
         ),
@@ -383,7 +383,7 @@ pub struct wl_registry_listener {
 pub struct wl_callback_listener {
     pub done: ::std::option::Option<
         unsafe extern "C" fn(
-            data: *mut ::std::os::raw::c_void,
+            data: *mut ::core::ffi::c_void,
             wl_callback: *mut wl_callback,
             callback_data: u32,
         ),
@@ -392,22 +392,22 @@ pub struct wl_callback_listener {
 pub const wl_seat_capability_WL_SEAT_CAPABILITY_POINTER: wl_seat_capability = 1;
 pub const wl_seat_capability_WL_SEAT_CAPABILITY_KEYBOARD: wl_seat_capability = 2;
 pub const wl_seat_capability_WL_SEAT_CAPABILITY_TOUCH: wl_seat_capability = 4;
-pub type wl_seat_capability = ::std::os::raw::c_uint;
+pub type wl_seat_capability = ::core::ffi::c_uint;
 #[repr(C)]
 #[derive(Debug, Copy, Clone)]
 pub struct wl_seat_listener {
     pub capabilities: ::std::option::Option<
         unsafe extern "C" fn(
-            data: *mut ::std::os::raw::c_void,
+            data: *mut ::core::ffi::c_void,
             wl_seat: *mut wl_seat,
             capabilities: u32,
         ),
     >,
     pub name: ::std::option::Option<
         unsafe extern "C" fn(
-            data: *mut ::std::os::raw::c_void,
+            data: *mut ::core::ffi::c_void,
             wl_seat: *mut wl_seat,
-            name: *const ::std::os::raw::c_char,
+            name: *const ::core::ffi::c_char,
         ),
     >,
 }
@@ -417,7 +417,7 @@ pub struct wl_seat_listener {
 pub struct wl_keyboard_listener {
     pub keymap: ::std::option::Option<
         unsafe extern "C" fn(
-            data: *mut ::std::os::raw::c_void,
+            data: *mut ::core::ffi::c_void,
             wl_keyboard: *mut wl_keyboard,
             format: u32,
             fd: i32,
@@ -426,7 +426,7 @@ pub struct wl_keyboard_listener {
     >,
     pub enter: ::std::option::Option<
         unsafe extern "C" fn(
-            data: *mut ::std::os::raw::c_void,
+            data: *mut ::core::ffi::c_void,
             wl_keyboard: *mut wl_keyboard,
             serial: u32,
             surface: *mut wl_surface,
@@ -435,7 +435,7 @@ pub struct wl_keyboard_listener {
     >,
     pub leave: ::std::option::Option<
         unsafe extern "C" fn(
-            data: *mut ::std::os::raw::c_void,
+            data: *mut ::core::ffi::c_void,
             wl_keyboard: *mut wl_keyboard,
             serial: u32,
             surface: *mut wl_surface,
@@ -443,7 +443,7 @@ pub struct wl_keyboard_listener {
     >,
     pub key: ::std::option::Option<
         unsafe extern "C" fn(
-            data: *mut ::std::os::raw::c_void,
+            data: *mut ::core::ffi::c_void,
             wl_keyboard: *mut wl_keyboard,
             serial: u32,
             time: u32,
@@ -453,7 +453,7 @@ pub struct wl_keyboard_listener {
     >,
     pub modifiers: ::std::option::Option<
         unsafe extern "C" fn(
-            data: *mut ::std::os::raw::c_void,
+            data: *mut ::core::ffi::c_void,
             wl_keyboard: *mut wl_keyboard,
             serial: u32,
             mods_depressed: u32,
@@ -464,7 +464,7 @@ pub struct wl_keyboard_listener {
     >,
     pub repeat_info: ::std::option::Option<
         unsafe extern "C" fn(
-            data: *mut ::std::os::raw::c_void,
+            data: *mut ::core::ffi::c_void,
             wl_keyboard: *mut wl_keyboard,
             rate: i32,
             delay: i32,
@@ -477,7 +477,7 @@ pub struct wl_keyboard_listener {
 pub struct wl_pointer_listener {
     pub enter: ::std::option::Option<
         unsafe extern "C" fn(
-            data: *mut ::std::os::raw::c_void,
+            data: *mut ::core::ffi::c_void,
             wl_pointer: *mut wl_pointer,
             serial: u32,
             surface: *mut wl_surface,
@@ -487,7 +487,7 @@ pub struct wl_pointer_listener {
     >,
     pub leave: ::std::option::Option<
         unsafe extern "C" fn(
-            data: *mut ::std::os::raw::c_void,
+            data: *mut ::core::ffi::c_void,
             wl_pointer: *mut wl_pointer,
             serial: u32,
             surface: *mut wl_surface,
@@ -495,7 +495,7 @@ pub struct wl_pointer_listener {
     >,
     pub motion: ::std::option::Option<
         unsafe extern "C" fn(
-            data: *mut ::std::os::raw::c_void,
+            data: *mut ::core::ffi::c_void,
             wl_pointer: *mut wl_pointer,
             time: u32,
             surface_x: i32,
@@ -504,7 +504,7 @@ pub struct wl_pointer_listener {
     >,
     pub button: ::std::option::Option<
         unsafe extern "C" fn(
-            data: *mut ::std::os::raw::c_void,
+            data: *mut ::core::ffi::c_void,
             wl_pointer: *mut wl_pointer,
             serial: u32,
             time: u32,
@@ -514,7 +514,7 @@ pub struct wl_pointer_listener {
     >,
     pub axis: ::std::option::Option<
         unsafe extern "C" fn(
-            data: *mut ::std::os::raw::c_void,
+            data: *mut ::core::ffi::c_void,
             wl_pointer: *mut wl_pointer,
             time: u32,
             axis: u32,
@@ -522,18 +522,18 @@ pub struct wl_pointer_listener {
         ),
     >,
     pub frame: ::std::option::Option<
-        unsafe extern "C" fn(data: *mut ::std::os::raw::c_void, wl_pointer: *mut wl_pointer),
+        unsafe extern "C" fn(data: *mut ::core::ffi::c_void, wl_pointer: *mut wl_pointer),
     >,
     pub axis_source: ::std::option::Option<
         unsafe extern "C" fn(
-            data: *mut ::std::os::raw::c_void,
+            data: *mut ::core::ffi::c_void,
             wl_pointer: *mut wl_pointer,
             axis_source: u32,
         ),
     >,
     pub axis_stop: ::std::option::Option<
         unsafe extern "C" fn(
-            data: *mut ::std::os::raw::c_void,
+            data: *mut ::core::ffi::c_void,
             wl_pointer: *mut wl_pointer,
             time: u32,
             axis: u32,
@@ -541,7 +541,7 @@ pub struct wl_pointer_listener {
     >,
     pub axis_discrete: ::std::option::Option<
         unsafe extern "C" fn(
-            data: *mut ::std::os::raw::c_void,
+            data: *mut ::core::ffi::c_void,
             wl_pointer: *mut wl_pointer,
             axis: u32,
             discrete: i32,
@@ -549,7 +549,7 @@ pub struct wl_pointer_listener {
     >,
     pub axis_value120: ::std::option::Option<
         unsafe extern "C" fn(
-            data: *mut ::std::os::raw::c_void,
+            data: *mut ::core::ffi::c_void,
             wl_pointer: *mut wl_pointer,
             axis: u32,
             value120: i32,
@@ -557,7 +557,7 @@ pub struct wl_pointer_listener {
     >,
     pub axis_relative_direction: ::std::option::Option<
         unsafe extern "C" fn(
-            data: *mut ::std::os::raw::c_void,
+            data: *mut ::core::ffi::c_void,
             wl_pointer: *mut wl_pointer,
             axis: u32,
             direction: u32,
@@ -566,7 +566,7 @@ pub struct wl_pointer_listener {
 }
 
 pub type wl_display_connect =
-    unsafe extern "C" fn(name: *const ::std::os::raw::c_char) -> *mut wl_display;
+    unsafe extern "C" fn(name: *const ::core::ffi::c_char) -> *mut wl_display;
 pub type wl_proxy_destroy = unsafe extern "C" fn(proxy: *mut wl_proxy);
 pub type wl_proxy_marshal = unsafe extern "C" fn(p: *mut wl_proxy, opcode: u32, ...);
 pub type wl_proxy_marshal_constructor = unsafe extern "C" fn(
@@ -585,13 +585,13 @@ pub type wl_proxy_marshal_constructor_versioned = unsafe extern "C" fn(
 pub type wl_proxy_add_listener = unsafe extern "C" fn(
     proxy: *mut wl_proxy,
     implementation: *mut ::std::option::Option<unsafe extern "C" fn()>,
-    data: *mut ::std::os::raw::c_void,
-) -> ::std::os::raw::c_int;
+    data: *mut ::core::ffi::c_void,
+) -> ::core::ffi::c_int;
 
 pub type wl_display_roundtrip =
-    unsafe extern "C" fn(display: *mut wl_display) -> ::std::os::raw::c_int;
+    unsafe extern "C" fn(display: *mut wl_display) -> ::core::ffi::c_int;
 pub type wl_display_dispatch_pending =
-    unsafe extern "C" fn(display: *mut wl_display) -> ::std::os::raw::c_int;
+    unsafe extern "C" fn(display: *mut wl_display) -> ::core::ffi::c_int;
 
 #[derive(Clone)]
 pub struct LibWaylandClient {

--- a/src/native/linux_wayland/libwayland_egl.rs
+++ b/src/native/linux_wayland/libwayland_egl.rs
@@ -9,24 +9,24 @@ pub struct wl_egl_window {
 }
 pub type wl_egl_window_create = unsafe extern "C" fn(
     surface: *mut wl_surface,
-    width: ::std::os::raw::c_int,
-    height: ::std::os::raw::c_int,
+    width: ::core::ffi::c_int,
+    height: ::core::ffi::c_int,
 ) -> *mut wl_egl_window;
 
 pub type wl_egl_window_destroy = unsafe extern "C" fn(egl_window: *mut wl_egl_window);
 
 pub type wl_egl_window_resize = unsafe extern "C" fn(
     egl_window: *mut wl_egl_window,
-    width: ::std::os::raw::c_int,
-    height: ::std::os::raw::c_int,
-    dx: ::std::os::raw::c_int,
-    dy: ::std::os::raw::c_int,
+    width: ::core::ffi::c_int,
+    height: ::core::ffi::c_int,
+    dx: ::core::ffi::c_int,
+    dy: ::core::ffi::c_int,
 );
 
 pub type wl_egl_window_get_attached_size = unsafe extern "C" fn(
     egl_window: *mut wl_egl_window,
-    width: *mut ::std::os::raw::c_int,
-    height: *mut ::std::os::raw::c_int,
+    width: *mut ::core::ffi::c_int,
+    height: *mut ::core::ffi::c_int,
 );
 
 pub struct LibWaylandEgl {

--- a/src/native/linux_wayland/libxkbcommon.rs
+++ b/src/native/linux_wayland/libxkbcommon.rs
@@ -16,14 +16,14 @@ pub struct xkb_state {
     _unused: [u8; 0],
 }
 
-pub type xkb_context_new = unsafe extern "C" fn(flags: ::std::os::raw::c_int) -> *mut xkb_context;
+pub type xkb_context_new = unsafe extern "C" fn(flags: ::core::ffi::c_int) -> *mut xkb_context;
 pub type xkb_context_unref = unsafe extern "C" fn(context: *mut xkb_context);
 
 pub type xkb_keymap_new_from_string = unsafe extern "C" fn(
     context: *mut xkb_context,
     file: *mut libc::FILE,
-    format: ::std::os::raw::c_int,
-    flags: ::std::os::raw::c_int,
+    format: ::core::ffi::c_int,
+    flags: ::core::ffi::c_int,
 ) -> *mut xkb_keymap;
 pub type xkb_keymap_unref = unsafe extern "C" fn(keymap: *mut xkb_keymap);
 
@@ -38,7 +38,7 @@ pub type xkb_state_update_mask = unsafe extern "C" fn(
     depressed_layout: u32,
     latched_layout: u32,
     locked_layout: u32,
-) -> ::std::os::raw::c_int;
+) -> ::core::ffi::c_int;
 
 pub type xkb_keysym_to_utf32 = unsafe extern "C" fn(_: u32) -> u32;
 

--- a/src/native/linux_x11/glx.rs
+++ b/src/native/linux_x11/glx.rs
@@ -30,19 +30,19 @@ pub const GLX_CONTEXT_CORE_PROFILE_BIT_ARB: libc::c_int = 0x1 as libc::c_int;
 pub const GLX_CONTEXT_FLAGS_ARB: libc::c_int = 0x2094 as libc::c_int;
 pub const GLX_CONTEXT_FORWARD_COMPATIBLE_BIT_ARB: libc::c_int = 0x2 as libc::c_int;
 
-pub type GLenum = ::std::os::raw::c_uint;
-pub type GLboolean = ::std::os::raw::c_uchar;
-pub type GLbitfield = ::std::os::raw::c_uint;
-pub type GLvoid = ::std::os::raw::c_void;
-pub type GLbyte = ::std::os::raw::c_schar;
-pub type GLshort = ::std::os::raw::c_short;
-pub type GLint = ::std::os::raw::c_int;
-pub type GLubyte = ::std::os::raw::c_uchar;
-pub type GLushort = ::std::os::raw::c_ushort;
-pub type GLuint = ::std::os::raw::c_uint;
-pub type GLuint64 = ::std::os::raw::c_ulonglong;
-pub type GLsizei = ::std::os::raw::c_int;
-pub type GLchar = ::std::os::raw::c_char;
+pub type GLenum = ::core::ffi::c_uint;
+pub type GLboolean = ::core::ffi::c_uchar;
+pub type GLbitfield = ::core::ffi::c_uint;
+pub type GLvoid = ::core::ffi::c_void;
+pub type GLbyte = ::core::ffi::c_schar;
+pub type GLshort = ::core::ffi::c_short;
+pub type GLint = ::core::ffi::c_int;
+pub type GLubyte = ::core::ffi::c_uchar;
+pub type GLushort = ::core::ffi::c_ushort;
+pub type GLuint = ::core::ffi::c_uint;
+pub type GLuint64 = ::core::ffi::c_ulonglong;
+pub type GLsizei = ::core::ffi::c_int;
+pub type GLchar = ::core::ffi::c_char;
 
 pub type PFNGLXDESTROYCONTEXTPROC =
     Option<unsafe extern "C" fn(_: *mut Display, _: GLXContext) -> ()>;

--- a/src/native/linux_x11/rand.rs
+++ b/src/native/linux_x11/rand.rs
@@ -1,4 +1,4 @@
 extern "C" {
-    pub fn rand() -> ::std::os::raw::c_int;
+    pub fn rand() -> ::core::ffi::c_int;
 }
 pub const RAND_MAX: u32 = 2147483647;

--- a/src/native/wasm.rs
+++ b/src/native/wasm.rs
@@ -97,11 +97,11 @@ where
     }
 }
 
-pub unsafe fn sapp_width() -> ::std::os::raw::c_int {
+pub unsafe fn sapp_width() -> ::core::ffi::c_int {
     canvas_width()
 }
 
-pub unsafe fn sapp_height() -> ::std::os::raw::c_int {
+pub unsafe fn sapp_height() -> ::core::ffi::c_int {
     canvas_height()
 }
 
@@ -111,11 +111,11 @@ extern "C" {
     pub fn canvas_width() -> i32;
     pub fn canvas_height() -> i32;
     pub fn dpi_scale() -> f32;
-    pub fn console_debug(msg: *const ::std::os::raw::c_char);
-    pub fn console_log(msg: *const ::std::os::raw::c_char);
-    pub fn console_info(msg: *const ::std::os::raw::c_char);
-    pub fn console_warn(msg: *const ::std::os::raw::c_char);
-    pub fn console_error(msg: *const ::std::os::raw::c_char);
+    pub fn console_debug(msg: *const ::core::ffi::c_char);
+    pub fn console_log(msg: *const ::core::ffi::c_char);
+    pub fn console_info(msg: *const ::core::ffi::c_char);
+    pub fn console_warn(msg: *const ::core::ffi::c_char);
+    pub fn console_error(msg: *const ::core::ffi::c_char);
 
     pub fn sapp_set_clipboard(clipboard: *const i8, len: usize);
 

--- a/src/native/wasm/webgl.rs
+++ b/src/native/wasm/webgl.rs
@@ -4,24 +4,24 @@
 
 #![allow(non_snake_case, non_camel_case_types, non_upper_case_globals)]
 
-pub type GLenum = ::std::os::raw::c_uint;
-pub type GLboolean = ::std::os::raw::c_uchar;
-pub type GLbitfield = ::std::os::raw::c_uint;
-pub type GLvoid = ::std::os::raw::c_void;
-pub type GLbyte = ::std::os::raw::c_schar;
-pub type GLshort = ::std::os::raw::c_short;
-pub type GLint = ::std::os::raw::c_int;
-pub type GLubyte = ::std::os::raw::c_uchar;
-pub type GLushort = ::std::os::raw::c_ushort;
-pub type GLuint = ::std::os::raw::c_uint;
-pub type GLint64 = ::std::os::raw::c_longlong;
-pub type GLuint64 = ::std::os::raw::c_ulonglong;
-pub type GLsizei = ::std::os::raw::c_int;
-pub type GLchar = ::std::os::raw::c_char;
+pub type GLenum = ::core::ffi::c_uint;
+pub type GLboolean = ::core::ffi::c_uchar;
+pub type GLbitfield = ::core::ffi::c_uint;
+pub type GLvoid = ::core::ffi::c_void;
+pub type GLbyte = ::core::ffi::c_schar;
+pub type GLshort = ::core::ffi::c_short;
+pub type GLint = ::core::ffi::c_int;
+pub type GLubyte = ::core::ffi::c_uchar;
+pub type GLushort = ::core::ffi::c_ushort;
+pub type GLuint = ::core::ffi::c_uint;
+pub type GLint64 = ::core::ffi::c_longlong;
+pub type GLuint64 = ::core::ffi::c_ulonglong;
+pub type GLsizei = ::core::ffi::c_int;
+pub type GLchar = ::core::ffi::c_char;
 
-pub type khronos_ssize_t = ::std::os::raw::c_long;
-pub type khronos_usize_t = ::std::os::raw::c_ulong;
-pub type khronos_intptr_t = ::std::os::raw::c_long;
+pub type khronos_ssize_t = ::core::ffi::c_long;
+pub type khronos_usize_t = ::core::ffi::c_ulong;
+pub type khronos_intptr_t = ::core::ffi::c_long;
 
 pub type GLsizeiptr = khronos_ssize_t;
 pub type GLintptr = khronos_intptr_t;
@@ -334,14 +334,14 @@ extern "C" {
     pub fn glBufferData(
         target: GLenum,
         size: GLsizeiptr,
-        data: *const ::std::os::raw::c_void,
+        data: *const ::core::ffi::c_void,
         usage: GLenum,
     );
     pub fn glBufferSubData(
         target: GLenum,
         offset: GLintptr,
         size: GLsizeiptr,
-        data: *const ::std::os::raw::c_void,
+        data: *const ::core::ffi::c_void,
     );
     pub fn glCheckFramebufferStatus(target: GLenum) -> GLenum;
     pub fn glClear(mask: GLbitfield);
@@ -358,7 +358,7 @@ extern "C" {
         height: GLsizei,
         border: GLint,
         imageSize: GLsizei,
-        data: *const ::std::os::raw::c_void,
+        data: *const ::core::ffi::c_void,
     );
     pub fn glCompressedTexSubImage2D(
         target: GLenum,
@@ -369,7 +369,7 @@ extern "C" {
         height: GLsizei,
         format: GLenum,
         imageSize: GLsizei,
-        data: *const ::std::os::raw::c_void,
+        data: *const ::core::ffi::c_void,
     );
     pub fn glCopyTexImage2D(
         target: GLenum,
@@ -411,7 +411,7 @@ extern "C" {
         mode: GLenum,
         count: GLsizei,
         type_: GLenum,
-        indices: *const ::std::os::raw::c_void,
+        indices: *const ::core::ffi::c_void,
     );
     pub fn glEnable(cap: GLenum);
     pub fn glEnableVertexAttribArray(index: GLuint);
@@ -510,7 +510,7 @@ extern "C" {
     pub fn glGetVertexAttribPointerv(
         index: GLuint,
         pname: GLenum,
-        pointer: *mut *mut ::std::os::raw::c_void,
+        pointer: *mut *mut ::core::ffi::c_void,
     );
     pub fn glHint(target: GLenum, mode: GLenum);
     pub fn glIsBuffer(buffer: GLuint) -> GLboolean;
@@ -531,7 +531,7 @@ extern "C" {
         height: GLsizei,
         format: GLenum,
         type_: GLenum,
-        pixels: *mut ::std::os::raw::c_void,
+        pixels: *mut ::core::ffi::c_void,
     );
     pub fn glReleaseShaderCompiler();
     pub fn glRenderbufferStorage(
@@ -546,7 +546,7 @@ extern "C" {
         count: GLsizei,
         shaders: *const GLuint,
         binaryformat: GLenum,
-        binary: *const ::std::os::raw::c_void,
+        binary: *const ::core::ffi::c_void,
         length: GLsizei,
     );
     pub fn glShaderSource(
@@ -570,7 +570,7 @@ extern "C" {
         border: GLint,
         format: GLenum,
         type_: GLenum,
-        pixels: *const ::std::os::raw::c_void,
+        pixels: *const ::core::ffi::c_void,
     );
     pub fn glTexParameterf(target: GLenum, pname: GLenum, param: GLfloat);
     pub fn glTexParameterfv(target: GLenum, pname: GLenum, params: *const GLfloat);
@@ -585,7 +585,7 @@ extern "C" {
         height: GLsizei,
         format: GLenum,
         type_: GLenum,
-        pixels: *const ::std::os::raw::c_void,
+        pixels: *const ::core::ffi::c_void,
     );
     pub fn glUniform1f(location: GLint, v0: GLfloat);
     pub fn glUniform1fv(location: GLint, count: GLsizei, value: *const GLfloat);
@@ -637,14 +637,14 @@ extern "C" {
         type_: GLenum,
         normalized: GLboolean,
         stride: GLsizei,
-        pointer: *const ::std::os::raw::c_void,
+        pointer: *const ::core::ffi::c_void,
     );
     pub fn glVertexAttribIPointer(
         index: GLuint,
         size: GLint,
         type_: GLenum,
         stride: GLsizei,
-        pointer: *const ::std::os::raw::c_void,
+        pointer: *const ::core::ffi::c_void,
     );
     pub fn glViewport(x: GLint, y: GLint, width: GLsizei, height: GLsizei);
     pub fn glReadBuffer(src: GLenum);
@@ -654,7 +654,7 @@ extern "C" {
         end: GLuint,
         count: GLsizei,
         type_: GLenum,
-        indices: *const ::std::os::raw::c_void,
+        indices: *const ::core::ffi::c_void,
     );
     pub fn glTexImage3D(
         target: GLenum,
@@ -666,7 +666,7 @@ extern "C" {
         border: GLint,
         format: GLenum,
         type_: GLenum,
-        pixels: *const ::std::os::raw::c_void,
+        pixels: *const ::core::ffi::c_void,
     );
     pub fn glTexSubImage3D(
         target: GLenum,
@@ -679,7 +679,7 @@ extern "C" {
         depth: GLsizei,
         format: GLenum,
         type_: GLenum,
-        pixels: *const ::std::os::raw::c_void,
+        pixels: *const ::core::ffi::c_void,
     );
     pub fn glCopyTexSubImage3D(
         target: GLenum,
@@ -701,7 +701,7 @@ extern "C" {
         depth: GLsizei,
         border: GLint,
         imageSize: GLsizei,
-        data: *const ::std::os::raw::c_void,
+        data: *const ::core::ffi::c_void,
     );
     pub fn glCompressedTexSubImage3D(
         target: GLenum,
@@ -714,7 +714,7 @@ extern "C" {
         depth: GLsizei,
         format: GLenum,
         imageSize: GLsizei,
-        data: *const ::std::os::raw::c_void,
+        data: *const ::core::ffi::c_void,
     );
     pub fn glGenQueries(n: GLsizei, ids: *mut GLuint);
     pub fn glDeleteQueries(n: GLsizei, ids: *const GLuint);
@@ -729,7 +729,7 @@ extern "C" {
     pub fn glGetBufferPointerv(
         target: GLenum,
         pname: GLenum,
-        params: *mut *mut ::std::os::raw::c_void,
+        params: *mut *mut ::core::ffi::c_void,
     );
     pub fn glDrawBuffers(n: GLsizei, bufs: *const GLenum);
     pub fn glUniformMatrix2x3fv(
@@ -799,7 +799,7 @@ extern "C" {
         offset: GLintptr,
         length: GLsizeiptr,
         access: GLbitfield,
-    ) -> *mut ::std::os::raw::c_void;
+    ) -> *mut ::core::ffi::c_void;
     pub fn glFlushMappedBufferRange(target: GLenum, offset: GLintptr, length: GLsizeiptr);
     pub fn glBindVertexArray(array: GLuint);
     pub fn glDeleteVertexArrays(n: GLsizei, arrays: *const GLuint);
@@ -901,7 +901,7 @@ extern "C" {
         mode: GLenum,
         count: GLsizei,
         type_: GLenum,
-        indices: *const ::std::os::raw::c_void,
+        indices: *const ::core::ffi::c_void,
         instancecount: GLsizei,
     );
     pub fn glFenceSync(condition: GLenum, flags: GLbitfield) -> GLsync;
@@ -941,12 +941,12 @@ extern "C" {
         bufSize: GLsizei,
         length: *mut GLsizei,
         binaryFormat: *mut GLenum,
-        binary: *mut ::std::os::raw::c_void,
+        binary: *mut ::core::ffi::c_void,
     );
     pub fn glProgramBinary(
         program: GLuint,
         binaryFormat: GLenum,
-        binary: *const ::std::os::raw::c_void,
+        binary: *const ::core::ffi::c_void,
         length: GLsizei,
     );
     pub fn glProgramParameteri(program: GLuint, pname: GLenum, value: GLint);


### PR DESCRIPTION
`std::os::raw` is semi-deprecated since six years and recommends using `core::ffi` instead.
This PR is just a replacement of all usages of this module.