### PR TITLE
Add //% QUAD_SURFACE_ON_CREATE_INPUT_CONNECTION to java/MainActivity.

### DIFF
--- a/java/MainActivity.java
+++ b/java/MainActivity.java
@@ -180,6 +180,8 @@ class QuadSurface
     // For some reason it only works if placed here and not in the parent layout.
     @Override
     public InputConnection onCreateInputConnection(EditorInfo outAttrs) {
+        //% QUAD_SURFACE_ON_CREATE_INPUT_CONNECTION
+
         InputConnection connection = super.onCreateInputConnection(outAttrs);
         outAttrs.imeOptions |= EditorInfo.IME_FLAG_NO_FULLSCREEN;
         return connection;


### PR DESCRIPTION
I need to modify onCreateInputConnection() to return my own InputConnection so I can catch user typing suggestions. Putting this here allows me to return early with my own custom input connection.

```java
//% QUAD_SURFACE_ON_CREATE_INPUT_CONNECTION

Log.i("darkfi", "QuadSurface::onCreateInputConnection() called");

// Needed to fix error: unreachable statement in Java
if (true) {
    outAttrs.inputType = InputType.TYPE_CLASS_TEXT;
    outAttrs.imeOptions = EditorInfo.IME_ACTION_DONE;
    // fullEditor is false, but we might set this to true for enabling
    // text selection, and copy/paste. Lets see.
    return new CustomInputConnection(this, false);
}

//% END

```

See also https://github.com/not-fl3/cargo-quad-apk/pull/8