### PR TITLE
fix and expand the support of the window_minimized_event

### DIFF
--- a/js/gl.js
+++ b/js/gl.js
@@ -1365,7 +1365,9 @@ var importObject = {
 
             let lastFocus = document.hasFocus();
             var checkFocus = function () {
-                let hasFocus = document.hasFocus();
+                // The element doesn't loose focus when the user switches tabs.
+                // However, the document becomes invisible
+                let hasFocus = document.hasFocus() && document.visibilityState == "visible";
                 if (lastFocus != hasFocus) {
                     wasm_exports.focus(hasFocus);
                     lastFocus = hasFocus;

--- a/src/event.rs
+++ b/src/event.rs
@@ -206,9 +206,9 @@ pub trait EventHandler {
     fn raw_mouse_motion(&mut self, _dx: f32, _dy: f32) {}
 
     /// Window has been minimized
-    /// Right now is only implemented on Android, X11 and wasm,
+    /// Right now is only implemented on Android, Windows, OSX, X11 and wasm,
     /// On Andoid window_minimized_event is called on a Pause ndk callback
-    /// On X11 and wasm it will be called on focus change events.
+    /// On X11, OSX, Windows and wasm it will be called on focus change events.
     fn window_minimized_event(&mut self) {}
 
     /// Window has been restored

--- a/src/native/windows.rs
+++ b/src/native/windows.rs
@@ -535,6 +535,13 @@ unsafe extern "system" fn win32_wndproc(
                 }
             }
         }
+        WM_ACTIVATE => {
+            if LOWORD(wparam as _) == WA_ACTIVE || LOWORD(wparam as _) == WA_CLICKACTIVE {
+                event_handler.window_restored_event();
+            } else {
+                event_handler.window_minimized_event();
+            }
+        }
         _ => {}
     }
 


### PR DESCRIPTION
## Why?

`macroquad` has a bug: not-fl3/macroquad#547.
There is a good fix we can implement, that has been suggested by @profan - the same issue, but in godot (godotengine/godot#28061). Essentially, this PR part 1 of the fix.

## Context

`miniquad` already has some ready-to-use handlers for a potential fix. There is `window_minimized_event`. Despite the name, on X Window system and WASM it gets fired when a window loses focus.

I decided not to change that and instead focus on the following:
* Adding a similar support for OSX (special thanks to @jonatino for the help!)
* Adding a similar support for Windows
* Fixing a related bug on WASM

## Bug Reproduction

The following application is sufficient to catch the bug

```rust
use macroquad::prelude::*;

#[macroquad::main("Catching Keys")]
async fn main() {
    loop {
        clear_background(WHITE);

        let col = if is_key_down(KeyCode::A) {
            GREEN
        } else {
            RED
        };
        draw_rectangle(0.0, 0.0, 32.0, 32.0, col);

        next_frame().await
    }
}
```

The steps are simple:
1. Run the app
2. Hold the A key
3. While still holding the key -- focus on a different window
4. Release the A key
5. Focus again on the window
6. The square remains green (because `is_key_down` is still returning `true`)

## Testing The Fix

1. Use the same setup
2. Add the following lines to your `Cargo.toml`
3. Repeat the same steps
4. The square will now turn red on step (6)!

```toml
[patch.crates-io]
# hosts the second part of the fix
macroquad = { git = "https://github.com/InnocentusLime/macroquad.git", branch="lab-repeat-keys" }
# This branch with the fix
miniquad = { git = "https://github.com/InnocentusLime/miniquad.git", branch="fix-window-minimized" }
```

Tests:
- [x] Works on Windows
- [x] Works on MacOS/OsX (tested by @birhburh)
- [x] Works on WASM
- [x] Works on X11 (tested by @profan)

## Technical Notes About the fixed `js/gl.js`

There were a few things that did not make the minimized events fire correctly:
1. ~~`lastFocus == hasFocus` caused the app being notified of focus only when it didn't change~~ (fixed in 8d7cb80)
2. the `visibilitychange`  listener had a mistake. Elements **do not** lose focus when the browser changes tabs of the browser window becomes inactive. Instead `document.visibilityState` becomes not equal to `"visible"`