### PR TITLE
Data returned from Xlib/XGetEventData is not guaranteed to be aligned

### DIFF
--- a/src/native/linux_x11/xi_input.rs
+++ b/src/native/linux_x11/xi_input.rs
@@ -123,8 +123,10 @@ impl LibXi {
 
         let raw_event = xcookie.data as *mut xi_input::XIRawEvent;
 
-        let dx = *(*raw_event).raw_values;
-        let dy = *(*raw_event).raw_values.offset(1);
+        // Data returned from Xlib is not guaranteed to be aligned
+        let ptr = (*raw_event).raw_values as *const u8;
+        let dx = std::ptr::read_unaligned(ptr as *const f64);
+        let dy = std::ptr::read_unaligned(ptr.add(1) as *const f64);
 
         (self.XFreeEventData)(display, &mut (*xcookie) as *mut _);
 


### PR DESCRIPTION
Fixes #394 
Data returned from Xlib is not guaranteed to be aligned. This could cause a "misaligned pointer deference" panic when getting the mouse deltas. The mouse deltas are two doubles, but the buffer in which they are stored might not be 8 byte aligned. This apparently could happen quite easily on a Linux 32 bit system.

Tested it on a 32bit Raspberry PI. Also tested this on a Ubuntu 64bit, just to see It didn't break anything there.