### PR TITLE
Add borderless windows for Windows and Linux X11

### DIFF
--- a/src/conf.rs
+++ b/src/conf.rs
@@ -162,6 +162,10 @@ pub struct Conf {
     ///
     /// Default: false
     pub fullscreen: bool,
+    /// Whether the window should be created without borders, ignored on wasm/android.
+    ///
+    /// Default: false
+    pub borderless: bool,
     /// MSAA sample count
     ///
     /// Default: 1
@@ -221,6 +225,7 @@ impl Default for Conf {
             window_height: 600,
             high_dpi: false,
             fullscreen: false,
+            borderless: false,
             sample_count: 1,
             window_resizable: true,
             icon: Some(Icon::miniquad_logo()),
@@ -238,6 +243,7 @@ impl Default for Conf {
             window_height: 600,
             high_dpi: true,
             fullscreen: true,
+            borderless: false,
             sample_count: 1,
             window_resizable: false,
             icon: Some(Icon::miniquad_logo()),

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -266,6 +266,13 @@ pub mod window {
             .unwrap();
     }
 
+    pub fn set_borderless(borderless: bool) {
+        let d = native_display().lock().unwrap();
+        d.native_requests
+            .send(native::Request::SetBorderless(borderless))
+            .unwrap();
+    }
+
     /// Get current OS clipboard value
     pub fn clipboard_get() -> Option<String> {
         let mut d = native_display().lock().unwrap();

--- a/src/native.rs
+++ b/src/native.rs
@@ -70,6 +70,7 @@ pub(crate) enum Request {
     SetWindowSize { new_width: u32, new_height: u32 },
     SetWindowPosition { new_x: u32, new_y: u32 },
     SetFullscreen(bool),
+    SetBorderless(bool),
     ShowKeyboard(bool),
 }
 

--- a/src/native/linux_x11.rs
+++ b/src/native/linux_x11.rs
@@ -16,7 +16,7 @@ use crate::{
 
 use libx11::*;
 
-use std::collections::HashMap;
+use std::{collections::HashMap, mem};
 
 #[derive(Debug, PartialEq, Eq, Clone)]
 pub enum X11Error {
@@ -261,6 +261,31 @@ impl X11Display {
         }
     }
 
+    unsafe fn set_borderless(&mut self, window: Window, borderless: bool) {
+        let hints_atom = (self.libx11.XInternAtom)(
+            self.display,
+            b"_MOTIF_WM_HINTS\x00" as *const u8 as *const _,
+            false as _,
+        );
+
+        let mut hints: MWMHints = mem::zeroed();
+
+        hints.flags = hints_atom;
+        hints.decorations = if borderless { 0 } else { 1 };
+
+        (self.libx11.XChangeProperty)(
+            self.display,
+            window,
+            hints_atom as _,
+            4 as _,
+            32,
+            PropModeReplace,
+            &mut hints as *mut _ as *mut _,
+            5,
+        );
+        (self.libx11.XFlush)(self.display);
+    }
+
     unsafe fn set_window_size(&mut self, window: Window, new_width: i32, new_height: i32) {
         (self.libx11.XResizeWindow)(self.display, window, new_width, new_height);
         (self.libx11.XFlush)(self.display);
@@ -418,6 +443,9 @@ where
     });
     if conf.fullscreen {
         display.set_fullscreen(display.window, true);
+    }
+    if conf.borderless {
+        display.set_borderless(display.window, true);
     }
 
     let mut event_handler = (f.take().unwrap())();

--- a/src/native/linux_x11.rs
+++ b/src/native/linux_x11.rs
@@ -384,6 +384,7 @@ impl X11Display {
                     self.set_window_position(self.window, new_x as _, new_y as _)
                 }
                 SetFullscreen(fullscreen) => self.set_fullscreen(self.window, fullscreen),
+                SetBorderless(borderless) => self.set_borderless(self.window, borderless),
                 ShowKeyboard(..) => {
                     eprintln!("Not implemented for X11")
                 }

--- a/src/native/linux_x11.rs
+++ b/src/native/linux_x11.rs
@@ -270,7 +270,7 @@ impl X11Display {
 
         let mut hints: MWMHints = mem::zeroed();
 
-        hints.flags = hints_atom;
+        hints.flags = 2; // MWM_HINTS_DECORATIONS
         hints.decorations = if borderless { 0 } else { 1 };
 
         (self.libx11.XChangeProperty)(

--- a/src/native/linux_x11.rs
+++ b/src/native/linux_x11.rs
@@ -277,7 +277,7 @@ impl X11Display {
             self.display,
             window,
             hints_atom as _,
-            4 as _,
+            hints_atom as _,
             32,
             PropModeReplace,
             &mut hints as *mut _ as *mut _,

--- a/src/native/linux_x11/libx11.rs
+++ b/src/native/linux_x11/libx11.rs
@@ -722,6 +722,15 @@ pub mod Xutil_h {
     }
     #[derive(Copy, Clone)]
     #[repr(C)]
+    pub struct MWMHints {
+        pub flags: libc::c_ulong,
+        pub functions: libc::c_ulong,
+        pub decorations: libc::c_ulong,
+        pub input_mode: libc::c_long,
+        pub status: libc::c_ulong,
+    }
+    #[derive(Copy, Clone)]
+    #[repr(C)]
     pub struct XWMHints {
         pub flags: libc::c_long,
         pub input: libc::c_int,

--- a/src/native/windows.rs
+++ b/src/native/windows.rs
@@ -196,6 +196,22 @@ impl WindowsDisplay {
             ShowWindow(self.wnd, SW_SHOW);
         };
     }
+
+    fn set_borderless(&mut self, borderless: bool) {
+        self.borderless = borderless as _;
+
+        let win_style: DWORD =
+            get_win_style(self.fullscreen, self.borderless, self.window_resizable);
+
+        unsafe {
+            #[cfg(target_arch = "x86_64")]
+            SetWindowLongPtrA(self.wnd, GWL_STYLE, win_style as _);
+            #[cfg(target_arch = "i686")]
+            SetWindowLong(self.wnd, GWL_STYLE, win_style as _);
+
+            ShowWindow(self.wnd, SW_SHOW);
+        };
+    }
 }
 
 fn get_win_style(is_fullscreen: bool, is_borderless: bool, is_resizable: bool) -> DWORD {
@@ -833,6 +849,7 @@ impl WindowsDisplay {
                 } => self.set_window_size(new_width as _, new_height as _),
                 SetWindowPosition { new_x, new_y } => self.set_window_position(new_x, new_y),
                 SetFullscreen(fullscreen) => self.set_fullscreen(fullscreen),
+                SetBorderless(borderless) => self.set_borderless(borderless),
                 ShowKeyboard(show) => {
                     eprintln!("Not implemented for windows")
                 }


### PR DESCRIPTION
Adds borderless field to Conf and `set_borderless` function to make the window borderless. I have implemented it for WIndows and Linux X11.

Haven't implemented it for MacOS or Wayland since I don't have any devices to test on.