### PR TITLE
native/linux_x11: Fix dy value in raw_mouse_motion

### DIFF
--- a/src/native/linux_x11/xi_input.rs
+++ b/src/native/linux_x11/xi_input.rs
@@ -124,9 +124,9 @@ impl LibXi {
         let raw_event = xcookie.data as *mut xi_input::XIRawEvent;
 
         // Data returned from Xlib is not guaranteed to be aligned
-        let ptr = (*raw_event).raw_values as *const u8;
-        let dx = std::ptr::read_unaligned(ptr as *const f64);
-        let dy = std::ptr::read_unaligned(ptr.add(1) as *const f64);
+        let ptr = (*raw_event).raw_values as *const f64;
+        let dx = std::ptr::read_unaligned(ptr);
+        let dy = std::ptr::read_unaligned(ptr.add(1));
 
         (self.XFreeEventData)(display, &mut (*xcookie) as *mut _);
 


### PR DESCRIPTION
On X11, event raw_mouse_motion returned incorrect dy value. This was introduced by #610. After reading the mouse x delta data pointer was only advanced by 1 byte instead of 8 bytes.