### PR TITLE
android: add platform config to set an FPS setting when `blocking_event_loop` is enabled

### DIFF
--- a/src/conf.rs
+++ b/src/conf.rs
@@ -152,6 +152,14 @@ pub struct Platform {
     /// [`schedule_update`]: super::window::schedule_update
     pub blocking_event_loop: bool,
 
+    /// When `blocking_event_loop` is enabled, we can set this value to periodically
+    /// wakeup the `update()` and `draw()` functions. This reduces CPU usage vs
+    /// continuously drawing without having to continuously schedule updates that can
+    /// choke the receiver queue.
+    ///
+    /// Currently supported only on Android.
+    pub sleep_interval_ms: Option<u32>,
+
     /// If `true`, the framebuffer includes an alpha channel.
     /// Currently supported only on Android.
     ///
@@ -183,6 +191,7 @@ impl Default for Platform {
             apple_gfx_api: AppleGfxApi::default(),
             webgl_version: WebGLVersion::default(),
             blocking_event_loop: false,
+            sleep_interval_ms: None,
             swap_interval: None,
             framebuffer_alpha: false,
             wayland_decorations: WaylandDecorations::default(),


### PR DESCRIPTION
Currently in my app I have a task scheduling updates continuously but this introduces latency and uneeded cpu usage. Instead we can make the receiver optionally call .recv_timeout() inside the main event loop. In fact all native platforms in miniquad should use an FPS by default instead of continuous drawing.

```rust
            // For animations do periodic refresh every 40 ms
            self.refresh_task = Some(self.ex.spawn(async move {
                loop {
                    system::msleep(40).await;
                    miniquad::window::schedule_update();
                }
            }));
```

(on android you dont want to continuous draw() or else it will drain battery. In fact you dont want to do this on most platforms)