### PR TITLE
make module native public

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -3,7 +3,7 @@ pub mod conf;
 mod event;
 pub mod fs;
 pub mod graphics;
-mod native;
+pub mod native;
 use std::collections::HashMap;
 use std::ops::{Index, IndexMut};
 


### PR DESCRIPTION
I'm following this guide https://macroquad.rs/articles/java/

which requires `miniquad::native::android::{self, ndk_sys, ndk_utils}` to be public in order to extend the Android java files.