### PR TITLE
macOS Metal | fix: wrap perform_redraw in autoreleasepool

### DIFF
--- a/src/native/macos.rs
+++ b/src/native/macos.rs
@@ -18,6 +18,7 @@ use {
         sync::mpsc::Receiver,
         time::{Duration, Instant},
     },
+    objc::rc::autoreleasepool,
 };
 
 pub struct MacosDisplay {
@@ -1175,7 +1176,9 @@ where
         }
 
         if !conf.platform.blocking_event_loop || display.update_requested {
-            perform_redraw(&mut display, conf.platform.apple_gfx_api, false);
+            autoreleasepool(|| {
+                perform_redraw(&mut display, conf.platform.apple_gfx_api, false);
+            });
         }
     }
 }


### PR DESCRIPTION
There seems to be a memory leak on the Metal backend during window resize where some Metal objects are not being released properly. `[... release]` can't be called manually on the objects because [perform_redraw](https://github.com/not-fl3/miniquad/blob/b4fa8fe551e4749953fa6ebbd75d93b861ed3b78/src/native/macos.rs#L946) is called within an autorelease pool in [draw_rect](https://github.com/not-fl3/miniquad/blob/b4fa8fe551e4749953fa6ebbd75d93b861ed3b78/src/native/macos.rs#L695) (since its an event handler), so that will cause a double-free. So I just wrapped `perform_draw` in [run](https://github.com/not-fl3/miniquad/blob/b4fa8fe551e4749953fa6ebbd75d93b861ed3b78/src/native/macos.rs#L1003) in an `autoreleasepool` and that seems to do the trick.