### PR TITLE
Android: Adding FULLSCREEN flag when the window is fullscreen.

### DIFF
--- a/java/MainActivity.java
+++ b/java/MainActivity.java
@@ -308,6 +308,7 @@ public class MainActivity extends Activity {
 
                     if (fullscreen) {
                         getWindow().setFlags(LayoutParams.FLAG_LAYOUT_NO_LIMITS, LayoutParams.FLAG_LAYOUT_NO_LIMITS);
+                        getWindow().addFlags(LayoutParams.FLAG_FULLSCREEN);
                         if (Build.VERSION.SDK_INT >= 28) {
                             getWindow().getAttributes().layoutInDisplayCutoutMode = LayoutParams.LAYOUT_IN_DISPLAY_CUTOUT_MODE_SHORT_EDGES;
                         }


### PR DESCRIPTION
This flag is needed to properly hide display cutout on Android devices,
Without it a black space appears on the status bar.
Refer to
https://stackoverflow.com/questions/49190381/fullscreen-app-with-displaycutout