### PR TITLE
Fix sapp_set_clipboard funciton

### DIFF
--- a/js/gl.js
+++ b/js/gl.js
@@ -640,7 +640,10 @@ var importObject = {
             emscripten_shaders_hack = flag;
         },
         sapp_set_clipboard: function (ptr, len) {
-            clipboard = UTF8ToString(ptr, len);
+            let string_copy = (' ' + UTF8ToString(ptr, len)).slice(1);
+            if (string_copy != "") {
+                clipboard = string_copy;
+            }
         },
         dpi_scale,
         rand: function () {


### PR DESCRIPTION
This creates deep copy of the string and it's not destroyed immediately after calling this function.

Before this function basically never worked. Now it works. Tested on my portals web demo.