### PR TITLE
Allow updating a part of a buffer

### DIFF
--- a/src/graphics.rs
+++ b/src/graphics.rs
@@ -1280,7 +1280,15 @@ pub trait RenderingBackend {
     /// ```
     fn new_buffer(&mut self, type_: BufferType, usage: BufferUsage, data: BufferSource)
         -> BufferId;
-    fn buffer_update(&mut self, buffer: BufferId, data: BufferSource);
+
+    fn buffer_update(&mut self, buffer: BufferId, data: BufferSource) {
+        self.buffer_update_part(buffer, 0, data);
+    }
+
+    /// Update only a part of a buffer. 
+    /// 
+    /// The offset is given in bytes
+    fn buffer_update_part(&mut self, buffer: BufferId, offset: usize, data: BufferSource);
 
     /// Size of buffer in bytes.
     /// For 1 element, u16 buffer this will return 2.


### PR DESCRIPTION
This PR adds a new method `buffer_update_part`, which compared to `buffer_update`, additionally takes an additional offset argument in bytes. This simply allows updating a buffer starting from a specific byte position, compared to always updating it from the start. 

The change is backward-compatible and should be available on all platforms.

One minor note is that I only tested this using the GL rendering backend (I don't have an apple device).