### PR TITLE
fix dropped files on Windows OS not resetting to default

### DIFF
--- a/src/native/windows.rs
+++ b/src/native/windows.rs
@@ -520,6 +520,7 @@ unsafe extern "system" fn win32_wndproc(
             let num_drops = DragQueryFileW(hdrop, u32::MAX, std::ptr::null_mut(), 0);
 
             let mut d = crate::native_display().lock().unwrap();
+            d.dropped_files = Default::default();
             for i in 0..num_drops {
                 let path_ptr = path.as_mut_ptr() as *mut u16;
                 let path_len = DragQueryFileW(hdrop, i, path_ptr, MAX_PATH as u32) as usize;


### PR DESCRIPTION
It's a pretty small change but I noticed that the behavior of dropped files isn't consistent across all platforms. On Linux and WASM it resets the dropped file buffer to default and on Windows it doesn't. I added the reset to default on Windows as well. 