### PR TITLE
android: allow calling window::schedule_update() from any thread with the blocking event loop active

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -211,9 +211,17 @@ pub mod window {
     /// TODO: implement window focus events
     pub fn set_cursor_grab(grab: bool) {
         let d = native_display().lock().unwrap();
-        d.native_requests
-            .send(native::Request::SetCursorGrab(grab))
-            .unwrap();
+        #[cfg(target_os = "android")]
+        {
+            (d.native_requests)(native::Request::SetCursorGrab(grab));
+        }
+
+        #[cfg(not(target_os = "android"))]
+        {
+            d.native_requests
+                .send(native::Request::SetCursorGrab(grab))
+                .unwrap();
+        }
     }
 
     /// With `conf.platform.blocking_event_loop`, `schedule_update` called from an
@@ -222,7 +230,13 @@ pub mod window {
     ///
     /// Does nothing without `conf.platform.blocking_event_loop`.
     pub fn schedule_update() {
-        #[cfg(not(target_arch = "wasm32"))]
+        #[cfg(all(target_os = "android", not(target_arch = "wasm32")))]
+        {
+            let d = native_display().lock().unwrap();
+            (d.native_requests)(native::Request::ScheduleUpdate);
+        }
+
+        #[cfg(not(any(target_arch = "wasm32", target_os = "android")))]
         {
             let d = native_display().lock().unwrap();
             d.native_requests
@@ -239,35 +253,70 @@ pub mod window {
     /// Show or hide the mouse cursor
     pub fn show_mouse(shown: bool) {
         let d = native_display().lock().unwrap();
-        d.native_requests
-            .send(native::Request::ShowMouse(shown))
-            .unwrap();
+        #[cfg(target_os = "android")]
+        {
+            (d.native_requests)(native::Request::ShowMouse(shown));
+        }
+
+        #[cfg(not(target_os = "android"))]
+        {
+            d.native_requests
+                .send(native::Request::ShowMouse(shown))
+                .unwrap();
+        }
     }
 
     /// Set the mouse cursor icon.
     pub fn set_mouse_cursor(cursor_icon: CursorIcon) {
         let d = native_display().lock().unwrap();
-        d.native_requests
-            .send(native::Request::SetMouseCursor(cursor_icon))
-            .unwrap();
+        #[cfg(target_os = "android")]
+        {
+            (d.native_requests)(native::Request::SetMouseCursor(cursor_icon));
+        }
+
+        #[cfg(not(target_os = "android"))]
+        {
+            d.native_requests
+                .send(native::Request::SetMouseCursor(cursor_icon))
+                .unwrap();
+        }
     }
 
     /// Set the application's window size.
     pub fn set_window_size(new_width: u32, new_height: u32) {
         let d = native_display().lock().unwrap();
-        d.native_requests
-            .send(native::Request::SetWindowSize {
+        #[cfg(target_os = "android")]
+        {
+            (d.native_requests)(native::Request::SetWindowSize {
                 new_width,
                 new_height,
-            })
-            .unwrap();
+            });
+        }
+
+        #[cfg(not(target_os = "android"))]
+        {
+            d.native_requests
+                .send(native::Request::SetWindowSize {
+                    new_width,
+                    new_height,
+                })
+                .unwrap();
+        }
     }
 
     pub fn set_window_position(new_x: u32, new_y: u32) {
         let d = native_display().lock().unwrap();
-        d.native_requests
-            .send(native::Request::SetWindowPosition { new_x, new_y })
-            .unwrap();
+        #[cfg(target_os = "android")]
+        {
+            (d.native_requests)(native::Request::SetWindowPosition { new_x, new_y });
+        }
+
+        #[cfg(not(target_os = "android"))]
+        {
+            d.native_requests
+                .send(native::Request::SetWindowPosition { new_x, new_y })
+                .unwrap();
+        }
     }
 
     /// Get the position of the window.
@@ -280,9 +329,17 @@ pub mod window {
 
     pub fn set_fullscreen(fullscreen: bool) {
         let d = native_display().lock().unwrap();
-        d.native_requests
-            .send(native::Request::SetFullscreen(fullscreen))
-            .unwrap();
+        #[cfg(target_os = "android")]
+        {
+            (d.native_requests)(native::Request::SetFullscreen(fullscreen));
+        }
+
+        #[cfg(not(target_os = "android"))]
+        {
+            d.native_requests
+                .send(native::Request::SetFullscreen(fullscreen))
+                .unwrap();
+        }
     }
 
     /// Get current OS clipboard value
@@ -313,9 +370,17 @@ pub mod window {
     /// Only works on Android right now.
     pub fn show_keyboard(show: bool) {
         let d = native_display().lock().unwrap();
-        d.native_requests
-            .send(native::Request::ShowKeyboard(show))
-            .unwrap();
+        #[cfg(target_os = "android")]
+        {
+            (d.native_requests)(native::Request::ShowKeyboard(show));
+        }
+
+        #[cfg(not(target_os = "android"))]
+        {
+            d.native_requests
+                .send(native::Request::ShowKeyboard(show))
+                .unwrap();
+        }
     }
 
     #[cfg(target_vendor = "apple")]

--- a/src/native.rs
+++ b/src/native.rs
@@ -1,5 +1,6 @@
 #![allow(dead_code)]
 
+#[cfg(not(target_os = "android"))]
 use std::sync::mpsc;
 
 #[derive(Default)]
@@ -15,6 +16,9 @@ pub(crate) struct NativeDisplayData {
     pub high_dpi: bool,
     pub quit_requested: bool,
     pub quit_ordered: bool,
+    #[cfg(target_os = "android")]
+    pub native_requests: Box<dyn Fn(Request) + Send>,
+    #[cfg(not(target_os = "android"))]
     pub native_requests: mpsc::Sender<Request>,
     pub clipboard: Box<dyn Clipboard>,
     pub dropped_files: DroppedFiles,
@@ -36,7 +40,8 @@ impl NativeDisplayData {
     pub fn new(
         screen_width: i32,
         screen_height: i32,
-        native_requests: mpsc::Sender<Request>,
+        #[cfg(target_os = "android")] native_requests: Box<dyn Fn(Request) + Send>,
+        #[cfg(not(target_os = "android"))] native_requests: mpsc::Sender<Request>,
         clipboard: Box<dyn Clipboard>,
     ) -> NativeDisplayData {
         NativeDisplayData {


### PR DESCRIPTION
Android with the non blocking event loop, uses mpsc rx.try_recv() repeatedly which drastically reduces the battery (revealed during my testing). The solution is then to use the blocking event loop, but due to the current design where requests are a separate queue, then calling schedule_update() will only work when the main queue has already been interrupted.

The reason calling schedule_update() inside events alone is insufficient is for async events like notifications such as connection status indicator which varies regardless of user action.

The solution then for android is to merge both these queues together. Since NativeDisplayData.native_requests() is a queue, we replace this with a callback instead. Then each native module can specify whichever logic they want to pass in requests. For android merging the queues together solves the issue.

For now I left Mac, Win, iOS and Linux untouched, but will gradually add these in since the goal is also to be able to use non blocking event loop on laptops and save battery as well.