### PR TITLE
define bottom_left_to_top_left only for macos

### DIFF
--- a/src/native/apple/apple_util.rs
+++ b/src/native/apple/apple_util.rs
@@ -402,6 +402,7 @@ pub unsafe fn superclass(this: &Object) -> &Class {
     &*(superclass as *const _)
 }
 
+#[cfg(target_os = "macos")]
 pub fn bottom_left_to_top_left(rect: NSRect) -> f64 {
     let height = unsafe { CGDisplayPixelsHigh(CGMainDisplayID()) };
     height as f64 - (rect.origin.y + rect.size.height)


### PR DESCRIPTION
because ios doesn't have [CGDisplayPixelsHigh](https://developer.apple.com/documentation/coregraphics/cgdisplaypixelshigh(_:)?language=objc) and it may cause error during running (from discord):
```
Undefined symbols for architecture arm64:
  "_CGDisplayPixelsHigh", referenced from:
      miniquad::native:apple:apple_util::bottom_left_to_top_left::h4dc20aa8ec8d1c1d in liblearnmq.a[108]
```

I'm not sure is bottom_left_to_top_left needed at all, but left it