### PR TITLE
android: ndk_utils::get_utf_str!() macro leaks memory. Free the string after use

### DIFF
--- a/src/native/android.rs
+++ b/src/native/android.rs
@@ -344,7 +344,7 @@ impl crate::native::Clipboard for AndroidClipboard {
                 return None;
             }
 
-            let text = ndk_utils::get_utf_str!(env, text).to_string();
+            let text = ndk_utils::get_utf_str!(env, text);
             Some(text)
         }
     }

--- a/src/native/android/ndk_utils.rs
+++ b/src/native/android/ndk_utils.rs
@@ -73,9 +73,13 @@ macro_rules! call_bool_method {
 #[macro_export]
 macro_rules! get_utf_str {
     ($env:expr, $obj:expr) => {{
-        let string = (**$env).GetStringUTFChars.unwrap()($env, $obj, std::ptr::null_mut());
-        let string = std::ffi::CStr::from_ptr(string);
-        string.to_str().unwrap()
+        let cstr_dat = (**$env).GetStringUTFChars.unwrap()($env, $obj, std::ptr::null_mut());
+        let string = std::ffi::CStr::from_ptr(cstr_dat)
+            .to_str()
+            .unwrap()
+            .to_string();
+        (**$env).ReleaseStringUTFChars.unwrap()($env, $obj, cstr_dat);
+        string
     }};
 }
 


### PR DESCRIPTION
According to JNI docs, UTF8 strings must be released.

Also plz merge https://github.com/not-fl3/cargo-quad-apk/pull/10 when you get a chance