### PR TITLE
android: make ACTIVITY jobject public

### DIFF
--- a/src/native/android.rs
+++ b/src/native/android.rs
@@ -83,7 +83,7 @@ fn send_message(message: Message) {
     })
 }
 
-static mut ACTIVITY: ndk_sys::jobject = std::ptr::null_mut();
+pub static mut ACTIVITY: ndk_sys::jobject = std::ptr::null_mut();
 static mut VM: *mut ndk_sys::JavaVM = std::ptr::null_mut();
 
 pub unsafe fn console_debug(msg: *const ::core::ffi::c_char) {


### PR DESCRIPTION
I need to access the main Context to get system services using `getSystemService()` so I can access `InputMethodManager`. I could workaround this by adding a hook in the MainActivity constructor but this seems the easiest solution since it's already in miniquad.