### PR TITLE
implement `Display` trait for most error types

### DIFF
--- a/src/fs.rs
+++ b/src/fs.rs
@@ -12,19 +12,25 @@ pub enum Error {
     IOSAssetNoData,
 }
 
-impl std::fmt::Display for Error {
-    fn fmt(&self, f: &mut std::fmt::Formatter) -> std::fmt::Result {
-        match *self {
-            _ => write!(f, "Error: {:?}", self),
-        }
-    }
-}
-
 impl From<std::io::Error> for Error {
     fn from(e: std::io::Error) -> Error {
         Error::IOError(e)
     }
 }
+
+impl std::fmt::Display for Error {
+    fn fmt(&self, f: &mut std::fmt::Formatter) -> std::fmt::Result {
+        match self {
+            Self::IOError(e) => write!(f, "I/O error: {e}"),
+            Self::DownloadFailed => write!(f, "Download failed"),
+            Self::AndroidAssetLoadingError => write!(f, "[android] Failed to load asset"),
+            Self::IOSAssetNoSuchFile => write!(f, "[ios] No such asset file"),
+            Self::IOSAssetNoData => write!(f, "[ios] No data in asset file"),
+        }
+    }
+}
+
+impl std::error::Error for Error {}
 
 pub type Response = Result<Vec<u8>, Error>;
 

--- a/src/graphics.rs
+++ b/src/graphics.rs
@@ -278,6 +278,15 @@ pub enum ShaderType {
     Fragment,
 }
 
+impl Display for ShaderType {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        match self {
+            Self::Vertex => write!(f, "Vertex"),
+            Self::Fragment => write!(f, "Fragment"),
+        }
+    }
+}
+
 #[derive(Clone, Debug)]
 pub enum ShaderError {
     CompilationError {
@@ -297,15 +306,18 @@ impl From<std::ffi::NulError> for ShaderError {
 
 impl Display for ShaderError {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
-        write!(f, "{:?}", self) // Display the same way as Debug
+        match self {
+            Self::CompilationError {
+                shader_type,
+                error_message,
+            } => write!(f, "{shader_type} shader error:\n{error_message}"),
+            Self::LinkError(msg) => write!(f, "Link shader error:\n{msg}"),
+            Self::FFINulError(e) => write!(f, "{e}"),
+        }
     }
 }
 
-impl Error for ShaderError {
-    fn source(&self) -> Option<&(dyn Error + 'static)> {
-        None
-    }
-}
+impl Error for ShaderError {}
 
 /// List of all the possible formats of input data when uploading to texture.
 /// The list is built by intersection of texture formats supported by 3.3 core profile and webgl1.

--- a/src/native/egl.rs
+++ b/src/native/egl.rs
@@ -17,6 +17,7 @@ pub type EGLNativePixmapType = ::core::ffi::c_ulong;
 pub type EGLNativeWindowType = ::core::ffi::c_ulong;
 
 pub use core::ptr::null_mut;
+use std::fmt::Display;
 
 pub const EGL_SUCCESS: u32 = 12288;
 
@@ -255,6 +256,18 @@ pub enum EglError {
     InitializeFailed,
     CreateContextFailed,
 }
+
+impl Display for EglError {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        match self {
+            Self::NoDisplay => write!(f, "No display"),
+            Self::InitializeFailed => write!(f, "Failed to initialize context"),
+            Self::CreateContextFailed => write!(f, "Faild to create context"),
+        }
+    }
+}
+
+impl std::error::Error for EglError {}
 
 pub struct Egl {}
 

--- a/src/native/linux_x11.rs
+++ b/src/native/linux_x11.rs
@@ -25,7 +25,10 @@ pub enum X11Error {
 }
 impl std::fmt::Display for X11Error {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
-        write!(f, "{:?}", self)
+        match self {
+            Self::LibraryNotFound(e) => write!(f, "Library not found error: {e}"),
+            Self::GLXError(msg) => write!(f, "GLX error:\n{msg}"),
+        }
     }
 }
 impl From<module::Error> for X11Error {

--- a/src/native/module.rs
+++ b/src/native/module.rs
@@ -4,6 +4,15 @@ pub enum Error {
     DlSymError(String),
 }
 
+impl Display for Error {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        match self {
+            Self::DlOpenError(msg) => write!(f, "Shared library open error:\n{msg}"),
+            Self::DlSymError(msg) => write!(f, "Shared library symlink error:\n{msg}"),
+        }
+    }
+}
+
 #[cfg(any(target_os = "linux", target_os = "android"))]
 pub mod linux {
     use super::Error;
@@ -78,6 +87,8 @@ mod windows {
         }
     }
 }
+
+use std::fmt::Display;
 
 #[cfg(any(target_os = "linux", target_os = "android"))]
 pub use linux::*;


### PR DESCRIPTION
This simple PR adds human readable `Display` implementation for most error types to simplify error handling

Namely for these types:

- `ShaderError`
- `ShaderType`
- `EglError`
- `X11Error`
- `Error` in `src/fs.rs`
- `Error` in `src/native/module.rs`

Error handling example:

```rust
let conf = miniquad::conf::Conf::default();

// `MyWindow::new()` returns `Result<MyWindow, ShaderError>`
miniquad::start(conf, move || match MyWindow::new() {
    Ok(window) => Box::new(window),
    Err(e) => {
        eprintln!("Miniquad error: {e}");
        std::process::exit(1);
    }
});
```

```glsl
#version 330

layout (location = 0) in vec2 in_pos;
layout (location = 1) in vec2 in_uv;

out vec2 uv;

void main() {
    uv = in_uv;
    I_MISSPELLED_VAR_NAME = vec4(in_pos, 0.0, 1.0);
}
```

Error message before:

```
Miniquad error: CompilationError { shader_type: Vertex, error_message: "0:10(2): error: `I_MISSPELLED_VAR_NAME' undeclared\n0:10(2): error: value of type vec4 cannot be assigned to variable of type error" }
```

After:

```
Miniquad error: Vertex shader error:
0:10(2): error: `I_MISSPELLED_VAR_NAME' undeclared
0:10(2): error: value of type vec4 cannot be assigned to variable of type error
```

EDIT: updated examples for more context