### PR TITLE
Improved Metal support

### DIFF
--- a/src/graphics/metal.rs
+++ b/src/graphics/metal.rs
@@ -408,7 +408,18 @@ impl RenderingBackend for MetalContext {
             msg_send_![texture.texture, release];
         }
     }
-    fn apply_viewport(&mut self, _x: i32, _y: i32, _w: i32, _h: i32) {}
+    fn apply_viewport(&mut self, x: i32, y: i32, w: i32, h: i32) {
+        assert!(self.render_encoder.is_some());
+        let viewport = MTLViewport {
+            origin_x: x as f64,
+            origin_y: y as f64,
+            width: w as f64,
+            height: h as f64,
+            znear: 0.0,
+            zfar: 1.0,
+        };
+        unsafe { msg_send_![self.render_encoder.unwrap(), setViewport: viewport] };
+    }
     fn apply_scissor_rect(&mut self, x: i32, y: i32, w: i32, h: i32) {
         assert!(self.render_encoder.is_some());
 
@@ -1252,16 +1263,15 @@ impl RenderingBackend for MetalContext {
         let pip = &self.pipelines[self.current_pipeline.unwrap().0];
         let primitive_type: MTLPrimitiveType = pip.params.primitive_type.into();
 
-        assert!(base_element == 0); // TODO: figure indexBufferOffset/baseVertex
+        let index_type = MTLIndexType::UInt16;
+
         unsafe {
             msg_send_![render_encoder,drawIndexedPrimitives:primitive_type
                        indexCount:num_elements as u64
-                       indexType:MTLIndexType::UInt16
+                       indexType:index_type
                        indexBuffer:index_buffer
-                       indexBufferOffset:0
+                       indexBufferOffset: base_element as u64 * index_type.size() as u64
                        instanceCount:num_instances as u64
-                       baseVertex:0
-                       baseInstance:0
             ];
         }
     }

--- a/src/graphics/metal.rs
+++ b/src/graphics/metal.rs
@@ -232,7 +232,7 @@ struct PipelineInternal {
     //layout: Vec<BufferLayout>,
     //attributes: Vec<VertexAttributeInternal>,
     _shader: ShaderId,
-    //params: PipelineParams,
+    params: PipelineParams,
 }
 
 #[derive(Clone, Copy)]
@@ -1037,7 +1037,7 @@ impl RenderingBackend for MetalContext {
                 //layout: buffer_layout.to_vec(),
                 //attributes: vertex_layout,
                 _shader: shader,
-                //params,
+                params,
             };
 
             self.pipelines.push(pipeline);
@@ -1248,9 +1248,13 @@ impl RenderingBackend for MetalContext {
         assert!(self.index_buffer.is_some());
         let index_buffer = self.index_buffer.unwrap();
 
+        assert!(self.current_pipeline.is_some(), "draw without pipeline");
+        let pip = &self.pipelines[self.current_pipeline.unwrap().0];
+        let primitive_type: MTLPrimitiveType = pip.params.primitive_type.into();
+
         assert!(base_element == 0); // TODO: figure indexBufferOffset/baseVertex
         unsafe {
-            msg_send_![render_encoder, drawIndexedPrimitives:MTLPrimitiveType::Triangle
+            msg_send_![render_encoder,drawIndexedPrimitives:primitive_type
                        indexCount:num_elements as u64
                        indexType:MTLIndexType::UInt16
                        indexBuffer:index_buffer

--- a/src/native/apple/frameworks.rs
+++ b/src/native/apple/frameworks.rs
@@ -545,6 +545,17 @@ pub enum MTLStoreAction {
 }
 
 #[repr(C)]
+#[derive(Debug, Clone, Copy)]
+pub struct MTLViewport {
+    pub origin_x: f64,
+    pub origin_y: f64,
+    pub width: f64,
+    pub height: f64,
+    pub znear: f64,
+    pub zfar: f64,
+}
+
+#[repr(C)]
 #[derive(Clone, Debug)]
 pub struct MTLClearColor {
     pub red: f64,
@@ -723,6 +734,14 @@ pub enum MTLPrimitiveType {
 pub enum MTLIndexType {
     UInt16 = 0,
     UInt32 = 1,
+}
+impl MTLIndexType {
+    pub fn size(&self) -> usize {
+        match self {
+            MTLIndexType::UInt16 => size_of::<u16>(),
+            MTLIndexType::UInt32 => size_of::<u32>(),
+        }
+    }
 }
 
 #[repr(u64)]


### PR DESCRIPTION
This is a fix for issue #418 
- When using Metal, primitive type was hardcoded to Triangles. Now the primitive type is taken from the pipeline parameters.
- Setting the view port was not supported in Metal. Implemented apply_viewport.
