### PR TITLE
Make some functions const

### DIFF
--- a/src/conf.rs
+++ b/src/conf.rs
@@ -246,7 +246,7 @@ pub struct Icon {
 }
 
 impl Icon {
-    pub fn miniquad_logo() -> Icon {
+    pub const fn miniquad_logo() -> Icon {
         Icon {
             small: crate::default_icon::SMALL,
             medium: crate::default_icon::MEDIUM,

--- a/src/graphics.rs
+++ b/src/graphics.rs
@@ -42,7 +42,7 @@ pub enum UniformType {
 
 impl UniformType {
     /// Byte size for a given UniformType
-    pub fn size(&self) -> usize {
+    pub const fn size(&self) -> usize {
         match self {
             UniformType::Float1 => 4,
             UniformType::Float2 => 8,
@@ -134,7 +134,7 @@ impl VertexFormat {
     /// Number of components in this VertexFormat
     /// it is called size in OpenGl, but do not confuse this with bytes size
     /// basically, its an N from FloatN/IntN
-    pub fn components(&self) -> i32 {
+    pub const fn components(&self) -> i32 {
         match self {
             VertexFormat::Float1 => 1,
             VertexFormat::Float2 => 2,
@@ -157,7 +157,7 @@ impl VertexFormat {
     }
 
     /// Size in bytes
-    pub fn size_bytes(&self) -> i32 {
+    pub const fn size_bytes(&self) -> i32 {
         match self {
             VertexFormat::Float1 => 1 * 4,
             VertexFormat::Float2 => 2 * 4,
@@ -179,7 +179,7 @@ impl VertexFormat {
         }
     }
 
-    fn type_(&self) -> GLuint {
+    const fn type_(&self) -> GLuint {
         match self {
             VertexFormat::Float1 => GL_FLOAT,
             VertexFormat::Float2 => GL_FLOAT,
@@ -328,7 +328,7 @@ pub enum TextureFormat {
 }
 impl TextureFormat {
     /// Returns the size in bytes of texture with `dimensions`.
-    pub fn size(self, width: u32, height: u32) -> u32 {
+    pub const fn size(self, width: u32, height: u32) -> u32 {
         let square = width * height;
         match self {
             TextureFormat::RGB8 => 3 * square,
@@ -436,7 +436,7 @@ impl TextureId {
     /// Wrap raw platform texture into a TextureId acceptable for miniquad
     /// Without allocating any miniquad memory and without letting miniquad
     /// manage the texture.
-    pub fn from_raw_id(raw_id: RawId) -> TextureId {
+    pub const fn from_raw_id(raw_id: RawId) -> TextureId {
         TextureId(TextureIdInner::Raw(raw_id))
     }
 }
@@ -465,7 +465,7 @@ pub struct BlendState {
 }
 
 impl BlendState {
-    pub fn new(equation: Equation, sfactor: BlendFactor, dfactor: BlendFactor) -> BlendState {
+    pub const fn new(equation: Equation, sfactor: BlendFactor, dfactor: BlendFactor) -> BlendState {
         BlendState {
             equation,
             sfactor,
@@ -547,7 +547,7 @@ pub enum PassAction {
 }
 
 impl PassAction {
-    pub fn clear_color(r: f32, g: f32, b: f32, a: f32) -> PassAction {
+    pub const fn clear_color(r: f32, g: f32, b: f32, a: f32) -> PassAction {
         PassAction::Clear {
             color: Some((r, g, b, a)),
             depth: Some(1.),
@@ -789,14 +789,14 @@ pub enum BufferUsage {
     Stream,
 }
 
-fn gl_buffer_target(buffer_type: &BufferType) -> GLenum {
+const fn gl_buffer_target(buffer_type: &BufferType) -> GLenum {
     match buffer_type {
         BufferType::VertexBuffer => GL_ARRAY_BUFFER,
         BufferType::IndexBuffer => GL_ELEMENT_ARRAY_BUFFER,
     }
 }
 
-fn gl_usage(usage: &BufferUsage) -> GLenum {
+const fn gl_usage(usage: &BufferUsage) -> GLenum {
     match usage {
         BufferUsage::Immutable => GL_STATIC_DRAW,
         BufferUsage::Dynamic => GL_DYNAMIC_DRAW,
@@ -879,7 +879,7 @@ impl Default for ElapsedQuery {
 }
 
 impl ElapsedQuery {
-    pub fn new() -> ElapsedQuery {
+    pub const fn new() -> ElapsedQuery {
         ElapsedQuery { gl_query: 0 }
     }
 
@@ -919,7 +919,7 @@ impl ElapsedQuery {
     /// available for retrieval.
     ///
     /// Use [`ElapsedQuery::is_supported()`] to check if functionality is available and the method can be called.
-    pub fn get_result(&self) -> u64 {
+    pub const fn get_result(&self) -> u64 {
         // let mut time: GLuint64 = 0;
         // assert!(self.gl_query != 0);
         // unsafe { glGetQueryObjectui64v(self.gl_query, GL_QUERY_RESULT, &mut time) };
@@ -940,7 +940,7 @@ impl ElapsedQuery {
     /// command submission.
     ///
     /// Use [`ElapsedQuery::is_supported()`] to check if functionality is available and the method can be called.
-    pub fn is_available(&self) -> bool {
+    pub const fn is_available(&self) -> bool {
         // let mut available: GLint = 0;
 
         // // begin_query was not called yet
@@ -996,7 +996,7 @@ impl<'a> BufferSource<'a> {
     /// types are not supported.
     ///
     /// For vertex buffers it is OK to use `empty::<u8>(byte_size);`
-    pub fn empty<T>(size: usize) -> BufferSource<'a> {
+    pub const fn empty<T>(size: usize) -> BufferSource<'a> {
         let element_size = std::mem::size_of::<T>();
         BufferSource::Empty {
             size: size * std::mem::size_of::<T>(),
@@ -1014,7 +1014,11 @@ impl<'a> BufferSource<'a> {
         })
     }
 
-    pub unsafe fn pointer(ptr: *const u8, size: usize, element_size: usize) -> BufferSource<'a> {
+    pub const unsafe fn pointer(
+        ptr: *const u8,
+        size: usize,
+        element_size: usize,
+    ) -> BufferSource<'a> {
         BufferSource::Slice(Arg {
             ptr: ptr as _,
             size,
@@ -1087,7 +1091,7 @@ pub struct ContextInfo {
 }
 
 impl ContextInfo {
-    pub fn has_integer_attributes(&self) -> bool {
+    pub const fn has_integer_attributes(&self) -> bool {
         match self.backend {
             Backend::Metal => true,
             Backend::OpenGl => {

--- a/src/graphics/gl.rs
+++ b/src/graphics/gl.rs
@@ -51,13 +51,13 @@ enum TextureOrRenderbuffer {
     Renderbuffer(GLuint),
 }
 impl TextureOrRenderbuffer {
-    fn texture(&self) -> Option<GLuint> {
+    const fn texture(&self) -> Option<GLuint> {
         match self {
             TextureOrRenderbuffer::Texture(id) => Some(*id),
             _ => None,
         }
     }
-    fn renderbuffer(&self) -> Option<GLuint> {
+    const fn renderbuffer(&self) -> Option<GLuint> {
         match self {
             TextureOrRenderbuffer::Renderbuffer(id) => Some(*id),
             _ => None,
@@ -72,7 +72,7 @@ struct Texture {
 }
 
 impl TextureFormat {
-    fn sized_internal_format(&self) -> GLenum {
+    const fn sized_internal_format(&self) -> GLenum {
         match self {
             TextureFormat::RGB8 => GL_RGB8,
             TextureFormat::RGBA8 => GL_RGBA8,
@@ -446,11 +446,11 @@ impl Texture {
     }
 
     #[inline]
-    fn size(&self, width: u32, height: u32) -> usize {
+    const fn size(&self, width: u32, height: u32) -> usize {
         self.params.format.size(width, height) as usize
     }
 
-    fn gl_filter(filter: FilterMode, mipmap_filter: MipmapFilterMode) -> GLenum {
+    const fn gl_filter(filter: FilterMode, mipmap_filter: MipmapFilterMode) -> GLenum {
         match filter {
             FilterMode::Nearest => match mipmap_filter {
                 MipmapFilterMode::None => GL_NEAREST,
@@ -574,7 +574,7 @@ impl GlContext {
         }
     }
 
-    pub fn features(&self) -> &Features {
+    pub const fn features(&self) -> &Features {
         &self.info.features
     }
 }

--- a/src/native/linux_wayland.rs
+++ b/src/native/linux_wayland.rs
@@ -227,7 +227,7 @@ struct KeyboardContext {
     timerfd: core::ffi::c_int,
 }
 
-fn new_itimerspec() -> libc::itimerspec {
+const fn new_itimerspec() -> libc::itimerspec {
     libc::itimerspec {
         it_interval: libc::timespec {
             tv_sec: 0,
@@ -329,7 +329,7 @@ struct PointerContext {
     relative_pointer: *mut extensions::cursor::zwp_relative_pointer_v1,
 }
 impl PointerContext {
-    fn new() -> Self {
+    const fn new() -> Self {
         Self {
             pointer: std::ptr::null_mut(),
             enter_serial: None,

--- a/src/native/linux_wayland/decorations.rs
+++ b/src/native/linux_wayland/decorations.rs
@@ -287,7 +287,10 @@ unsafe extern "C" fn libdecor_frame_handle_close(_frame: *mut libdecor_frame, _d
     crate::native_display().try_lock().unwrap().quit_requested = true;
 }
 
-unsafe extern "C" fn libdecor_frame_handle_commit(_frame: *mut libdecor_frame, _data: *mut c_void) {
+const unsafe extern "C" fn libdecor_frame_handle_commit(
+    _frame: *mut libdecor_frame,
+    _data: *mut c_void,
+) {
 }
 unsafe extern "C" fn libdecor_handle_error(
     _context: *mut libdecor,

--- a/src/native/linux_wayland/extensions/cursor.rs
+++ b/src/native/linux_wayland/extensions/cursor.rs
@@ -108,7 +108,7 @@ crate::wl_listener!(
     ),
 );
 
-pub fn translate_cursor(icon: crate::CursorIcon) -> core::ffi::c_uint {
+pub const fn translate_cursor(icon: crate::CursorIcon) -> core::ffi::c_uint {
     // https://wayland.app/protocols/cursor-shape-v1#wp_cursor_shape_device_v1:enum:shape
     match icon {
         crate::CursorIcon::Default => 1,

--- a/src/native/linux_wayland/keycodes.rs
+++ b/src/native/linux_wayland/keycodes.rs
@@ -16,7 +16,7 @@
 use crate::event::KeyCode;
 use crate::native::linux_wayland::libxkbcommon::xkb_keysym_t;
 
-pub fn translate_keysym(keysym: xkb_keysym_t) -> KeyCode {
+pub const fn translate_keysym(keysym: xkb_keysym_t) -> KeyCode {
     // See xkbcommon/xkbcommon-keysyms.h
     match keysym {
         65307 => KeyCode::Escape,

--- a/src/native/linux_wayland/libwayland_client.rs
+++ b/src/native/linux_wayland/libwayland_client.rs
@@ -372,7 +372,7 @@ macro_rules! wl_listener {
         /// Implementation for the dummy event handlers
         mod $name_dummy {
             use super::*;
-            $(pub unsafe extern "C" fn $event(_: *mut core::ffi::c_void, _: *mut $name, $(_: $arg_ty),*) {})*
+            $(pub const unsafe extern "C" fn $event(_: *mut core::ffi::c_void, _: *mut $name, $(_: $arg_ty),*) {})*
         }
         impl $name_listener {
             /// Create a listener with dummy event handlers

--- a/src/native/linux_x11/clipboard.rs
+++ b/src/native/linux_x11/clipboard.rs
@@ -218,7 +218,7 @@ unsafe impl Send for X11Clipboard {}
 unsafe impl Sync for X11Clipboard {}
 
 impl X11Clipboard {
-    pub fn new(libx11: LibX11, display: *mut Display, window: Window) -> X11Clipboard {
+    pub const fn new(libx11: LibX11, display: *mut Display, window: Window) -> X11Clipboard {
         X11Clipboard {
             libx11,
             display,

--- a/src/native/linux_x11/keycodes.rs
+++ b/src/native/linux_x11/keycodes.rs
@@ -156,7 +156,7 @@ pub unsafe fn translate_mod(x11_mods: i32) -> KeyMods {
     mods
 }
 
-pub unsafe fn translate_mouse_button(button: i32) -> MouseButton {
+pub const unsafe fn translate_mouse_button(button: i32) -> MouseButton {
     match button {
         1 => MouseButton::Left,
         2 => MouseButton::Middle,


### PR DESCRIPTION
It'd be useful for us if `PassAction::clear_color` were `const`.

This PR marks everything as `const` that can be, by iterating
```sh
cargo clippy --fix -- -A clippy::all -A rust_2024_compatibility -A unused -W clippy::missing_const_for_fn
```
until a fixed point is reached.

That might be too aggressive, since making something `const` is an API commitment. For instance, making `Icon::miniquad_logo` `const` might make addressing #570 a breaking change. A subset of these changes are probably sane, though, and I decided it's more useful as a PR than an issue.