### PR TITLE
android: improve panic_hook output. {:?} will show not actually show the error message

### DIFF
--- a/src/native/android.rs
+++ b/src/native/android.rs
@@ -346,7 +346,7 @@ where
         use std::panic;
 
         panic::set_hook(Box::new(|info| {
-            let msg = CString::new(format!("{:?}", info)).unwrap_or_else(|_| {
+            let msg = CString::new(format!("{info}")).unwrap_or_else(|_| {
                 CString::new(format!("MALFORMED ERROR MESSAGE {:?}", info.location())).unwrap()
             });
             console_error(msg.as_ptr());


### PR DESCRIPTION
```
01-08 10:10:50.759 12542 12564 E SAPP    : PanicHookInfo { payload: Any { .. }, location: Location { file: "/usr/local/cargo/registry/src/index.crates.io-6f17d22bba15001f/ndk-context-0.1.1/src/lib.rs", line: 72, col: 30 }, can_unwind: true, force_no_backtrace: false }
```

vs

```
01-08 10:08:59.217 12451 12478 E SAPP    : panicked at /usr/local/cargo/registry/src/index.crates.io-6f17d22bba15001f/ndk-context-0.1.1/src/lib.rs:72:30:
01-08 10:08:59.217 12451 12478 E SAPP    : android context was not initialized
```