### PR TITLE
refactor file dropping to use a single Vec instead of two

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -298,15 +298,15 @@ pub mod window {
     }
     pub fn dropped_file_count() -> usize {
         let d = native_display().lock().unwrap();
-        d.dropped_files.bytes.len()
+        d.dropped_files.len()
     }
     pub fn dropped_file_bytes(index: usize) -> Option<Vec<u8>> {
         let d = native_display().lock().unwrap();
-        d.dropped_files.bytes.get(index).cloned()
+        d.dropped_files.get(index).map(|file| file.bytes.clone())
     }
     pub fn dropped_file_path(index: usize) -> Option<std::path::PathBuf> {
         let d = native_display().lock().unwrap();
-        d.dropped_files.paths.get(index).cloned()
+        d.dropped_files.get(index).map(|file| file.path.clone())
     }
 
     /// Show/hide onscreen keyboard.

--- a/src/native.rs
+++ b/src/native.rs
@@ -2,11 +2,11 @@
 
 use std::sync::mpsc;
 
-#[derive(Default)]
-pub(crate) struct DroppedFiles {
-    pub paths: Vec<std::path::PathBuf>,
-    pub bytes: Vec<Vec<u8>>,
+pub(crate) struct DroppedFile {
+    pub path: std::path::PathBuf,
+    pub bytes: Vec<u8>,
 }
+
 pub(crate) struct NativeDisplayData {
     pub screen_width: i32,
     pub screen_height: i32,
@@ -17,7 +17,7 @@ pub(crate) struct NativeDisplayData {
     pub quit_ordered: bool,
     pub native_requests: mpsc::Sender<Request>,
     pub clipboard: Box<dyn Clipboard>,
-    pub dropped_files: DroppedFiles,
+    pub dropped_files: Vec<DroppedFile>,
     pub blocking_event_loop: bool,
 
     #[cfg(target_vendor = "apple")]

--- a/src/native/linux_wayland.rs
+++ b/src/native/linux_wayland.rs
@@ -18,7 +18,7 @@ use libxkbcommon::*;
 
 use crate::{
     event::{EventHandler, KeyCode, KeyMods, MouseButton},
-    native::{egl, NativeDisplayData, Request},
+    native::{egl, DroppedFile, NativeDisplayData, Request},
 };
 
 use core::time::Duration;
@@ -1277,8 +1277,7 @@ where
                         for filename in filenames.lines() {
                             let path = std::path::PathBuf::from(filename);
                             if let Ok(bytes) = std::fs::read(&path) {
-                                d.dropped_files.paths.push(path);
-                                d.dropped_files.bytes.push(bytes);
+                                d.dropped_files.push(DroppedFile { path, bytes });
                             }
                         }
                         // drop d since files_dropped_event is likely to need access to it

--- a/src/native/linux_x11.rs
+++ b/src/native/linux_x11.rs
@@ -11,7 +11,7 @@ mod xi_input;
 
 use crate::{
     event::EventHandler,
-    native::{egl, gl, module, NativeDisplayData, Request},
+    native::{egl, gl, module, DroppedFile, NativeDisplayData, Request},
     CursorIcon,
 };
 
@@ -203,8 +203,7 @@ impl X11Display {
                         for filename in filenames.lines() {
                             let path = std::path::PathBuf::from(filename);
                             if let Ok(bytes) = std::fs::read(&path) {
-                                d.dropped_files.paths.push(path);
-                                d.dropped_files.bytes.push(bytes);
+                                d.dropped_files.push(DroppedFile { path, bytes });
                             }
                         }
                         // drop d since files_dropped_event is likely to need access to it

--- a/src/native/wasm.rs
+++ b/src/native/wasm.rs
@@ -12,7 +12,7 @@ use std::{
 
 use crate::{
     event::EventHandler,
-    native::{NativeDisplayData, Request},
+    native::{DroppedFile, NativeDisplayData, Request},
 };
 
 // fn dropped_file_count(&mut self) -> usize {
@@ -362,6 +362,5 @@ pub extern "C" fn on_file_dropped(
     let path = PathBuf::from(unsafe { String::from_raw_parts(path, path_len, path_len) });
     let bytes = unsafe { Vec::from_raw_parts(bytes, bytes_len, bytes_len) };
 
-    d.dropped_files.paths.push(path);
-    d.dropped_files.bytes.push(bytes);
+    d.dropped_files.push(DroppedFile { path, bytes });
 }

--- a/src/native/windows.rs
+++ b/src/native/windows.rs
@@ -3,7 +3,7 @@ use std::{ffi::OsString, os::windows::ffi::OsStringExt, path::PathBuf};
 use crate::{
     conf::{Conf, Icon},
     event::{KeyMods, MouseButton},
-    native::{NativeDisplayData, Request},
+    native::{DroppedFile, NativeDisplayData, Request},
     CursorIcon, EventHandler,
 };
 
@@ -531,8 +531,10 @@ unsafe extern "system" fn win32_wndproc(
                         let path = path.assume_init();
                         PathBuf::from(OsString::from_wide(&path[0..path_len]))
                     };
-                    d.dropped_files.bytes.push(std::fs::read(&path).unwrap());
-                    d.dropped_files.paths.push(path);
+                    d.dropped_files.push(DroppedFile {
+                        bytes: std::fs::read(&path).unwrap(),
+                        path,
+                    });
                 }
             }
         }


### PR DESCRIPTION
A change that I noticed could be done in file dropping. There's two Vecs related to dropped files, one for storing the paths and the other for storing the bytes of the files. I thought that having this done as a single Vec of a new DroppedFile struct containing both the path to the file and the bytes of the file is probably a more obvious way of doing this, instead of having two separate Vecs that are ultimately still connected. It also allows for easier further changes, as now you can work with the entire file structs instead of needing to worry about whether or not the Vecs actually match in content counts (which they should always do)