### PR TITLE
native/linux_wayland: Fix keymods for key repeat

### DIFF
--- a/src/native/linux_wayland.rs
+++ b/src/native/linux_wayland.rs
@@ -127,7 +127,7 @@ impl WaylandPayload {
         // the message string is not accessible to us.
         match errno {
             0 => (),
-            EPROTO => {
+            libc::EPROTO => {
                 let mut interface: *const wl_interface = std::ptr::null();
                 let mut id = 0;
                 let code = (self.client.wl_display_get_protocol_error)(

--- a/src/native/linux_wayland/libwayland_client.rs
+++ b/src/native/linux_wayland/libwayland_client.rs
@@ -186,11 +186,6 @@ pub const WL_SUBSURFACE_PLACE_BELOW_SINCE_VERSION: u32 = 1;
 pub const WL_SUBSURFACE_SET_SYNC_SINCE_VERSION: u32 = 1;
 pub const WL_SUBSURFACE_SET_DESYNC_SINCE_VERSION: u32 = 1;
 
-pub const ENOMEM: c_int = 12;
-pub const EFAULT: c_int = 14;
-pub const EINVAL: c_int = 22;
-pub const EPROTO: c_int = 71;
-
 pub type wl_shm_format = ::core::ffi::c_uint;
 
 pub const wl_shm_format_WL_SHM_FORMAT_ARGB8888: wl_shm_format = 0;


### PR DESCRIPTION
The keymods used to be updated when a key is pressed/released and then used for key repeat; but for example when `Shift` is pressed, `keymods.shift` at this moment is false, and all subsequent repeats will not use the shift modifier. So instead now we check the keymods when a repeat is being generated.

(Oops, missed the new version release)