### PR TITLE
android: make set_panic_hook configurable using a Platform conf setting.

### DIFF
--- a/src/conf.rs
+++ b/src/conf.rs
@@ -169,6 +169,10 @@ pub struct Platform {
     // for most purposes they are the same so we just use class name for simplicity
     // https://unix.stackexchange.com/questions/494169/
     pub linux_wm_class: &'static str,
+
+    /// Whether to automatically setup the panic hook for Android.
+    /// Set this to false if your app does its own panic_hook setup to avoid conflicts.
+    pub android_panic_hook: bool,
 }
 
 impl Default for Platform {
@@ -183,6 +187,7 @@ impl Default for Platform {
             framebuffer_alpha: false,
             wayland_decorations: WaylandDecorations::default(),
             linux_wm_class: "miniquad-application",
+            android_panic_hook: true,
         }
     }
 }

--- a/src/native/android.rs
+++ b/src/native/android.rs
@@ -369,7 +369,7 @@ pub unsafe fn run<F>(conf: crate::conf::Conf, f: F)
 where
     F: 'static + FnOnce() -> Box<dyn EventHandler>,
 {
-    {
+    if conf.platform.android_panic_hook {
         use std::ffi::CString;
         use std::panic;
 


### PR DESCRIPTION
Apologies my last commit commented out the panic hook override by accident.

I normally disable this locally because I want the backtrace and my own format.

So I made it configurable.

BTW do we want the backtrace in the default miniquad output? I find it more useful than a simple single line crash. Here's what I use:

```rust
fn panic_hook(panic_info: &std::panic::PanicHookInfo) {
    error!("panic occurred: {panic_info}");
    error!("{}", std::backtrace::Backtrace::force_capture().to_string());
    std::process::abort()
}
```

Anyways this is my PR