### PR TITLE
improve docs for docs.rs

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -17,9 +17,11 @@ categories = ["rendering::graphics-api"]
 
 [features]
 
-# Optional log-rs like macros implementation
-# disabled by default
+# Optional log-rs like macros implementation. Disabled by default
 log-impl = []
+
+# Documentation for docs.rs. Enables `doc_cfg` nightly feature
+_docsrs = ["log-impl"]
 
 [target.'cfg(target_os = "linux")'.dependencies]
 libc = "0.2"
@@ -59,3 +61,6 @@ incremental = false
 rpath = false
 codegen-units = 1
 strip = true
+
+[package.metadata.docs.rs]
+features = ["_docsrs"]

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,4 +1,6 @@
 #![doc = include_str!("../README.md")]
+#![cfg_attr(feature = "_docsrs", feature(doc_cfg))]
+
 pub mod conf;
 mod event;
 pub mod fs;
@@ -8,6 +10,7 @@ use std::collections::HashMap;
 use std::ops::{Index, IndexMut};
 
 #[cfg(feature = "log-impl")]
+#[cfg_attr(feature = "_docsrs", doc(cfg(feature = "log-impl")))]
 pub mod log;
 
 pub use event::*;


### PR DESCRIPTION
- add a new `_docsrs` private feature that enables the `doc_cfg` nightly feature.
- show the required feature for the `log` module and its items.
- add `[package.metadata.docs.rs]` section to the manifest.

To check it run:
```sh
cargo +nightly doc --open -F _docsrs
```