### PR TITLE
graphics!: separate texture binding from the `Bindings` struct

### DIFF
--- a/examples/blobs.rs
+++ b/examples/blobs.rs
@@ -47,8 +47,7 @@ impl Stage {
 
         let bindings = Bindings {
             vertex_buffers: vec![vertex_buffer],
-            index_buffer: index_buffer,
-            images: vec![],
+            index_buffer,
         };
 
         let shader = ctx

--- a/examples/instancing.rs
+++ b/examples/instancing.rs
@@ -58,8 +58,7 @@ impl Stage {
 
         let bindings = Bindings {
             vertex_buffers: vec![geometry_vertex_buffer, positions_vertex_buffer],
-            index_buffer: index_buffer,
-            images: vec![],
+            index_buffer,
         };
 
         let shader = ctx

--- a/examples/msaa_render_texture.rs
+++ b/examples/msaa_render_texture.rs
@@ -8,6 +8,7 @@ struct Stage {
     offscreen_pipeline: Pipeline,
     offscreen_bind: Bindings,
     offscreen_pass: RenderPass,
+    color_resolve_img: TextureId,
     rx: f32,
     ry: f32,
     ctx: Box<dyn RenderingBackend>,
@@ -104,9 +105,8 @@ impl Stage {
         );
 
         let offscreen_bind = Bindings {
-            vertex_buffers: vec![vertex_buffer.clone()],
-            index_buffer: index_buffer.clone(),
-            images: vec![],
+            vertex_buffers: vec![vertex_buffer],
+            index_buffer,
         };
 
         let display_bind = {
@@ -130,8 +130,7 @@ impl Stage {
             );
             Bindings {
                 vertex_buffers: vec![vertex_buffer],
-                index_buffer: index_buffer,
-                images: vec![color_resolve_img],
+                index_buffer,
             }
         };
 
@@ -195,6 +194,7 @@ impl Stage {
             offscreen_pipeline,
             offscreen_bind,
             offscreen_pass,
+            color_resolve_img,
             rx: 0.,
             ry: 0.,
             ctx,
@@ -240,6 +240,7 @@ impl EventHandler for Stage {
             .begin_default_pass(PassAction::clear_color(0.0, 0., 0.45, 1.));
         self.ctx.apply_pipeline(&self.display_pipeline);
         self.ctx.apply_bindings(&self.display_bind);
+        self.ctx.apply_image(&self.color_resolve_img);
         self.ctx.apply_uniforms(UniformsSource::table(&vs_params));
         self.ctx.draw(0, 6, 1);
         self.ctx.end_render_pass();

--- a/examples/offscreen.rs
+++ b/examples/offscreen.rs
@@ -8,6 +8,7 @@ struct Stage {
     offscreen_pipeline: Pipeline,
     offscreen_bind: Bindings,
     offscreen_pass: RenderPass,
+    color_img: TextureId,
     rx: f32,
     ry: f32,
     ctx: Box<dyn RenderingBackend>,
@@ -89,15 +90,13 @@ impl Stage {
         );
 
         let offscreen_bind = Bindings {
-            vertex_buffers: vec![vertex_buffer.clone()],
-            index_buffer: index_buffer.clone(),
-            images: vec![],
+            vertex_buffers: vec![vertex_buffer],
+            index_buffer,
         };
 
         let display_bind = Bindings {
             vertex_buffers: vec![vertex_buffer],
-            index_buffer: index_buffer,
-            images: vec![color_img],
+            index_buffer,
         };
 
         let source = match ctx.info().backend {
@@ -160,6 +159,7 @@ impl Stage {
             offscreen_pipeline,
             offscreen_bind,
             offscreen_pass,
+            color_img,
             rx: 0.,
             ry: 0.,
             ctx,
@@ -205,6 +205,7 @@ impl EventHandler for Stage {
             .begin_default_pass(PassAction::clear_color(0.0, 0., 0.45, 1.));
         self.ctx.apply_pipeline(&self.display_pipeline);
         self.ctx.apply_bindings(&self.display_bind);
+        self.ctx.apply_image(&self.color_img);
         self.ctx.apply_uniforms(UniformsSource::table(&vs_params));
         self.ctx.draw(0, 36, 1);
         self.ctx.end_render_pass();

--- a/examples/post_processing.rs
+++ b/examples/post_processing.rs
@@ -8,6 +8,7 @@ struct Stage {
     offscreen_pipeline: Pipeline,
     offscreen_bind: Bindings,
     offscreen_pass: RenderPass,
+    color_img: TextureId,
     rx: f32,
     ry: f32,
 
@@ -90,9 +91,8 @@ impl Stage {
         );
 
         let offscreen_bind = Bindings {
-            vertex_buffers: vec![vertex_buffer.clone()],
-            index_buffer: index_buffer.clone(),
-            images: vec![],
+            vertex_buffers: vec![vertex_buffer],
+            index_buffer,
         };
 
         #[rustfmt::skip]
@@ -120,8 +120,7 @@ impl Stage {
 
         let post_processing_bind = Bindings {
             vertex_buffers: vec![vertex_buffer],
-            index_buffer: index_buffer,
-            images: vec![color_img],
+            index_buffer,
         };
 
         let default_shader = ctx
@@ -180,6 +179,7 @@ impl Stage {
             offscreen_pipeline,
             offscreen_bind,
             offscreen_pass,
+            color_img,
             rx: 0.,
             ry: 0.,
             ctx,
@@ -208,7 +208,7 @@ impl EventHandler for Stage {
 
         self.ctx.delete_render_pass(self.offscreen_pass);
         self.offscreen_pass = offscreen_pass;
-        self.post_processing_bind.images[0] = color_img;
+        self.color_img = color_img;
     }
 
     fn draw(&mut self) {
@@ -247,6 +247,7 @@ impl EventHandler for Stage {
         self.ctx.begin_default_pass(PassAction::Nothing);
         self.ctx.apply_pipeline(&self.post_processing_pipeline);
         self.ctx.apply_bindings(&self.post_processing_bind);
+        self.ctx.apply_image(&self.color_img);
         self.ctx
             .apply_uniforms(UniformsSource::table(&post_processing_shader::Uniforms {
                 resolution: glam::vec2(w, h),

--- a/examples/quad.rs
+++ b/examples/quad.rs
@@ -16,6 +16,7 @@ struct Stage {
 
     pipeline: Pipeline,
     bindings: Bindings,
+    texture: TextureId,
 }
 
 impl Stage {
@@ -53,8 +54,7 @@ impl Stage {
 
         let bindings = Bindings {
             vertex_buffers: vec![vertex_buffer],
-            index_buffer: index_buffer,
-            images: vec![texture],
+            index_buffer,
         };
 
         let shader = ctx
@@ -85,6 +85,7 @@ impl Stage {
         Stage {
             pipeline,
             bindings,
+            texture,
             ctx,
         }
     }
@@ -100,6 +101,7 @@ impl EventHandler for Stage {
 
         self.ctx.apply_pipeline(&self.pipeline);
         self.ctx.apply_bindings(&self.bindings);
+        self.ctx.apply_image(&self.texture);
         for i in 0..10 {
             let t = t + i as f64 * 0.3;
 

--- a/examples/triangle.rs
+++ b/examples/triangle.rs
@@ -37,8 +37,7 @@ impl Stage {
 
         let bindings = Bindings {
             vertex_buffers: vec![vertex_buffer],
-            index_buffer: index_buffer,
-            images: vec![],
+            index_buffer,
         };
 
         let shader = ctx

--- a/examples/triangle_color4b.rs
+++ b/examples/triangle_color4b.rs
@@ -37,8 +37,7 @@ impl Stage {
 
         let bindings = Bindings {
             vertex_buffers: vec![vertex_buffer],
-            index_buffer: index_buffer,
-            images: vec![],
+            index_buffer,
         };
 
         let shader = ctx

--- a/src/graphics.rs
+++ b/src/graphics.rs
@@ -767,7 +767,7 @@ impl Default for PipelineParams {
     }
 }
 
-/// Geometry bindings
+/// Geometry buffers bindings
 #[derive(Clone, Debug)]
 pub struct Bindings {
     /// Vertex buffers. Data contained in the buffer must match layout
@@ -781,9 +781,6 @@ pub struct Bindings {
     /// from a vertex buffer, with each subsequent 3 indices forming a
     /// triangle.
     pub index_buffer: BufferId,
-    /// Textures to be used with when drawing the geometry in the fragment
-    /// shader.
-    pub images: Vec<TextureId>,
 }
 
 #[derive(Clone, Copy, Debug, PartialEq)]
@@ -1322,19 +1319,15 @@ pub trait RenderingBackend {
     /// Should be applied after begin_pass.
     fn apply_scissor_rect(&mut self, x: i32, y: i32, w: i32, h: i32);
 
-    fn apply_bindings_from_slice(
-        &mut self,
-        vertex_buffers: &[BufferId],
-        index_buffer: BufferId,
-        textures: &[TextureId],
-    );
-
+    fn apply_bindings_from_slice(&mut self, vertex_buffers: &[BufferId], index_buffer: BufferId);
     fn apply_bindings(&mut self, bindings: &Bindings) {
-        self.apply_bindings_from_slice(
-            &bindings.vertex_buffers,
-            bindings.index_buffer,
-            &bindings.images,
-        );
+        self.apply_bindings_from_slice(&bindings.vertex_buffers, bindings.index_buffer);
+    }
+
+    fn apply_images(&mut self, images: &[TextureId]);
+    /// Same as [RenderingBackend::apply_images], but applies only one image
+    fn apply_image(&mut self, image: &TextureId) {
+        self.apply_images(std::slice::from_ref(image));
     }
 
     fn apply_uniforms(&mut self, uniforms: UniformsSource) {

--- a/src/graphics/metal.rs
+++ b/src/graphics/metal.rs
@@ -1057,12 +1057,7 @@ impl RenderingBackend for MetalContext {
         }
     }
 
-    fn apply_bindings_from_slice(
-        &mut self,
-        vertex_buffers: &[BufferId],
-        index_buffer: BufferId,
-        textures: &[TextureId],
-    ) {
+    fn apply_bindings_from_slice(&mut self, vertex_buffers: &[BufferId], index_buffer: BufferId) {
         assert!(
             self.render_encoder.is_some(),
             "apply_bindings before begin_pass"
@@ -1078,13 +1073,20 @@ impl RenderingBackend for MetalContext {
                                    atIndex:(index + 1) as u64];
                 buffer.next_value = buffer.value + 1;
             }
+
             let index_buffer = &mut self.buffers[index_buffer.0];
             self.index_buffer = Some(index_buffer.raw[index_buffer.value]);
             index_buffer.next_value = index_buffer.value + 1;
+        }
+    }
 
-            let img_count = textures.len();
+    fn apply_images(&mut self, images: &[TextureId]) {
+        unsafe {
+            let render_encoder = self.render_encoder.unwrap();
+
+            let img_count = images.len();
             if img_count > 0 {
-                for (n, img) in textures.iter().enumerate() {
+                for (n, img) in images.iter().enumerate() {
                     let Texture {
                         sampler, texture, ..
                     } = self.textures.get(*img);


### PR DESCRIPTION
>[!WARNING]
>This PR **will** break most of the existing code

This PR aims to make MINIQUAD api more flexible by separating texture binding to its own method `RenderingBackend::apply_images`

## Why?

Sometimes i need to use the same buffer bindings (vertex and index buffers) for different sprites for example (because they all are quads), but creating a new `Bindings` for each sprite just to change their texture is tedious.

This is especially frustrating when, for example, you need to load hundreds of .png files and create a texture for each of them. This can also lead to relatively huge memory usage and poor performance, as you need to allocate and store a vector of buffer IDs + another buffer ID for each texture.

## Migration


```diff
 struct Stage {
     // ...
 }
 impl Stage {
     fn new() -> Stage {
         let my_texture_1: TextureId = /* load texture... */;
         let my_texture_2: TextureId = /* load texture... */;

         // `images` field was removed from the `Bindings` struct
         let my_bindings = Bindings {
             vertex_buffers: /* ... */,
             index_buffers: /* ... */,
-            images: vec![my_texture_1, my_texture_2],
         }

         // ...

         Stage {
             // ...
             my_bindings,

             // You'd better store these textures as separate variables:
+            my_texture_1,
+            my_texture_2,
         }
     }
 }
 impl EventHandler for Stage {
     // ...

     fn draw(&mut self) {
         // ...

         self.ctx.apply_bindings(self.my_bindings);
         // Now you need to explicitly apply textures
+        self.ctx.apply_images(&[self.my_texture_1, self.my_texture_2]);

         self.ctx.draw(0, 6, 1);
     }
 }
```

## Example

*This code is significantly simplified for clarity*

Initialization:

```rust
let bindings = Bindings {
    vertex_buffers: /* ... */,
    index_buffer: /* ... */,
};

// Storing each texture in a separate variable
let texture1: TextureId = /* load texture... */;
let texture2: TextureId = /* load texture... */;

// All other steps are the same as before (e.g. creating pipeline or shader)
// ...
```

Drawing logic:

```rust
pub fn draw_sprite(&mut self, x: i32, y: i32, texture: &TextureId) {
    self.ctx.apply_pipeline(&self.pipeline);
    self.ctx.apply_bindings(&self.bindings);

    self.ctx.apply_image(texture);
    // If i need to apply multiple textures:
    // self.context.apply_images(&[texture, texture_n, ...]);

    self.ctx.apply_uniforms(/* ... */);

    self.ctx.draw(0, 6, 1);
}
```

Drawing sprites:

```rust
fn draw(&mut self) {
    // ...

    self.draw_sprite(10, 10, &texture1);
    self.draw_sprite(60, 10, &texture2);

    // I can draw as many sprites as i want:
    // self.draw_sprite(0, 0, &texture_n);
}
```

Result:

![image](https://github.com/user-attachments/assets/2a7fdf0e-40c4-4dc4-8be0-1ebba3119c8d)

## P.S.

Thanks for your time!

Hopefully this PR will be merged, but as I said earlier, it will break most of the existing code.
