### PR TITLE
simplify redundant `std::char` paths

### DIFF
--- a/src/native/linux_wayland.rs
+++ b/src/native/linux_wayland.rs
@@ -771,7 +771,7 @@ where
 
                     let chr = keycodes::keysym_to_unicode(&mut display.xkb, *keysym);
                     if chr > 0 {
-                        if let Some(chr) = std::char::from_u32(chr as u32) {
+                        if let Some(chr) = char::from_u32(chr as u32) {
                             event_handler.char_event(chr, keymods, true);
                         }
                     }
@@ -821,7 +821,7 @@ where
 
                                 let chr = keycodes::keysym_to_unicode(&mut display.xkb, keysym);
                                 if chr > 0 {
-                                    if let Some(chr) = std::char::from_u32(chr as u32) {
+                                    if let Some(chr) = char::from_u32(chr as u32) {
                                         event_handler.char_event(chr, keymods, false);
                                     }
                                 }

--- a/src/native/linux_x11.rs
+++ b/src/native/linux_x11.rs
@@ -67,7 +67,7 @@ impl X11Display {
                 );
                 let chr = keycodes::keysym_to_unicode(&mut self.libxkbcommon, keysym);
                 if chr > 0 {
-                    if let Some(chr) = std::char::from_u32(chr as u32) {
+                    if let Some(chr) = char::from_u32(chr as u32) {
                         event_handler.char_event(chr, mods, repeat);
                     }
                 }

--- a/src/native/windows.rs
+++ b/src/native/windows.rs
@@ -462,7 +462,7 @@ unsafe extern "system" fn win32_wndproc(
             let repeat = !!(lparam & 0x40000000) != 0;
             let mods = key_mods();
             if chr > 0 {
-                if let Some(chr) = std::char::from_u32(chr as u32) {
+                if let Some(chr) = char::from_u32(chr as u32) {
                     event_handler.char_event(chr, mods, repeat);
                 }
             }


### PR DESCRIPTION
No need to use `std::char`, just `char` suffices and is also the recommended way of using it.