### PR TITLE
actually use dpi_scale() on wasm backend

### DIFF
--- a/src/native/wasm.rs
+++ b/src/native/wasm.rs
@@ -82,9 +82,11 @@ where
     REQUESTS.with(|r| *r.borrow_mut() = Some(rx));
     let w = unsafe { canvas_width() as _ };
     let h = unsafe { canvas_height() as _ };
+    let dpi_scale = unsafe { dpi_scale() };
     let clipboard = Box::new(Clipboard);
     crate::set_display(NativeDisplayData {
         blocking_event_loop: conf.platform.blocking_event_loop,
+        dpi_scale,
         ..NativeDisplayData::new(w, h, tx, clipboard)
     });
     EVENT_HANDLER.with(|g| {


### PR DESCRIPTION
I was messing around with scaling in wasm builds, trying to get pixel perfect results.
I was pretty confused why `screen_dpi_scale()` in macroquad always reported 1.0 even when that was clearly wrong.
![grafik](https://github.com/user-attachments/assets/776f5c17-392f-402b-846c-61929540712c)

It turns out that the DPI value was never written to the NativeDisplayData.
This PR fixes that.