### PR TITLE
native/linux_x11: Allow setting WM_CLASS

### DIFF
--- a/src/conf.rs
+++ b/src/conf.rs
@@ -145,6 +145,12 @@ pub struct Platform {
 
     /// When using Wayland, this controls whether to draw the default window decorations.
     pub wayland_use_fallback_decorations: bool,
+
+    /// Set the `WM_CLASS` window property on X11
+    // in fact `WM_CLASS` contains two strings "instance name" and "class name"
+    // for most purposes they are the same so we just use class name for simplicity
+    // https://unix.stackexchange.com/questions/494169/
+    pub linux_x11_wm_class: &'static str,
 }
 
 impl Default for Platform {
@@ -158,6 +164,7 @@ impl Default for Platform {
             swap_interval: None,
             framebuffer_alpha: false,
             wayland_use_fallback_decorations: true,
+            linux_x11_wm_class: "miniquad-application",
         }
     }
 }
@@ -196,6 +203,8 @@ pub struct Conf {
     /// - On macOS, Dock/title bar icon
     /// - TODO: Favicon on HTML5
     /// - TODO: Taskbar/title bar icon on Linux (depends on WM)
+    /// - Note: on gnome (with X11), icon is determined using `WM_CLASS` (can be set under
+    /// `Platform`) and an external `.desktop` file
     pub icon: Option<Icon>,
 
     /// Platform-specific hints (e.g., context creation, driver settings).

--- a/src/native/linux_x11/libx11.rs
+++ b/src/native/linux_x11/libx11.rs
@@ -806,6 +806,8 @@ pub mod Xresource_h {
 
 pub type XSetWMNormalHints = unsafe extern "C" fn(_: *mut Display, _: Window, _: *mut XSizeHints);
 pub type XAllocSizeHints = unsafe extern "C" fn() -> *mut XSizeHints;
+pub type XAllocClassHint = unsafe extern "C" fn() -> *mut XClassHint;
+pub type XSetClassHint = unsafe extern "C" fn(_: *mut Display, _: Window, _: *mut XClassHint);
 pub type Xutf8SetWMProperties = unsafe extern "C" fn(
     _: *mut Display,
     _: Window,
@@ -1025,6 +1027,8 @@ pub struct LibX11 {
     pub extensions: X11Extensions,
     pub XSetWMNormalHints: XSetWMNormalHints,
     pub XAllocSizeHints: XAllocSizeHints,
+    pub XAllocClassHint: XAllocClassHint,
+    pub XSetClassHint: XSetClassHint,
     pub Xutf8SetWMProperties: Xutf8SetWMProperties,
     pub XLookupString: XLookupString,
     pub XInitThreads: XInitThreads,
@@ -1080,6 +1084,8 @@ impl LibX11 {
             .map(|module| LibX11 {
                 XSetWMNormalHints: module.get_symbol("XSetWMNormalHints").unwrap(),
                 XAllocSizeHints: module.get_symbol("XAllocSizeHints").unwrap(),
+                XAllocClassHint: module.get_symbol("XAllocClassHint").unwrap(),
+                XSetClassHint: module.get_symbol("XSetClassHint").unwrap(),
                 Xutf8SetWMProperties: module.get_symbol("Xutf8SetWMProperties").unwrap(),
                 XLookupString: module.get_symbol("XLookupString").unwrap(),
                 XInitThreads: module.get_symbol("XInitThreads").unwrap(),

--- a/src/native/linux_x11/libx11_ex.rs
+++ b/src/native/linux_x11/libx11_ex.rs
@@ -119,7 +119,7 @@ impl LibX11 {
         let icons = [
             (16, &icon.small[..]),
             (32, &icon.medium[..]),
-            (65, &icon.big[..]),
+            (64, &icon.big[..]),
         ];
 
         {
@@ -233,6 +233,13 @@ impl LibX11 {
         (*hints).win_gravity = StaticGravity;
         (self.XSetWMNormalHints)(display, window, hints);
         (self.XFree)(hints as *mut libc::c_void);
+
+        let class_hint = (self.XAllocClassHint)();
+        let wm_class = std::ffi::CString::new(conf.platform.linux_x11_wm_class).unwrap();
+        (*class_hint).res_name = wm_class.as_ptr() as _;
+        (*class_hint).res_class = wm_class.as_ptr() as _;
+        (self.XSetClassHint)(display, window, class_hint);
+        (self.XFree)(class_hint as *mut libc::c_void);
 
         if let Some(ref icon) = conf.icon {
             self.update_window_icon(display, window, icon);


### PR DESCRIPTION
Following #501

Since `Platform` is `Copy`, I used `&'static str` instead of `String` for the name. Shouldn't be a problem cuz you won't want to change it.

Also fixed a typo in icon :)