### PR TITLE
Wayland backend

### DIFF
--- a/src/conf.rs
+++ b/src/conf.rs
@@ -101,6 +101,22 @@ pub enum WebGLVersion {
     WebGL2,
 }
 
+/// On Wayland, specify how to draw client-side decoration (CSD) if server-side decoration (SSD) is
+/// not supported (e.g., on GNOME).
+///
+/// Defaults to ServerWithLibDecorFallback
+#[derive(Clone, Copy, Debug, Default, PartialEq, Eq, Hash)]
+pub enum WaylandDecorations {
+    /// If SSD is not supported, will try to load `libdecor` to draw CSD. This is the default
+    /// choice.
+    #[default]
+    ServerWithLibDecorFallback,
+    /// If SSD is not supported, draw a light gray border.
+    ServerWithMiniquadFallback,
+    /// If SSD is not supported, no CSD will be drawn.
+    ServerOnly,
+}
+
 /// Platform-specific settings.
 #[derive(Clone, Copy, Debug, PartialEq, Eq, Hash)]
 pub struct Platform {
@@ -143,9 +159,9 @@ pub struct Platform {
     /// - TODO: Document(and check) what does it actually mean on android. Transparent window?
     pub framebuffer_alpha: bool,
 
-    /// On Wayland, the decorations are either drawn by the server or via `libdecor`. If neither is
-    /// available, then this flag controls whether fallback window decorations should be used.
-    pub wayland_use_fallback_decorations: bool,
+    /// On Wayland, specifies how to draw client-side decoration (CSD) if server-side decoration (SSD) is
+    /// not supported (e.g., on GNOME).
+    pub wayland_decorations: WaylandDecorations,
 
     /// Set the `WM_CLASS` window property on X11 and the `app_id` on Wayland. This is used
     /// by gnome to determine the window icon (together with an external `.desktop` file).
@@ -165,7 +181,7 @@ impl Default for Platform {
             blocking_event_loop: false,
             swap_interval: None,
             framebuffer_alpha: false,
-            wayland_use_fallback_decorations: true,
+            wayland_decorations: WaylandDecorations::default(),
             linux_wm_class: "miniquad-application",
         }
     }

--- a/src/conf.rs
+++ b/src/conf.rs
@@ -143,7 +143,9 @@ pub struct Platform {
     /// - TODO: Document(and check) what does it actually mean on android. Transparent window?
     pub framebuffer_alpha: bool,
 
-    /// When using Wayland, this controls whether to draw the default window decorations.
+    /// On Wayland, the decorations are either drawn by the server or via `libdecor`. If neither is
+    /// available then no decorations will be drawn.
+    #[deprecated]
     pub wayland_use_fallback_decorations: bool,
 
     /// Set the `WM_CLASS` window property on X11 and the `app_id` on Wayland. This is used
@@ -156,6 +158,7 @@ pub struct Platform {
 
 impl Default for Platform {
     fn default() -> Platform {
+        #[allow(deprecated)]
         Platform {
             linux_x11_gl: LinuxX11Gl::default(),
             linux_backend: LinuxBackend::default(),

--- a/src/conf.rs
+++ b/src/conf.rs
@@ -144,8 +144,7 @@ pub struct Platform {
     pub framebuffer_alpha: bool,
 
     /// On Wayland, the decorations are either drawn by the server or via `libdecor`. If neither is
-    /// available then no decorations will be drawn.
-    #[deprecated]
+    /// available, then this flag controls whether fallback window decorations should be used.
     pub wayland_use_fallback_decorations: bool,
 
     /// Set the `WM_CLASS` window property on X11 and the `app_id` on Wayland. This is used
@@ -158,7 +157,6 @@ pub struct Platform {
 
 impl Default for Platform {
     fn default() -> Platform {
-        #[allow(deprecated)]
         Platform {
             linux_x11_gl: LinuxX11Gl::default(),
             linux_backend: LinuxBackend::default(),

--- a/src/conf.rs
+++ b/src/conf.rs
@@ -146,11 +146,12 @@ pub struct Platform {
     /// When using Wayland, this controls whether to draw the default window decorations.
     pub wayland_use_fallback_decorations: bool,
 
-    /// Set the `WM_CLASS` window property on X11
+    /// Set the `WM_CLASS` window property on X11 and the `app_id` on Wayland. This is used
+    /// by gnome to determine the window icon (together with an external `.desktop` file).
     // in fact `WM_CLASS` contains two strings "instance name" and "class name"
     // for most purposes they are the same so we just use class name for simplicity
     // https://unix.stackexchange.com/questions/494169/
-    pub linux_x11_wm_class: &'static str,
+    pub linux_wm_class: &'static str,
 }
 
 impl Default for Platform {
@@ -164,7 +165,7 @@ impl Default for Platform {
             swap_interval: None,
             framebuffer_alpha: false,
             wayland_use_fallback_decorations: true,
-            linux_x11_wm_class: "miniquad-application",
+            linux_wm_class: "miniquad-application",
         }
     }
 }
@@ -203,8 +204,8 @@ pub struct Conf {
     /// - On macOS, Dock/title bar icon
     /// - TODO: Favicon on HTML5
     /// - TODO: Taskbar/title bar icon on Linux (depends on WM)
-    /// - Note: on gnome (with X11), icon is determined using `WM_CLASS` (can be set under
-    /// `Platform`) and an external `.desktop` file
+    /// - Note: on gnome, icon is determined using `WM_CLASS` (can be set under [`Platform`]) and
+    ///   an external `.desktop` file
     pub icon: Option<Icon>,
 
     /// Platform-specific hints (e.g., context creation, driver settings).

--- a/src/native/linux_wayland.rs
+++ b/src/native/linux_wayland.rs
@@ -694,9 +694,6 @@ unsafe extern "C" fn pointer_handle_axis(
 ) {
     let display: &mut WaylandPayload = &mut *(data as *mut _);
     let mut value = wl_fixed_to_double(value);
-    // Normalize the value to {-1, 0, 1}
-    value /= value.abs();
-
     // https://wayland-book.com/seat/pointer.html
     if axis == 0 {
         // Vertical scroll

--- a/src/native/linux_wayland.rs
+++ b/src/native/linux_wayland.rs
@@ -1150,12 +1150,8 @@ where
             (libegl.eglGetProcAddress)(name.as_ptr() as _)
         });
 
-        let borderless = false;
-        display.decorations = decorations::Decorations::new(
-            &mut display,
-            borderless,
-            conf.platform.wayland_use_fallback_decorations,
-        );
+        display.decorations =
+            decorations::Decorations::new(&mut display, conf.platform.wayland_decorations);
         assert!(!display.xdg_toplevel.is_null());
 
         display.decorations.set_title(

--- a/src/native/linux_wayland.rs
+++ b/src/native/linux_wayland.rs
@@ -53,7 +53,7 @@ struct WaylandPayload {
     keyboard: *mut wl_keyboard,
     focused_window: *mut wl_surface,
     decoration_manager: *mut extensions::xdg_decoration::zxdg_decoration_manager_v1,
-    decorations: Option<decorations::Decorations>,
+    decorations: decorations::Decorations,
 
     events: Vec<WaylandEvent>,
     keyboard_context: KeyboardContext,
@@ -949,7 +949,7 @@ where
             keyboard: std::ptr::null_mut(),
             focused_window: std::ptr::null_mut(),
             decoration_manager: std::ptr::null_mut(),
-            decorations: None,
+            decorations: decorations::Decorations::None,
             events: Vec::new(),
             pointer_context: PointerContext::new(),
             keyboard_context: KeyboardContext::new(),
@@ -1019,16 +1019,15 @@ where
             (libegl.eglGetProcAddress)(name.as_ptr() as _)
         });
 
-        display.decorations = decorations::Decorations::new(&mut display);
+        let borderless = false;
+        display.decorations = decorations::Decorations::new(&mut display, borderless);
         assert!(!display.xdg_toplevel.is_null());
 
-        if let Some(ref mut decorations) = display.decorations {
-            decorations.set_title(
-                &mut display.client,
-                display.xdg_toplevel,
-                conf.window_title.as_str(),
-            );
-        }
+        display.decorations.set_title(
+            &mut display.client,
+            display.xdg_toplevel,
+            conf.window_title.as_str(),
+        );
 
         let wm_class = std::ffi::CString::new(conf.platform.linux_wm_class).unwrap();
         wl_request!(

--- a/src/native/linux_wayland/clipboard.rs
+++ b/src/native/linux_wayland/clipboard.rs
@@ -1,0 +1,172 @@
+use super::*;
+use crate::{wl_request, wl_request_constructor};
+
+use core::ffi::{c_char, c_int, c_void};
+
+// new clipboard content is available
+// this could be fired at any time, so we just store the `data_offer` for later use
+pub(super) unsafe extern "C" fn data_device_handle_selection(
+    data: *mut c_void,
+    data_device: *mut wl_data_device,
+    data_offer: *mut wl_data_offer,
+) {
+    let display: &mut WaylandPayload = &mut *(data as *mut _);
+    assert_eq!(data_device, display.data_device);
+    CLIPBOARD.get_mut().unwrap().data_offer = (!data_offer.is_null()).then_some(data_offer);
+}
+
+use std::sync::OnceLock;
+static mut CLIPBOARD: OnceLock<ClipboardContext> = OnceLock::new();
+
+// Contains the owned clipboard and the `data_source` (object in Wayland that indicates clipboard
+// ownership). There is a static instance `CLIPBOARD` available globally, initialized when creating
+// the `WaylandClipboard`.
+#[derive(Debug)]
+struct ClipboardContext {
+    display: *mut WaylandPayload,
+    content: String,
+    data_source: Option<*mut wl_data_source>,
+    data_offer: Option<*mut wl_data_offer>,
+}
+
+impl ClipboardContext {
+    unsafe fn get_clipboard(&mut self, mime_type: &str) -> Option<Vec<u8>> {
+        self.data_offer.map(|data_offer| {
+            let display: &mut WaylandPayload = &mut *self.display;
+            let mime_type = std::ffi::CString::new(mime_type).unwrap();
+            display
+                .client
+                .data_offer_receive(display.display, data_offer, mime_type.as_ptr())
+        })
+    }
+
+    unsafe fn set(&mut self, data: &str) {
+        self.content.clear();
+        self.content.push_str(data);
+        let display: &mut WaylandPayload = &mut *self.display;
+        // Wayland requires that only the window with focus can set the clipboard
+        if let Some(serial) = display.keyboard_context.enter_serial {
+            let data_source = self.new_data_source();
+            // only support copying utf8 strings
+            let mime_type = std::ffi::CString::new("UTF8_STRING").unwrap();
+            wl_request!(
+                display.client,
+                data_source,
+                WL_DATA_SOURCE_OFFER,
+                mime_type.as_ptr()
+            );
+            wl_request!(
+                display.client,
+                display.data_device,
+                WL_DATA_DEVICE_SET_SELECTION,
+                data_source,
+                serial
+            );
+        }
+    }
+
+    unsafe fn respond_to_clipboard_request(&mut self, mime_type: &str, fd: c_int) {
+        #![allow(clippy::single_match)]
+        match mime_type {
+            "UTF8_STRING" => {
+                libc::write(fd, self.content.as_ptr() as _, self.content.len());
+            }
+            _ => {}
+        }
+        libc::close(fd);
+    }
+
+    unsafe fn destroy_data_source(&mut self) {
+        // since the data_source is constructed by us, we need to dispose of it properly
+        if let Some(data_source) = self.data_source {
+            let display: &mut WaylandPayload = &mut *self.display;
+            wl_request!(display.client, data_source, WL_DATA_SOURCE_DESTROY);
+            (display.client.wl_proxy_destroy)(data_source as _);
+            self.data_source = None;
+        }
+    }
+
+    unsafe fn new_data_source(&mut self) -> *mut wl_data_source {
+        self.destroy_data_source();
+        let display: &mut WaylandPayload = &mut *self.display;
+        let data_source: *mut wl_data_source = wl_request_constructor!(
+            display.client,
+            display.data_device_manager,
+            WL_DATA_DEVICE_MANAGER_CREATE_DATA_SOURCE,
+            display.client.wl_data_source_interface,
+        );
+        assert!(!data_source.is_null());
+        (display.client.wl_proxy_add_listener)(
+            data_source as _,
+            &DATA_SOURCE_LISTENER as *const _ as _,
+            self.display as *const _ as _,
+        );
+        self.data_source = Some(data_source);
+        data_source
+    }
+}
+
+static mut DATA_SOURCE_LISTENER: wl_data_source_listener = wl_data_source_listener {
+    target: None,
+    send: Some(data_source_handle_send),
+    cancelled: Some(data_source_handle_cancelled),
+    dnd_drop_performed: None,
+    dnd_finished: None,
+    action: None,
+};
+
+// some app (could be ourself) is requesting the owned clipboard
+unsafe extern "C" fn data_source_handle_send(
+    _data: *mut c_void,
+    data_source: *mut wl_data_source,
+    mime_type: *const c_char,
+    fd: c_int,
+) {
+    let mime_type = core::ffi::CStr::from_ptr(mime_type).to_str().unwrap();
+    let ctx = CLIPBOARD.get_mut().unwrap();
+    assert!(ctx.data_source == Some(data_source));
+    ctx.respond_to_clipboard_request(mime_type, fd);
+}
+
+// the owned clipboard has been replaced by some other app
+unsafe extern "C" fn data_source_handle_cancelled(
+    _data: *mut c_void,
+    data_source: *mut wl_data_source,
+) {
+    let ctx = CLIPBOARD.get_mut().unwrap();
+    assert!(ctx.data_source == Some(data_source));
+    ctx.destroy_data_source();
+}
+
+pub struct WaylandClipboard {}
+unsafe impl Send for WaylandClipboard {}
+unsafe impl Sync for WaylandClipboard {}
+
+impl WaylandClipboard {
+    pub(super) fn new(display: *mut WaylandPayload) -> Self {
+        // initialize the global context
+        unsafe {
+            CLIPBOARD
+                .set(ClipboardContext {
+                    display,
+                    content: String::new(),
+                    data_source: None,
+                    data_offer: None,
+                })
+                .unwrap();
+        }
+        WaylandClipboard {}
+    }
+}
+
+impl crate::native::Clipboard for WaylandClipboard {
+    fn get(&mut self) -> Option<String> {
+        let bytes = unsafe { CLIPBOARD.get_mut().unwrap().get_clipboard("UTF8_STRING")? };
+        Some(std::str::from_utf8(&bytes).ok()?.to_string())
+    }
+    fn set(&mut self, data: &str) {
+        unsafe {
+            CLIPBOARD.get_mut().unwrap().set(data);
+        }
+    }
+}

--- a/src/native/linux_wayland/clipboard.rs
+++ b/src/native/linux_wayland/clipboard.rs
@@ -37,7 +37,7 @@ impl ClipboardContext {
             display
                 .client
                 .data_offer_receive(display.display, data_offer, mime_type.as_ptr())
-        })
+        })?
     }
 
     unsafe fn set(&mut self, data: &str) {

--- a/src/native/linux_wayland/clipboard.rs
+++ b/src/native/linux_wayland/clipboard.rs
@@ -96,6 +96,8 @@ impl ClipboardContext {
             display.client.wl_data_source_interface,
         );
         assert!(!data_source.is_null());
+        DATA_SOURCE_LISTENER.send = data_source_handle_send;
+        DATA_SOURCE_LISTENER.cancelled = data_source_handle_cancelled;
         (display.client.wl_proxy_add_listener)(
             data_source as _,
             &DATA_SOURCE_LISTENER as *const _ as _,
@@ -106,14 +108,7 @@ impl ClipboardContext {
     }
 }
 
-static mut DATA_SOURCE_LISTENER: wl_data_source_listener = wl_data_source_listener {
-    target: None,
-    send: Some(data_source_handle_send),
-    cancelled: Some(data_source_handle_cancelled),
-    dnd_drop_performed: None,
-    dnd_finished: None,
-    action: None,
-};
+static mut DATA_SOURCE_LISTENER: wl_data_source_listener = wl_data_source_listener::dummy();
 
 // some app (could be ourself) is requesting the owned clipboard
 unsafe extern "C" fn data_source_handle_send(

--- a/src/native/linux_wayland/decorations.rs
+++ b/src/native/linux_wayland/decorations.rs
@@ -1,196 +1,260 @@
 //! Window decorations(borders, titlebards, close/minimize buttons) are optional
-//! Most importantly they are not implemented on Gnome.
-//! Gnome suggest linking with GTK and do lots of gnome-specific things to
-//! get decorations working...
+//! Most importantly they are not implemented on Gnome so we need to do some
+//! extra work.
 //!
-//! So this module is drawing some sort of a window border, just for GNOME
-//! looks horrible, doesn't fit OS theme at all, but better than nothing
+//! We use `libdecor` which is also used by `xwayland` so we will get the same
+//! decorations as the X11 backend. If it's not available then no decorations
+//! will be drawn at all.
 
 #![allow(static_mut_refs)]
 
-use crate::{
-    native::linux_wayland::{
-        extensions::viewporter::{wp_viewport, wp_viewport_interface, wp_viewporter},
-        libwayland_client::*,
-        shm, WaylandPayload,
+use super::*;
+use crate::{wl_request, wl_request_constructor};
+use core::ffi::{c_char, c_int, c_void};
+use extensions::libdecor::*;
+use extensions::xdg_shell::*;
+
+/// Window decorations, whether they should be done by the compositor or by us.
+/// In the later case we use `libdecor` so it needs to be loaded.
+/// If it's not available then no decorations will be drawn at all.
+pub(super) enum Decorations {
+    Server,
+    Client {
+        libdecor: LibDecor,
+        context: *mut libdecor,
+        frame: *mut libdecor_frame,
     },
-    wl_request, wl_request_constructor,
-};
-
-pub struct Decoration {
-    pub surface: *mut wl_surface,
-    pub subsurface: *mut wl_subsurface,
-    pub viewport: *mut wp_viewport,
 }
 
-pub(crate) struct Decorations {
-    buffer: *mut wl_buffer,
-    pub top_decoration: Decoration,
-    pub bottom_decoration: Decoration,
-    pub left_decoration: Decoration,
-    pub right_decoration: Decoration,
-}
-
-#[allow(clippy::too_many_arguments)]
-unsafe fn create_decoration(
-    display: &mut WaylandPayload,
-    compositor: *mut wl_compositor,
-    subcompositor: *mut wl_subcompositor,
-    parent: *mut wl_surface,
-    buffer: *mut wl_buffer,
-    x: i32,
-    y: i32,
-    w: i32,
-    h: i32,
-) -> Decoration {
-    let surface = wl_request_constructor!(
+// If we use client decorations, `libdecor` will handle the creation for us.
+// So this is used for either server or no decorations.
+unsafe fn create_xdg_toplevel(display: &mut WaylandPayload) {
+    let xdg_surface: *mut xdg_surface = wl_request_constructor!(
         display.client,
-        compositor,
-        WL_COMPOSITOR_CREATE_SURFACE,
-        display.client.wl_surface_interface,
+        display.xdg_wm_base,
+        extensions::xdg_shell::xdg_wm_base::get_xdg_surface,
+        &xdg_surface_interface,
+        display.surface
+    );
+    assert!(!xdg_surface.is_null());
+    (display.client.wl_proxy_add_listener)(
+        xdg_surface as _,
+        &XDG_SURFACE_LISTENER as *const _ as _,
+        display as *mut _ as _,
     );
 
-    let subsurface = wl_request_constructor!(
+    display.xdg_toplevel = wl_request_constructor!(
         display.client,
-        subcompositor,
-        WL_SUBCOMPOSITOR_GET_SUBSURFACE,
-        display.client.wl_subsurface_interface,
-        surface,
-        parent
+        xdg_surface,
+        extensions::xdg_shell::xdg_surface::get_toplevel,
+        &extensions::xdg_shell::xdg_toplevel_interface
     );
-
-    wl_request!(display.client, subsurface, WL_SUBSURFACE_SET_POSITION, x, y);
-
-    let viewport = wl_request_constructor!(
-        display.client,
-        display.viewporter,
-        wp_viewporter::get_viewport,
-        &wp_viewport_interface,
-        surface
+    assert!(!display.xdg_toplevel.is_null());
+    (display.client.wl_proxy_add_listener)(
+        display.xdg_toplevel as _,
+        &XDG_TOPLEVEL_LISTENER as *const _ as _,
+        display as *mut _ as _,
     );
-
-    wl_request!(display.client, viewport, wp_viewport::set_destination, w, h);
-    wl_request!(display.client, surface, WL_SURFACE_ATTACH, buffer, 0, 0);
-    wl_request!(display.client, surface, WL_SURFACE_COMMIT);
-
-    Decoration {
-        surface,
-        subsurface,
-        viewport,
-    }
 }
 
 impl Decorations {
-    pub const WIDTH: i32 = 2;
-    pub const BAR_HEIGHT: i32 = 15;
-
-    pub(super) unsafe fn new(display: &mut WaylandPayload, width: i32, height: i32) -> Decorations {
-        let buffer = shm::create_shm_buffer(
-            &mut display.client,
-            display.shm,
-            1,
-            1,
-            &[200, 200, 200, 255],
-        );
-
-        Decorations {
-            buffer,
-            top_decoration: create_decoration(
-                display,
-                display.compositor,
-                display.subcompositor,
-                display.surface,
-                buffer,
-                -Self::WIDTH,
-                -Self::BAR_HEIGHT,
-                width + Self::WIDTH * Self::WIDTH,
-                Self::BAR_HEIGHT,
-            ),
-            left_decoration: create_decoration(
-                display,
-                display.compositor,
-                display.subcompositor,
-                display.surface,
-                buffer,
-                -Self::WIDTH,
-                -Self::BAR_HEIGHT,
-                Self::WIDTH,
-                height + Self::BAR_HEIGHT,
-            ),
-            right_decoration: create_decoration(
-                display,
-                display.compositor,
-                display.subcompositor,
-                display.surface,
-                buffer,
-                width,
-                -Self::BAR_HEIGHT,
-                Self::WIDTH,
-                height + Self::BAR_HEIGHT,
-            ),
-            bottom_decoration: create_decoration(
-                display,
-                display.compositor,
-                display.subcompositor,
-                display.surface,
-                buffer,
-                -Self::WIDTH,
-                height,
-                width + Self::WIDTH,
-                Self::WIDTH,
-            ),
+    pub(super) fn new(display: &mut WaylandPayload) -> Option<Self> {
+        unsafe {
+            if display.decoration_manager.is_null() {
+                Decorations::try_client(display)
+            } else {
+                Some(Decorations::server(display))
+            }
         }
     }
 
-    pub unsafe fn resize(&self, client: &mut LibWaylandClient, width: i32, height: i32) {
-        wl_request!(
-            client,
-            self.top_decoration.viewport,
-            wp_viewport::set_destination,
-            width,
-            Self::BAR_HEIGHT
+    pub(super) unsafe fn set_title(
+        &mut self,
+        client: &mut LibWaylandClient,
+        xdg_toplevel: *mut xdg_toplevel,
+        title: &str,
+    ) {
+        let title = std::ffi::CString::new(title).unwrap();
+        match self {
+            Decorations::Server => {
+                wl_request!(
+                    client,
+                    xdg_toplevel,
+                    extensions::xdg_shell::xdg_toplevel::set_title,
+                    title.as_ptr()
+                );
+            }
+            Decorations::Client {
+                libdecor, frame, ..
+            } => {
+                (libdecor.libdecor_frame_set_title)(*frame, title.as_ptr());
+            }
+        }
+    }
+
+    unsafe fn server(display: &mut WaylandPayload) -> Self {
+        create_xdg_toplevel(display);
+
+        let server_decoration: *mut extensions::xdg_decoration::zxdg_toplevel_decoration_v1 = wl_request_constructor!(
+            display.client,
+            display.decoration_manager,
+            extensions::xdg_decoration::zxdg_decoration_manager_v1::get_toplevel_decoration,
+            &extensions::xdg_decoration::zxdg_toplevel_decoration_v1_interface,
+            display.xdg_toplevel
         );
-        wl_request!(client, self.top_decoration.surface, WL_SURFACE_COMMIT);
+        assert!(!server_decoration.is_null());
 
         wl_request!(
-            client,
-            self.left_decoration.viewport,
-            wp_viewport::set_destination,
-            Self::WIDTH,
-            height
+            display.client,
+            server_decoration,
+            extensions::xdg_decoration::zxdg_toplevel_decoration_v1::set_mode,
+            extensions::xdg_decoration::ZXDG_TOPLEVEL_DECORATION_V1_MODE_SERVER_SIDE
         );
-        wl_request!(client, self.left_decoration.surface, WL_SURFACE_COMMIT);
+        Decorations::Server
+    }
 
-        wl_request!(
-            client,
-            self.right_decoration.subsurface,
-            WL_SUBSURFACE_SET_POSITION,
-            width - Self::WIDTH * 2,
-            -Self::BAR_HEIGHT
-        );
-        wl_request!(
-            client,
-            self.right_decoration.viewport,
-            wp_viewport::set_destination,
-            Self::WIDTH,
-            height
-        );
-        wl_request!(client, self.right_decoration.surface, WL_SURFACE_COMMIT);
+    unsafe fn try_client(display: &mut WaylandPayload) -> Option<Self> {
+        if let Ok(libdecor) = LibDecor::try_load() {
+            let context = (libdecor.libdecor_new)(display.display, &mut LIBDECOR_INTERFACE as _);
+            let frame = (libdecor.libdecor_decorate)(
+                context,
+                display.surface,
+                &mut LIBDECOR_FRAME_INTERFACE as _,
+                display as *mut _ as _,
+            );
+            (libdecor.libdecor_frame_map)(frame);
+            display.xdg_toplevel = (libdecor.libdecor_frame_get_xdg_toplevel)(frame);
+            assert!(!display.xdg_toplevel.is_null());
+            Some(Decorations::Client {
+                libdecor,
+                context,
+                frame,
+            })
+        } else {
+            // If we can't load `libdecor` we just create the `xdg_toplevel` and return `None`
+            create_xdg_toplevel(display);
+            None
+        }
+    }
 
-        wl_request!(
-            client,
-            self.bottom_decoration.subsurface,
-            WL_SUBSURFACE_SET_POSITION,
-            0,
-            height - Self::BAR_HEIGHT - Self::WIDTH
-        );
-        wl_request!(
-            client,
-            self.bottom_decoration.viewport,
-            wp_viewport::set_destination,
-            width - Self::WIDTH * 2,
-            Self::WIDTH
-        );
-        wl_request!(client, self.bottom_decoration.surface, WL_SURFACE_COMMIT);
+    fn libdecor(&mut self) -> Option<&mut LibDecor> {
+        if let Decorations::Client { libdecor, .. } = self {
+            Some(libdecor)
+        } else {
+            None
+        }
     }
 }
+
+unsafe extern "C" fn xdg_surface_handle_configure(
+    data: *mut std::ffi::c_void,
+    xdg_surface: *mut extensions::xdg_shell::xdg_surface,
+    serial: u32,
+) {
+    assert!(!data.is_null());
+    let payload: &mut WaylandPayload = &mut *(data as *mut _);
+
+    wl_request!(
+        payload.client,
+        xdg_surface,
+        extensions::xdg_shell::xdg_surface::ack_configure,
+        serial
+    );
+    wl_request!(payload.client, payload.surface, WL_SURFACE_COMMIT)
+}
+
+unsafe extern "C" fn handle_configure(data: *mut std::ffi::c_void, width: i32, height: i32) {
+    assert!(!data.is_null());
+    let payload: &mut WaylandPayload = &mut *(data as *mut _);
+
+    if width != 0 && height != 0 {
+        (payload.egl.wl_egl_window_resize)(payload.egl_window, width, height, 0, 0);
+
+        let mut d = crate::native_display().lock().unwrap();
+        d.screen_width = width;
+        d.screen_height = height;
+        drop(d);
+
+        payload
+            .events
+            .push(WaylandEvent::Resize(width as _, height as _));
+    }
+}
+
+unsafe extern "C" fn xdg_toplevel_handle_configure(
+    data: *mut std::ffi::c_void,
+    _toplevel: *mut extensions::xdg_shell::xdg_toplevel,
+    width: i32,
+    height: i32,
+    _states: *mut wl_array,
+) {
+    handle_configure(data, width, height);
+}
+
+unsafe extern "C" fn libdecor_handle_frame_configure(
+    frame: *mut libdecor_frame,
+    configuration: *mut libdecor_configuration,
+    data: *mut c_void,
+) {
+    let display: &mut WaylandPayload = &mut *(data as *mut _);
+    let libdecor = display.decorations.as_mut().unwrap().libdecor().unwrap();
+
+    let mut width: c_int = 0;
+    let mut height: c_int = 0;
+
+    if (libdecor.libdecor_configuration_get_content_size)(
+        configuration,
+        frame,
+        &mut width,
+        &mut height,
+    ) == 0
+    {
+        // libdecor failed to retrieve the new dimension, so we use the old value
+        let d = crate::native_display().lock().unwrap();
+        width = d.screen_width;
+        height = d.screen_height;
+        drop(d);
+    }
+    let state = (libdecor.libdecor_state_new)(width, height);
+    (libdecor.libdecor_frame_commit)(frame, state, configuration);
+    (libdecor.libdecor_state_free)(state);
+
+    handle_configure(data, width, height);
+}
+
+unsafe extern "C" fn xdg_toplevel_handle_close(
+    _data: *mut std::ffi::c_void,
+    _xdg_toplevel: *mut extensions::xdg_shell::xdg_toplevel,
+) {
+    crate::native_display().try_lock().unwrap().quit_requested = true;
+}
+
+unsafe extern "C" fn libdecor_handle_frame_close(_frame: *mut libdecor_frame, _data: *mut c_void) {
+    crate::native_display().try_lock().unwrap().quit_requested = true;
+}
+
+unsafe extern "C" fn libdecor_handle_frame_commit(_frame: *mut libdecor_frame, _data: *mut c_void) {
+}
+unsafe extern "C" fn libdecor_handle_error(
+    _context: *mut libdecor,
+    _error: *mut libdecor_error,
+    message: *const c_char,
+) {
+    let message = core::ffi::CStr::from_ptr(message).to_str().unwrap();
+    eprintln!("{}", message);
+}
+static mut LIBDECOR_INTERFACE: libdecor_interface = libdecor_interface {
+    error: libdecor_handle_error,
+};
+static mut LIBDECOR_FRAME_INTERFACE: libdecor_frame_interface = libdecor_frame_interface {
+    frame_configure: libdecor_handle_frame_configure,
+    frame_close: libdecor_handle_frame_close,
+    frame_commit: libdecor_handle_frame_commit,
+};
+static mut XDG_TOPLEVEL_LISTENER: xdg_toplevel_listener = xdg_toplevel_listener {
+    configure: Some(xdg_toplevel_handle_configure),
+    close: Some(xdg_toplevel_handle_close),
+};
+static mut XDG_SURFACE_LISTENER: xdg_surface_listener = xdg_surface_listener {
+    configure: Some(xdg_surface_handle_configure),
+};

--- a/src/native/linux_wayland/drag_n_drop.rs
+++ b/src/native/linux_wayland/drag_n_drop.rs
@@ -81,7 +81,7 @@ pub(super) unsafe extern "C" fn data_device_handle_drop(
                 .data_offer_receive(display.display, data_offer, mime_type.as_ptr());
         wl_request!(display.client, data_offer, WL_DATA_OFFER_FINISH);
         if let Ok(filenames) = String::from_utf8(bytes) {
-            EVENTS.push(WaylandEvent::FilesDropped(filenames));
+            display.events.push(WaylandEvent::FilesDropped(filenames));
         }
     }
 }

--- a/src/native/linux_wayland/drag_n_drop.rs
+++ b/src/native/linux_wayland/drag_n_drop.rs
@@ -1,0 +1,87 @@
+use super::*;
+use crate::wl_request;
+
+#[derive(Default)]
+pub struct WaylandDnD {
+    data_offer: Option<*mut wl_data_offer>,
+    enter_serial: Option<core::ffi::c_uint>,
+}
+
+pub(super) unsafe extern "C" fn data_offer_handle_source_actions(
+    data: *mut ::core::ffi::c_void,
+    data_offer: *mut wl_data_offer,
+    actions: ::core::ffi::c_uint,
+) {
+    if actions & WL_DATA_DEVICE_MANAGER_DND_ACTION_COPY == 1 {
+        let display: &mut WaylandPayload = &mut *(data as *mut _);
+        wl_request!(
+            display.client,
+            data_offer,
+            WL_DATA_OFFER_SET_ACTIONS,
+            WL_DATA_DEVICE_MANAGER_DND_ACTION_COPY,
+            WL_DATA_DEVICE_MANAGER_DND_ACTION_COPY
+        );
+    }
+}
+
+pub(super) unsafe extern "C" fn data_device_handle_enter(
+    data: *mut ::core::ffi::c_void,
+    data_device: *mut wl_data_device,
+    serial: core::ffi::c_uint,
+    _surface: *mut wl_surface,
+    _surface_x: i32,
+    _surface_y: i32,
+    data_offer: *mut wl_data_offer,
+) {
+    let display: &mut WaylandPayload = &mut *(data as *mut _);
+    assert_eq!(data_device, display.data_device);
+    display.drag_n_drop.enter_serial = Some(serial);
+    display.drag_n_drop.data_offer = Some(data_offer);
+    // only accept utf8 strings
+    let mime_type = std::ffi::CString::new("UTF8_STRING").unwrap();
+    wl_request!(
+        display.client,
+        data_offer,
+        WL_DATA_OFFER_ACCEPT,
+        serial,
+        mime_type.as_ptr()
+    );
+}
+
+pub(super) unsafe extern "C" fn data_device_handle_motion(
+    _data: *mut ::core::ffi::c_void,
+    _data_device: *mut wl_data_device,
+    _time: core::ffi::c_uint,
+    _surface_x: i32,
+    _surface_y: i32,
+) {
+}
+
+pub(super) unsafe extern "C" fn data_device_handle_leave(
+    data: *mut ::core::ffi::c_void,
+    data_device: *mut wl_data_device,
+) {
+    let display: &mut WaylandPayload = &mut *(data as *mut _);
+    assert_eq!(data_device, display.data_device);
+    display.drag_n_drop.enter_serial = None;
+    display.drag_n_drop.data_offer = None;
+}
+
+pub(super) unsafe extern "C" fn data_device_handle_drop(
+    data: *mut ::core::ffi::c_void,
+    data_device: *mut wl_data_device,
+) {
+    let display: &mut WaylandPayload = &mut *(data as *mut _);
+    assert_eq!(data_device, display.data_device);
+    if let Some(data_offer) = display.drag_n_drop.data_offer {
+        let mime_type = std::ffi::CString::new("UTF8_STRING").unwrap();
+        let bytes =
+            display
+                .client
+                .data_offer_receive(display.display, data_offer, mime_type.as_ptr());
+        wl_request!(display.client, data_offer, WL_DATA_OFFER_FINISH);
+        if let Ok(filenames) = String::from_utf8(bytes) {
+            EVENTS.push(WaylandEvent::FilesDropped(filenames));
+        }
+    }
+}

--- a/src/native/linux_wayland/drag_n_drop.rs
+++ b/src/native/linux_wayland/drag_n_drop.rs
@@ -48,15 +48,6 @@ pub(super) unsafe extern "C" fn data_device_handle_enter(
     );
 }
 
-pub(super) unsafe extern "C" fn data_device_handle_motion(
-    _data: *mut ::core::ffi::c_void,
-    _data_device: *mut wl_data_device,
-    _time: core::ffi::c_uint,
-    _surface_x: i32,
-    _surface_y: i32,
-) {
-}
-
 pub(super) unsafe extern "C" fn data_device_handle_leave(
     data: *mut ::core::ffi::c_void,
     data_device: *mut wl_data_device,

--- a/src/native/linux_wayland/extensions.rs
+++ b/src/native/linux_wayland/extensions.rs
@@ -2,7 +2,7 @@
 
 pub mod cursor;
 pub mod libdecor;
-// pub mod viewporter;
+pub mod viewporter;
 pub mod xdg_decoration;
 pub mod xdg_shell;
 

--- a/src/native/linux_wayland/extensions.rs
+++ b/src/native/linux_wayland/extensions.rs
@@ -1,5 +1,6 @@
 #![allow(unused_variables, dead_code, non_upper_case_globals, static_mut_refs)]
 
+pub mod cursor;
 pub mod libdecor;
 // pub mod viewporter;
 pub mod xdg_decoration;

--- a/src/native/linux_wayland/extensions.rs
+++ b/src/native/linux_wayland/extensions.rs
@@ -1,5 +1,6 @@
 #![allow(unused_variables, dead_code, non_upper_case_globals, static_mut_refs)]
 
+pub mod libdecor;
 pub mod viewporter;
 pub mod xdg_decoration;
 pub mod xdg_shell;

--- a/src/native/linux_wayland/extensions.rs
+++ b/src/native/linux_wayland/extensions.rs
@@ -1,7 +1,7 @@
 #![allow(unused_variables, dead_code, non_upper_case_globals, static_mut_refs)]
 
 pub mod libdecor;
-pub mod viewporter;
+// pub mod viewporter;
 pub mod xdg_decoration;
 pub mod xdg_shell;
 

--- a/src/native/linux_wayland/extensions/cursor.rs
+++ b/src/native/linux_wayland/extensions/cursor.rs
@@ -1,0 +1,127 @@
+use super::super::libwayland_client::{wl_fixed_t, wl_interface, wl_message};
+use crate::wayland_interface;
+
+pub const CURSOR_SHAPE_MANAGER_GET_POINTER: u32 = 1;
+pub const CURSOR_SHAPE_DEVICE_SET_SHAPE: u32 = 1;
+pub const RELATIVE_POINTER_MANAGER_GET_RELATIVE_POINTER: u32 = 1;
+pub const POINTER_CONSTRAINTS_LOCK_POINTER: u32 = 1;
+pub const zwp_pointer_constraints_v1_lifetime_ONESHOT: u32 = 1;
+pub const zwp_pointer_constraints_v1_lifetime_PERSISTENT: u32 = 2;
+
+#[rustfmt::skip]
+wayland_interface!(
+    wp_cursor_shape_manager_v1_interface,
+    wp_cursor_shape_manager_v1,
+    1,
+    [
+        (destroy, "", ()),
+        (get_pointer, "no", (wp_cursor_shape_device_v1_interface)),
+        (get_tablet_tool_v2, "no", (wp_cursor_shape_device_v1_interface))
+    ],
+    []
+);
+
+#[rustfmt::skip]
+wayland_interface!(
+    wp_cursor_shape_device_v1_interface,
+    wp_cursor_shape_device_v1,
+    1,
+    [
+        (destroy, "", ()),
+        (set_shape, "uu", ())
+    ],
+    []
+);
+
+#[rustfmt::skip]
+wayland_interface!(
+    zwp_relative_pointer_manager_v1_interface,
+    zwp_relative_pointer_manager_v1,
+    1,
+    [
+        (destroy, "", ()),
+        (get_relative_pointer, "no", (zwp_relative_pointer_v1_interface))
+    ],
+    []
+);
+
+#[rustfmt::skip]
+wayland_interface!(
+    zwp_pointer_constraints_v1_interface,
+    zwp_pointer_constraints_v1,
+    1,
+    [
+        (destroy, "", ()),
+        (lock_pointer, "noo?ou", (zwp_locked_pointer_v1_interface)),
+        (confine_pointer, "noo?ou", (zwp_confined_pointer_v1_interface))
+    ],
+    []
+);
+
+#[rustfmt::skip]
+wayland_interface!(
+    zwp_locked_pointer_v1_interface,
+    zwp_locked_pointer_v1,
+    1,
+    [
+        (destroy, "", ()),
+        (set_cursor_position_hint, "ff", ()),
+        (set_region, "?o", ())
+    ],
+    [("locked", ""), ("unlocked", "")]
+);
+
+#[rustfmt::skip]
+wayland_interface!(
+    zwp_confined_pointer_v1_interface,
+    zwp_confined_pointer_v1,
+    1,
+    [
+        (destroy, "", ()),
+        (set_region, "?o", ())
+    ],
+    [("confined", ""), ("unconfined", "")]
+);
+
+#[rustfmt::skip]
+wayland_interface!(
+    zwp_relative_pointer_v1_interface,
+    zwp_relative_pointer_v1,
+    1,
+    [
+        (destroy, "", ())
+    ],
+    [("relative_motion", "uuffff")]
+);
+
+crate::wl_listener!(
+    zwp_relative_pointer_v1_listener,
+    zwp_relative_pointer_v1,
+    zwp_relative_pointer_v1_dummy,
+    fn relative_motion(
+        utime_hi: core::ffi::c_uint,
+        utime_lo: core::ffi::c_uint,
+        dx: wl_fixed_t,
+        dy: wl_fixed_t,
+        dx_unaccel: wl_fixed_t,
+        dy_unaccel: wl_fixed_t,
+    ),
+);
+
+pub fn translate_cursor(icon: crate::CursorIcon) -> core::ffi::c_uint {
+    // https://wayland.app/protocols/cursor-shape-v1#wp_cursor_shape_device_v1:enum:shape
+    match icon {
+        crate::CursorIcon::Default => 1,
+        crate::CursorIcon::Help => 3,
+        crate::CursorIcon::Pointer => 4,
+        crate::CursorIcon::Wait => 6,
+        crate::CursorIcon::Crosshair => 8,
+        crate::CursorIcon::Text => 9,
+        crate::CursorIcon::Move => 13,
+        crate::CursorIcon::NotAllowed => 15,
+        crate::CursorIcon::EWResize => 26,
+        crate::CursorIcon::NSResize => 27,
+        crate::CursorIcon::NESWResize => 28,
+        crate::CursorIcon::NWSEResize => 29,
+    }
+}

--- a/src/native/linux_wayland/extensions/libdecor.rs
+++ b/src/native/linux_wayland/extensions/libdecor.rs
@@ -1,0 +1,87 @@
+#![allow(non_camel_case_types, dead_code)]
+
+use super::super::libwayland_client::*;
+use super::xdg_shell::*;
+use crate::declare_module;
+
+#[repr(C)]
+#[derive(Debug, Copy, Clone)]
+pub struct libdecor {
+    _unused: [u8; 0],
+}
+
+#[repr(C)]
+#[derive(Debug, Copy, Clone)]
+pub struct libdecor_frame {
+    _unused: [u8; 0],
+}
+
+#[repr(C)]
+#[derive(Debug, Copy, Clone)]
+pub struct libdecor_configuration {
+    _unused: [u8; 0],
+}
+
+#[repr(C)]
+#[derive(Debug, Copy, Clone)]
+pub struct libdecor_state {
+    _unused: [u8; 0],
+}
+
+#[repr(C)]
+#[derive(Debug, Copy, Clone)]
+pub struct libdecor_error {
+    _unused: [u8; 0],
+}
+
+#[repr(C)]
+#[derive(Debug, Copy, Clone)]
+pub struct libdecor_interface {
+    pub error: unsafe extern "C" fn(*mut libdecor, *mut libdecor_error, *const c_char),
+}
+
+#[repr(C)]
+#[derive(Debug, Copy, Clone)]
+pub struct libdecor_frame_interface {
+    pub frame_configure:
+        unsafe extern "C" fn(*mut libdecor_frame, *mut libdecor_configuration, *mut c_void),
+    pub frame_close: unsafe extern "C" fn(*mut libdecor_frame, *mut c_void),
+    pub frame_commit: unsafe extern "C" fn(*mut libdecor_frame, *mut c_void),
+}
+
+use core::ffi::{c_char, c_int, c_void};
+
+declare_module! {
+    LibDecor,
+    "libdecor-0.so",
+    "libdecor-0.so.0",
+    ...
+    ...
+    pub fn libdecor_new(*mut wl_display, *mut libdecor_interface) -> *mut libdecor,
+    pub fn libdecor_decorate(
+        *mut libdecor,
+        *mut wl_surface,
+        *mut libdecor_frame_interface,
+        *mut c_void
+    ) -> *mut libdecor_frame,
+    pub fn libdecor_frame_set_app_id(*mut libdecor_frame, *const c_char),
+    pub fn libdecor_frame_set_title(*mut libdecor_frame, *const c_char),
+    pub fn libdecor_frame_map(*mut libdecor_frame),
+    pub fn libdecor_state_new(c_int, c_int) -> *mut libdecor_state,
+    pub fn libdecor_frame_commit(
+        *mut libdecor_frame,
+        *mut libdecor_state,
+        *mut libdecor_configuration,
+    ),
+    pub fn libdecor_state_free(*mut libdecor_state),
+    pub fn libdecor_configuration_get_content_size(
+        *mut libdecor_configuration,
+        *mut libdecor_frame,
+        *mut c_int,
+        *mut c_int,
+    ) -> c_int,
+    pub fn libdecor_frame_get_xdg_surface(*mut libdecor_frame) -> *mut xdg_surface,
+    pub fn libdecor_frame_get_xdg_toplevel(*mut libdecor_frame) -> *mut xdg_toplevel,
+    ...
+    ...
+}

--- a/src/native/linux_wayland/extensions/libdecor.rs
+++ b/src/native/linux_wayland/extensions/libdecor.rs
@@ -43,10 +43,10 @@ pub struct libdecor_interface {
 #[repr(C)]
 #[derive(Debug, Copy, Clone)]
 pub struct libdecor_frame_interface {
-    pub frame_configure:
+    pub configure:
         unsafe extern "C" fn(*mut libdecor_frame, *mut libdecor_configuration, *mut c_void),
-    pub frame_close: unsafe extern "C" fn(*mut libdecor_frame, *mut c_void),
-    pub frame_commit: unsafe extern "C" fn(*mut libdecor_frame, *mut c_void),
+    pub close: unsafe extern "C" fn(*mut libdecor_frame, *mut c_void),
+    pub commit: unsafe extern "C" fn(*mut libdecor_frame, *mut c_void),
 }
 
 use core::ffi::{c_char, c_int, c_void};

--- a/src/native/linux_wayland/extensions/xdg_shell.rs
+++ b/src/native/linux_wayland/extensions/xdg_shell.rs
@@ -87,31 +87,28 @@ wayland_interface!(
     [("configure", "iiii"), ("popup_done", "")]
 );
 
-#[derive(Copy, Clone)]
-#[repr(C)]
-pub(crate) struct xdg_wm_base_listener {
-    pub ping:
-        Option<unsafe extern "C" fn(_: *mut std::ffi::c_void, _: *mut xdg_wm_base, _: u32) -> ()>,
-}
+crate::wl_listener!(
+    xdg_wm_base_listener,
+    xdg_wm_base,
+    xdg_wm_base_dummy,
+    fn ping(serial: core::ffi::c_uint),
+);
 
-#[derive(Copy, Clone)]
-#[repr(C)]
-pub(crate) struct xdg_surface_listener {
-    pub configure:
-        Option<unsafe extern "C" fn(_: *mut std::ffi::c_void, _: *mut xdg_surface, _: u32) -> ()>,
-}
+crate::wl_listener!(
+    xdg_surface_listener,
+    xdg_surface,
+    xdg_surface_dummy,
+    fn configure(serial: core::ffi::c_uint),
+);
 
-#[derive(Copy, Clone)]
-#[repr(C)]
-pub(crate) struct xdg_toplevel_listener {
-    pub configure: Option<
-        unsafe extern "C" fn(
-            _: *mut std::ffi::c_void,
-            _: *mut xdg_toplevel,
-            _: i32,
-            _: i32,
-            _: *mut wl_array,
-        ) -> (),
-    >,
-    pub close: Option<unsafe extern "C" fn(_: *mut std::ffi::c_void, _: *mut xdg_toplevel) -> ()>,
-}
+crate::wl_listener!(
+    xdg_toplevel_listener,
+    xdg_toplevel,
+    xdg_toplevel_dummy,
+    fn configure(
+        width: core::ffi::c_int,
+        height: core::ffi::c_int,
+        states: *mut wl_array,
+    ),
+    fn close(),
+);

--- a/src/native/linux_wayland/keycodes.rs
+++ b/src/native/linux_wayland/keycodes.rs
@@ -5,6 +5,7 @@ pub fn translate(keysym: u32) -> KeyCode {
     // See xkbcommon/xkbcommon-keysyms.h
     match keysym {
         65307 => KeyCode::Escape,
+        65056 => KeyCode::Tab, // LeftTab
         65289 => KeyCode::Tab,
         65505 => KeyCode::LeftShift,
         65506 => KeyCode::RightShift,

--- a/src/native/linux_wayland/libwayland_client.rs
+++ b/src/native/linux_wayland/libwayland_client.rs
@@ -643,3 +643,39 @@ impl LibWaylandClient {
         bytes
     }
 }
+
+#[macro_export]
+macro_rules! wl_request_constructor {
+    ($libwayland:expr, $instance:expr, $request_name:expr, $interface:expr) => {
+        wl_request_constructor!($libwayland, $instance, $request_name, $interface, ())
+    };
+
+    ($libwayland:expr, $instance:expr, $request_name:expr, $interface:expr, $($arg:expr),*) => {{
+        let id: *mut wl_proxy;
+
+        id = ($libwayland.wl_proxy_marshal_constructor)(
+            $instance as _,
+            $request_name,
+            $interface as _,
+            std::ptr::null_mut::<std::ffi::c_void>(),
+            $($arg,)*
+        );
+
+        id as *mut _
+    }};
+}
+
+#[macro_export]
+macro_rules! wl_request {
+    ($libwayland:expr, $instance:expr, $request_name:expr) => {
+        wl_request!($libwayland, $instance, $request_name, ())
+    };
+
+    ($libwayland:expr, $instance:expr, $request_name:expr, $($arg:expr),*) => {{
+        ($libwayland.wl_proxy_marshal)(
+            $instance as _,
+            $request_name,
+            $($arg,)*
+        )
+    }};
+}

--- a/src/native/linux_wayland/libwayland_client.rs
+++ b/src/native/linux_wayland/libwayland_client.rs
@@ -510,6 +510,26 @@ wl_listener!(
 );
 
 wl_listener!(
+    wl_touch_listener,
+    wl_touch,
+    wl_touch_dummy,
+    fn down(
+        serial: c_uint,
+        time: c_uint,
+        surface: *mut wl_surface,
+        id: c_int,
+        x: wl_fixed_t,
+        y: wl_fixed_t,
+    ),
+    fn up(serial: c_uint, time: c_uint, id: c_int),
+    fn motion(time: c_uint, id: c_int, x: wl_fixed_t, y: wl_fixed_t),
+    fn frame(),
+    fn cancel(),
+    fn shape(id: c_int, major: wl_fixed_t, minor: wl_fixed_t),
+    fn orientation(id: c_int, orientation: wl_fixed_t),
+);
+
+wl_listener!(
     wl_data_device_listener,
     wl_data_device,
     wl_data_device_dummy,
@@ -565,6 +585,7 @@ crate::declare_module!(
     pub wl_output_interface: *mut wl_interface,
     pub wl_keyboard_interface: *mut wl_interface,
     pub wl_pointer_interface: *mut wl_interface,
+    pub wl_touch_interface: *mut wl_interface,
     pub wl_data_device_manager_interface: *mut wl_interface,
     pub wl_data_device_interface: *mut wl_interface,
     pub wl_data_source_interface: *mut wl_interface,

--- a/src/native/linux_wayland/libxkbcommon.rs
+++ b/src/native/linux_wayland/libxkbcommon.rs
@@ -16,7 +16,16 @@ pub struct xkb_state {
     _unused: [u8; 0],
 }
 
-use core::ffi::{c_int, c_uint};
+pub const XKB_STATE_MODS_EFFECTIVE: c_int = 1 << 3;
+pub const XKB_MOD_NAME_SHIFT: &str = "Shift";
+pub const XKB_MOD_NAME_CTRL: &str = "Control";
+pub const XKB_MOD_NAME_ALT: &str = "Mod1";
+pub const XKB_MOD_NAME_LOGO: &str = "Mod4";
+
+use core::ffi::{c_char, c_int, c_uint};
+pub type xkb_keycode_t = c_uint;
+pub type xkb_keysym_t = c_uint;
+pub type xkb_mod_index_t = c_uint;
 crate::declare_module!(
     LibXkbCommon,
     "libxkbcommon.so",
@@ -29,12 +38,92 @@ crate::declare_module!(
     pub fn xkb_context_unref(*mut xkb_context),
     pub fn xkb_keymap_new_from_string(*mut xkb_context, *mut libc::FILE, c_int, c_int) -> *mut xkb_keymap,
     pub fn xkb_keymap_unref(*mut xkb_keymap),
-    pub fn xkb_keymap_key_repeats(*mut xkb_keymap, c_uint) -> c_int,
+    pub fn xkb_keymap_key_repeats(*mut xkb_keymap, xkb_keycode_t) -> c_int,
     pub fn xkb_state_new(*mut xkb_keymap) -> *mut xkb_state,
     pub fn xkb_state_unref(*mut xkb_state),
-    pub fn xkb_state_key_get_one_sym(*mut xkb_state, c_uint) -> c_uint,
+    pub fn xkb_state_key_get_one_sym(*mut xkb_state, xkb_keycode_t) -> xkb_keysym_t,
+    pub fn xkb_keymap_mod_get_index(*mut xkb_keymap, *const c_char) -> xkb_mod_index_t,
+    pub fn xkb_state_mod_index_is_active(*mut xkb_state, xkb_mod_index_t, c_int) -> c_int,
     pub fn xkb_state_update_mask(*mut xkb_state, c_uint, c_uint, c_uint, c_uint, c_uint, c_uint) -> c_int,
-    pub fn xkb_keysym_to_utf32(c_uint) -> c_uint,
+    pub fn xkb_keysym_to_utf32(xkb_keysym_t) -> c_uint,
     ...
     ...
 );
+
+impl LibXkbCommon {
+    // The keycodes in Miniquad are obtained without modifiers (for example, `Shift + Key1` is
+    // translated to `Key1` and not `Exclam`)
+    pub unsafe fn keymap_key_get_sym_without_mod(
+        &mut self,
+        keymap: *mut xkb_keymap,
+        keycode: xkb_keycode_t,
+    ) -> xkb_keysym_t {
+        let xkb_state = (self.xkb_state_new)(keymap);
+        let keysym = (self.xkb_state_key_get_one_sym)(xkb_state, keycode);
+        (self.xkb_state_unref)(xkb_state);
+        keysym
+    }
+}
+
+pub mod libxkbcommon_ex {
+    use super::*;
+    use crate::KeyMods;
+
+    /// In `xkb` the modifier indices are tied to a particular `xkb_keymap` and not hardcoded.
+    #[derive(Copy, Clone)]
+    pub struct XkbKeymap {
+        pub xkb_keymap: *mut xkb_keymap,
+        shift: xkb_mod_index_t,
+        ctrl: xkb_mod_index_t,
+        alt: xkb_mod_index_t,
+        logo: xkb_mod_index_t,
+    }
+
+    impl Default for XkbKeymap {
+        fn default() -> Self {
+            XkbKeymap {
+                xkb_keymap: std::ptr::null_mut(),
+                shift: 0,
+                ctrl: 0,
+                alt: 0,
+                logo: 0,
+            }
+        }
+    }
+
+    impl XkbKeymap {
+        pub unsafe fn cache_mod_indices(&mut self, libxkb: &mut LibXkbCommon) {
+            let shift = std::ffi::CString::new(XKB_MOD_NAME_SHIFT).unwrap();
+            self.shift = (libxkb.xkb_keymap_mod_get_index)(self.xkb_keymap, shift.as_ptr());
+            let ctrl = std::ffi::CString::new(XKB_MOD_NAME_CTRL).unwrap();
+            self.ctrl = (libxkb.xkb_keymap_mod_get_index)(self.xkb_keymap, ctrl.as_ptr());
+            let alt = std::ffi::CString::new(XKB_MOD_NAME_ALT).unwrap();
+            self.alt = (libxkb.xkb_keymap_mod_get_index)(self.xkb_keymap, alt.as_ptr());
+            let logo = std::ffi::CString::new(XKB_MOD_NAME_LOGO).unwrap();
+            self.logo = (libxkb.xkb_keymap_mod_get_index)(self.xkb_keymap, logo.as_ptr());
+        }
+        pub unsafe fn get_keymods(
+            &self,
+            libxkb: &mut LibXkbCommon,
+            xkb_state: *mut xkb_state,
+        ) -> KeyMods {
+            let mut mods = KeyMods::default();
+            let is_active = libxkb.xkb_state_mod_index_is_active;
+            if (is_active)(xkb_state, self.shift, XKB_STATE_MODS_EFFECTIVE) == 1 {
+                mods.shift = true;
+            }
+            if (is_active)(xkb_state, self.ctrl, XKB_STATE_MODS_EFFECTIVE) == 1 {
+                mods.ctrl = true;
+            }
+            if (is_active)(xkb_state, self.alt, XKB_STATE_MODS_EFFECTIVE) == 1 {
+                mods.alt = true;
+            }
+            if (is_active)(xkb_state, self.logo, XKB_STATE_MODS_EFFECTIVE) == 1 {
+                mods.logo = true;
+            }
+            mods
+        }
+    }
+}
+
+pub use libxkbcommon_ex::XkbKeymap;

--- a/src/native/linux_x11.rs
+++ b/src/native/linux_x11.rs
@@ -558,6 +558,10 @@ where
         panic!("eglMakeCurrent failed");
     }
 
+    if (egl_lib.eglSwapInterval)(egl_display, conf.platform.swap_interval.unwrap_or(1)) == 0 {
+        eprintln!("eglSwapInterval failed");
+    }
+
     crate::native::gl::load_gl_funcs(|proc| {
         let name = std::ffi::CString::new(proc).unwrap();
         (egl_lib.eglGetProcAddress)(name.as_ptr() as _)

--- a/src/native/linux_x11/libx11_ex.rs
+++ b/src/native/linux_x11/libx11_ex.rs
@@ -235,7 +235,7 @@ impl LibX11 {
         (self.XFree)(hints as *mut libc::c_void);
 
         let class_hint = (self.XAllocClassHint)();
-        let wm_class = std::ffi::CString::new(conf.platform.linux_x11_wm_class).unwrap();
+        let wm_class = std::ffi::CString::new(conf.platform.linux_wm_class).unwrap();
         (*class_hint).res_name = wm_class.as_ptr() as _;
         (*class_hint).res_class = wm_class.as_ptr() as _;
         (self.XSetClassHint)(display, window, class_hint);


### PR DESCRIPTION
We now have
- Cursor shape / hide and grab (the cursor shape protocol is not supported under gnome for now but apparently it will be there in the next version)
- Key repeat
- Clipboard and drag-n-drop
- Blocking event loop
- High-dpi support
- Client-side window decorations under gnome using `libdecor`, which is what xwayland uses (I removed the old fallback decorations: it looks bad but more importantly it also messes up the cursor positioning, and I don't want to manually fix the offset)

Probably some tests are needed before merging, especially under different compositors and on different machines (I tested on `mutter`, `hyprland`, and `sway`, and I've had the same code working under one but not another...)

Also I did modify the code structure quite a bit. Probably gonna be bad for others who worked/are working on it (@narodnik maybe? btw I rebased upon your clipboard implementation; it got me started so your work is not in vain :)

There's still some code that's a bit messy; also it'd probably be nice for the X11 and Wayland implementations to share more common patterns, which I didn't pay enough attention. But at least it works now :)