### PR TITLE
android: add MainActivity.java hooks for ResizingLayout

### DIFF
--- a/java/MainActivity.java
+++ b/java/MainActivity.java
@@ -199,21 +199,38 @@ class ResizingLayout
         LinearLayout
     implements
         View.OnApplyWindowInsetsListener {
+    //% RESIZING_LAYOUT_BODY
 
-    public ResizingLayout(Context context){
-        super(context);
+    public ResizingLayout(MainActivity activity){
+        super(activity);
         // When viewing in landscape mode with keyboard shown, there are
         // gaps on both sides so we fill the negative space with black.
         setBackgroundColor(Color.BLACK);
         setOnApplyWindowInsetsListener(this);
+
+        //% RESIZING_LAYOUT_CONSTRUCTOR
     }
 
     @Override
     public WindowInsets onApplyWindowInsets(View v, WindowInsets insets) {
+        // This handler provides a default impl which resizes content when the
+        // IME is shown or hidden.
+        //
+        // However this will lead to flickers in your app as the content is
+        // resized before you have a chance to redraw it.
+        //
+        // The workaround for now is:
+        // * Get IME and system insets and send them to your app.
+        // * Notify your app to draw and apply the insets to fit.
+        // * Disable this function by returning early.
+
+        //% RESIZING_LAYOUT_ON_APPLY_WINDOW_INSETS
+
         if (Build.VERSION.SDK_INT >= 30) {
             Insets imeInsets = insets.getInsets(WindowInsets.Type.ime());
             Insets sysInsets = insets.getInsets(WindowInsets.Type.systemBars());
 
+            // When IME is visible then we dont need bottom inset
             int bottomPadding = sysInsets.bottom;
             if (imeInsets.bottom > 0) {
                 bottomPadding = imeInsets.bottom;


### PR DESCRIPTION
See this provided comment:
```java
// This handler provides a default impl which resizes content when the
// IME is shown or hidden.
//
// However this will lead to flickers in your app as the content is
// resized before you have a chance to redraw it.
//
// The workaround for now is:
// * Get IME and system insets and send them to your app.
// * Notify your app to draw and apply the insets to fit.
// * Disable this function by returning early.
```

Basically before miniquad used to use the whole canvas and not resize when IME (keyboard in android speak) was shown/hidden. So then I added the `ResizingLayout` to make it automatically resize the canvas.

However this causes a noticeable flicker since the program flow goes like this:

ResizingLayout apply insets -> resize canvas -> surface changed -> native android -> resize event

during which time the screen is being drawn by android and whatever is there gets resized before the user has a chance to hit update()/draw() and redo the entire canvas.

The solution then in my case was to disable the screen resize and listen myself for the insets but this would then introduce complexity into miniquad. I've introduced these hooks for now as the lowest impact solution but I'm also open to alternative solutions if we think having this directly in miniquad is useful.

Here is my application code using these hooks:

java/MainActivity.java:
```java
//% RESIZING_LAYOUT_ON_APPLY_WINDOW_INSETS

{
    Insets imeInsets = insets.getInsets(WindowInsets.Type.ime());
    Insets sysInsets = insets.getInsets(WindowInsets.Type.systemBars());

    // Screen: (1440, 3064)
    // IME height: 1056
    // Sys insets: (0, 152, 0, 135)

    onApplyInsets(
        sysInsets.left, sysInsets.top, sysInsets.right, sysInsets.bottom,
        imeInsets.left, imeInsets.top, imeInsets.right, imeInsets.bottom
    );
}
// Workaround for Java error due to remaining body.
// We handle the insets in our app directly.
if (true)
    return insets;

//% END
```

android ndk handler code:
```rust
use miniquad::native::android::{self, ndk_sys, ndk_utils};
use parking_lot::Mutex as SyncMutex;
use std::sync::LazyLock;

type Insets = [f32; 4];
type InsetsSender = async_channel::Sender<Insets>;

struct InsetsGlobals {
    sender: Option<InsetsSender>,
    insets: Insets,
}

static GLOBALS: LazyLock<SyncMutex<InsetsGlobals>> =
    LazyLock::new(|| SyncMutex::new(InsetsGlobals { sender: None, insets: [0.; 4] }));

pub fn set_sender(sender: InsetsSender) {
    GLOBALS.lock().sender = Some(sender);
}

pub fn get_insets() -> Insets {
    GLOBALS.lock().insets.clone()
}

#[no_mangle]
pub unsafe extern "C" fn Java_darkfi_darkfi_1app_ResizingLayout_onApplyInsets(
    _env: *mut ndk_sys::JNIEnv,
    _: ndk_sys::jobject,
    sys_left: ndk_sys::jint,
    sys_top: ndk_sys::jint,
    sys_right: ndk_sys::jint,
    sys_bottom: ndk_sys::jint,
    ime_left: ndk_sys::jint,
    ime_top: ndk_sys::jint,
    ime_right: ndk_sys::jint,
    ime_bottom: ndk_sys::jint,
) {
    debug!(
        target: "android::insets",
        "onApplyInsets() \
            sys=({sys_left}, {sys_top}, {sys_right}, {sys_bottom}) \
            ime=({ime_left}, {ime_top}, {ime_right}, {ime_bottom}) \
        )"
    );
    let mut globals = GLOBALS.lock();
    globals.insets = [sys_left as f32, sys_top as f32, sys_right as f32, sys_bottom as f32];
    if ime_bottom > 0 {
        globals.insets[3] = ime_bottom as f32;
    }
    if let Some(sender) = &globals.sender {
        let _ = sender.try_send(globals.insets.clone());
    } else {
        warn!(target: "android::insets", "Dropping insets notify since no sender is set");
    }
}
```

This way the canvas remains unchanged. It is my user code that does the resizing. Another benefit is I can draw below the navigation and system bars too.

Also check https://github.com/not-fl3/cargo-quad-apk/pull/13