### PR TITLE
call glDisableVertexAttribArray when delete buffer

### DIFF
--- a/src/graphics/gl/cache.rs
+++ b/src/graphics/gl/cache.rs
@@ -133,6 +133,12 @@ impl GlCache {
     pub fn clear_vertex_attributes(&mut self) {
         for attr_index in 0..MAX_VERTEX_ATTRIBUTES {
             let cached_attr = &mut self.attributes[attr_index];
+
+            if cached_attr.is_some() {
+                unsafe {
+                    glDisableVertexAttribArray(attr_index as GLuint)
+                };
+            }
             *cached_attr = None;
         }
     }


### PR DESCRIPTION
I have this minimal example:

Cargo.toml:
```toml
[package]
name = "miniquad_bug"
version = "0.1.0"
edition = "2021"

[dependencies]
miniquad = { git = "https://github.com/not-fl3/miniquad", rev = "ce657cf6a0c47dba11b712b2d5a127f9731a6e45"}
```

main.rs
```rust
use miniquad::*;

static QUAD_VERTEX_POSITIONS: [f32; 8] = [0.0, 0.0, 1.0, 0.0, 1.0, 1.0, 0.0, 1.0];
static QUAD_VERTEX_INDICES: [u16; 6] = [0, 1, 3, 1, 2, 3];

struct Stage {
    ctx: Box<dyn RenderingBackend>,
    fill_pipeline: Pipeline,
    fill_bindings: Bindings,
    tile_pipeline: Pipeline,
    tile_bindings: Bindings,
}

impl Stage {
    pub fn new() -> Stage {
        let mut ctx: Box<dyn RenderingBackend> = window::new_rendering_backend();

        let quad_vertex_positions_buffer = ctx.new_buffer(
            BufferType::VertexBuffer,
            BufferUsage::Immutable,
            BufferSource::slice(&QUAD_VERTEX_POSITIONS),
        );
        let quad_vertex_indices_buffer = ctx.new_buffer(
            BufferType::IndexBuffer,
            BufferUsage::Immutable,
            BufferSource::slice(&QUAD_VERTEX_INDICES),
        );

        let fill_buffer = ctx.new_buffer(
            BufferType::VertexBuffer,
            BufferUsage::Immutable,
            BufferSource::empty::<f32>(0),
        );

        let fill_shader = ctx
            .new_shader(
                ShaderSource::Glsl {
                    vertex: "
                            #version 100

                            attribute vec2 aTessCoord;
                            attribute vec4 aLineSegment;

                            void main() {
                                gl_Position = vec4(aTessCoord - vec2(1.0, 0.0), 0.0, 1.0);
                                aLineSegment.xy; // comment this and everything works again
                            }
                        ",
                    fragment: "
                            #version 100

                            void main() {
                                gl_FragColor = vec4(1.52, 0.0, 0.152, 1.0052);
                            }
                        ",
                },
                ShaderMeta {
                    images: vec![],
                    uniforms: UniformBlockLayout {
                        uniforms: vec![
                            UniformDesc::new("uFramebufferSize", UniformType::Float2),
                            UniformDesc::new("uTileSize", UniformType::Float2),
                        ],
                    },
                },
            )
            .unwrap();

        let fill_bindings = Bindings {
            vertex_buffers: vec![quad_vertex_positions_buffer, fill_buffer],
            index_buffer: quad_vertex_indices_buffer,
            images: vec![],
        };

        let fill_pipeline = ctx.new_pipeline(
            &[
                BufferLayout::default(),
                BufferLayout {
                    step_func: VertexStep::PerInstance,
                    stride: size_of::<f32>() as i32,
                    ..Default::default()
                },
            ],
            &[
                VertexAttribute::with_buffer("aTessCoord", VertexFormat::Float2, 0),
                VertexAttribute::with_buffer("aLineSegment", VertexFormat::Float4, 1),
                VertexAttribute::with_buffer("aTileIndex", VertexFormat::Float1, 1),
            ],
            fill_shader,
            PipelineParams::default(),
        );

        let tile_shader = ctx
            .new_shader(
                ShaderSource::Glsl {
                    vertex: "
                            #version 100

                            attribute vec2 aTileOffset;

                            void main() {
                                gl_Position = vec4(aTileOffset, 0.0, 1.0);
                            }
                        ",
                    fragment: "
                            #version 100

                            void main() {
                                gl_FragColor = vec4(1.0, 0.52, 0.0, 1.0);
                            }
                        ",
                },
                ShaderMeta {
                    images: vec![],
                    uniforms: UniformBlockLayout {
                        uniforms: vec![],
                    },
                },
            )
            .unwrap();

        let tile_bindings = Bindings {
            vertex_buffers: vec![quad_vertex_positions_buffer],
            index_buffer: quad_vertex_indices_buffer,
            images: vec![],
        };

        let tile_pipeline = ctx.new_pipeline(
            &[BufferLayout::default()],
            &[VertexAttribute::with_buffer(
                "aTileOffset",
                VertexFormat::Float2,
                0,
            )],
            tile_shader,
            PipelineParams::default(),
        );

        Stage {
            ctx,

            fill_pipeline,
            fill_bindings,

            tile_pipeline,
            tile_bindings,
        }
    }
}

impl EventHandler for Stage {
    fn update(&mut self) {}

    fn draw(&mut self) {
        let old_fill_buffer = self.fill_bindings.vertex_buffers[1];
        self.fill_bindings.vertex_buffers[1] = self.ctx.new_buffer(
            BufferType::VertexBuffer,
            BufferUsage::Immutable,
            BufferSource::slice(&[486.0, 1832.0]),
        );

        self.ctx
            .begin_default_pass(PassAction::clear_color(0.0, 0.0, 0.0, 1.0));
        self.ctx.apply_pipeline(&self.fill_pipeline);
        self.ctx.apply_bindings(&self.fill_bindings);
        self.ctx.draw(0, 6, 1 as i32);
        self.ctx.end_render_pass();

        self.ctx.delete_buffer(self.fill_bindings.vertex_buffers[1]);
        self.fill_bindings.vertex_buffers[1] = old_fill_buffer;

        self.ctx.begin_default_pass(PassAction::Nothing);
        self.ctx.apply_pipeline(&self.tile_pipeline);
        self.ctx.apply_bindings(&self.tile_bindings);

        self.ctx.draw(0, 6, 1);
        self.ctx.end_render_pass();
    }
}

fn main() {
    let mut conf = conf::Conf::default();
    conf.window_title = "gl(Enable/Disable)VertexAttribArray bug".to_owned();
    conf.platform.blocking_event_loop = true;
    miniquad::start(conf, move || Box::new(Stage::new()));
}
```

Without this patch:
osx:
<img width="912" alt="Screenshot 2025-02-02 at 04 19 12" src="https://github.com/user-attachments/assets/1223ea3e-0143-4e7b-85e4-319c0fe97abf" />
Web:
<img width="741" alt="image" src="https://github.com/user-attachments/assets/4f86223f-f7d4-4ae2-83cb-4b153adfb7c3" />

With this patch:
osx:
<img width="912" alt="Screenshot 2025-02-02 at 04 22 26" src="https://github.com/user-attachments/assets/83bdb050-96ca-4f1d-9a93-1596f3df079a" />
Web:
<img width="1378" alt="image" src="https://github.com/user-attachments/assets/93d822fc-f597-413e-a461-902d7b649e19" />
