### PR TITLE
clear the modifier keys on exiting the focused window

### DIFF
--- a/src/event.rs
+++ b/src/event.rs
@@ -181,6 +181,8 @@ pub trait EventHandler {
 
     fn key_down_event(&mut self, _keycode: KeyCode, _keymods: KeyMods, _repeat: bool) {}
 
+    /// Note: you are not always guaranteed to receive a key_up event. For example on
+    /// Wayland when leaving the focused window, the key_up event will not be caught.
     fn key_up_event(&mut self, _keycode: KeyCode, _keymods: KeyMods) {}
 
     /// Default implementation emulates mouse clicks

--- a/src/native/linux_wayland.rs
+++ b/src/native/linux_wayland.rs
@@ -131,6 +131,7 @@ unsafe extern "C" fn seat_handle_capabilities(
 }
 
 enum WaylandEvent {
+    KeyboardLeave,
     KeyboardKey(u32, bool),
     PointerMotion(f32, f32),
     PointerButton(MouseButton, bool),
@@ -184,6 +185,8 @@ unsafe extern "C" fn keyboard_handle_enter(
     _surface: *mut wl_surface,
     _keys: *mut wl_array,
 ) {
+    // We can capture held keys when window is refocused.
+    // Ignore this for now.
 }
 unsafe extern "C" fn keyboard_handle_leave(
     _data: *mut ::core::ffi::c_void,
@@ -191,6 +194,7 @@ unsafe extern "C" fn keyboard_handle_leave(
     _serial: u32,
     _surface: *mut wl_surface,
 ) {
+    EVENTS.push(WaylandEvent::KeyboardLeave);
 }
 unsafe extern "C" fn keyboard_handle_key(
     data: *mut ::core::ffi::c_void,
@@ -802,6 +806,9 @@ where
 
                 for event in EVENTS.drain(..) {
                     match event {
+                        WaylandEvent::KeyboardLeave => {
+                            repeated_keys.clear();
+                        }
                         WaylandEvent::KeyboardKey(key, state) => {
                             // https://wayland-book.com/seat/keyboard.html
                             // To translate this to an XKB scancode, you must add 8 to the evdev scancode.

--- a/src/native/linux_wayland.rs
+++ b/src/native/linux_wayland.rs
@@ -189,11 +189,14 @@ unsafe extern "C" fn keyboard_handle_enter(
     // Ignore this for now.
 }
 unsafe extern "C" fn keyboard_handle_leave(
-    _data: *mut ::core::ffi::c_void,
+    data: *mut ::core::ffi::c_void,
     _wl_keyboard: *mut wl_keyboard,
     _serial: u32,
     _surface: *mut wl_surface,
 ) {
+    // Clear modifiers
+    let display: &mut WaylandPayload = &mut *(data as *mut _);
+    (display.xkb.xkb_state_update_mask)(display.xkb_state, 0, 0, 0, 0, 0, 0);
     EVENTS.push(WaylandEvent::KeyboardLeave);
 }
 unsafe extern "C" fn keyboard_handle_key(
@@ -808,6 +811,10 @@ where
                     match event {
                         WaylandEvent::KeyboardLeave => {
                             repeated_keys.clear();
+                            keymods.shift = false;
+                            keymods.ctrl = false;
+                            keymods.logo = false;
+                            keymods.alt = false;
                         }
                         WaylandEvent::KeyboardKey(key, state) => {
                             // https://wayland-book.com/seat/keyboard.html


### PR DESCRIPTION
we need to clear the mods otherwise they can be released outside the window's focus and stay on when the window is refocused.

btw when you get a chance, please approve issue https://github.com/not-fl3/miniquad/issues/517, ty!