### PR TITLE
android: set or replace display to allow restarting UI when foreground service is enabled

### DIFF
--- a/src/event.rs
+++ b/src/event.rs
@@ -213,7 +213,7 @@ pub trait EventHandler {
 
     /// Window has been restored
     /// Right now is only implemented on Android, X11 and wasm,
-    /// On Andoid window_minimized_event is called on a Pause ndk callback
+    /// On Andoid window_restored_event is called on a Resume ndk callback
     /// On X11 and wasm it will be called on focus change events.
     fn window_restored_event(&mut self) {}
 
@@ -222,6 +222,7 @@ pub trait EventHandler {
     /// handler callback code can handle this event by calling
     /// ctx.cancel_quit() to cancel the quit.
     /// If the event is ignored, the application will quit as usual.
+    /// On Andoid quit_requested_event is called on a Destroy ndk callback
     fn quit_requested_event(&mut self) {}
 
     /// A file has been dropped over the application.

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -97,6 +97,17 @@ fn set_display(display: native::NativeDisplayData) {
         .set(Mutex::new(display))
         .unwrap_or_else(|_| panic!("NATIVE_DISPLAY already set"));
 }
+/// This for now is Android specific since the process can continue running but the display
+/// is restarted. We support reinitializing the display.
+fn set_or_replace_display(display: native::NativeDisplayData) {
+    if let Some(m) = NATIVE_DISPLAY.get() {
+        // Replace existing display
+        *m.lock().unwrap() = display;
+    } else {
+        // First time initialization
+        set_display(display);
+    }
+}
 fn native_display() -> &'static Mutex<native::NativeDisplayData> {
     NATIVE_DISPLAY
         .get()

--- a/src/native/android.rs
+++ b/src/native/android.rs
@@ -193,10 +193,6 @@ impl MainThreadState {
                 width,
                 height,
             } => {
-                unsafe {
-                    self.update_surface(window);
-                }
-
                 {
                     let mut d = crate::native_display().lock().unwrap();
                     d.screen_width = width as _;
@@ -450,7 +446,7 @@ where
 
         let (tx, requests_rx) = std::sync::mpsc::channel();
         let clipboard = Box::new(AndroidClipboard::new());
-        crate::set_display(NativeDisplayData {
+        crate::set_or_replace_display(NativeDisplayData {
             high_dpi: conf.high_dpi,
             blocking_event_loop: conf.platform.blocking_event_loop,
             ..NativeDisplayData::new(screen_width as _, screen_height as _, tx, clipboard)


### PR DESCRIPTION
On Android, when you have an app in the background for a few secs it will be closed. Also most users will just close the app when they intend to minimize.

This is annoying if you're downloading stuff in the background. Every time you restart the app, you have to redo initialization such as connecting to services and so on. The way to handle this in Android is to create a long running `ForegroundService`.

However then globals remain persistent, and miniquad will crash due to the display having been already initialized. So this commit fixes that by replacing the display if already initialized. It doesn't change existing usage of Android apps.