### PR TITLE
MacOS: Fix gl_context null pointer dereference on startup

### DIFF
--- a/src/native/macos.rs
+++ b/src/native/macos.rs
@@ -300,6 +300,10 @@ pub fn define_cocoa_window_delegate() -> *const Class {
 
     extern "C" fn window_did_move(this: &Object, _: Sel, _: ObjcId) {
         let payload = get_window_payload(this);
+        if payload.gl_context.is_null() {
+            // Startup: the gl_context has not yet been created.
+            return;
+        }
         unsafe {
             msg_send_![payload.gl_context, update];
         }


### PR DESCRIPTION
When using Macroquad, I started running into crashes on MacOS on startup recently. I'm not sure if it is due to a newer Rust version that started checking this, or due to a new MacOS version that started moving windows on startup.

In any case, ignoring a null `gl_context` fixed the issue, and everything else works as expected afterwards.