### PR TITLE
macos: add window_resizable impl

### DIFF
--- a/src/native/macos.rs
+++ b/src/native/macos.rs
@@ -1049,10 +1049,13 @@ where
 
     initialize_menu_bar(ns_app);
 
-    let window_masks = NSWindowStyleMask::NSTitledWindowMask as u64
+    let mut window_masks = NSWindowStyleMask::NSTitledWindowMask as u64
         | NSWindowStyleMask::NSClosableWindowMask as u64
-        | NSWindowStyleMask::NSMiniaturizableWindowMask as u64
-        | NSWindowStyleMask::NSResizableWindowMask as u64;
+        | NSWindowStyleMask::NSMiniaturizableWindowMask as u64;
+
+    if conf.window_resizable {
+        window_masks |= NSWindowStyleMask::NSResizableWindowMask as u64;
+    }
 
     let window_frame = NSRect {
         origin: NSPoint { x: 0., y: 0. },


### PR DESCRIPTION
Resolves not-fl3/macroquad#210 on macOS only.
This makes `window_masks` mutable but it can be changed to be within a block instead.

Let me know if I'm missing something obvious like a set_resizable function, it's my first time looking at this codebase.