### PR TITLE
native/macos: Add frame pacing for smooth motion

### DIFF
--- a/src/native/apple/frameworks.rs
+++ b/src/native/apple/frameworks.rs
@@ -238,6 +238,65 @@ extern "C" {
     pub fn MTLCopyAllDevices() -> ObjcId; //TODO: Array
 }
 
+#[cfg(target_os = "macos")]
+#[repr(C)]
+#[derive(Clone, Copy, Debug)]
+pub struct CVTime {
+    pub time_value: i64,
+    pub time_scale: i32,
+    pub flags: i32,
+    pub epoch: i64,
+}
+
+#[cfg(target_os = "macos")]
+pub type CVDisplayLinkRef = *mut c_void;
+
+#[cfg(target_os = "macos")]
+pub type CVOptionFlags = u64;
+
+#[cfg(target_os = "macos")]
+#[repr(C)]
+#[derive(Clone, Copy, Debug)]
+pub struct CVTimeStamp {
+    pub version: u32,
+    pub video_time_scale: i32,
+    pub video_time: i64,
+    pub host_time: u64,
+    pub rate_scalar: f64,
+    pub video_refresh_period: i64,
+    pub smpte_time: i64,
+    pub flags: u64,
+    pub reserved: u64,
+}
+
+#[cfg(target_os = "macos")]
+pub type CVDisplayLinkOutputCallback = extern "C" fn(
+    display_link: CVDisplayLinkRef,
+    now: *const CVTimeStamp,
+    output_time: *const CVTimeStamp,
+    flags_in: CVOptionFlags,
+    flags_out: *mut CVOptionFlags,
+    display_link_context: *mut c_void,
+) -> i32;
+
+#[cfg(target_os = "macos")]
+pub const kCVTimeIsIndefinite: i32 = 1 << 0;
+
+#[cfg(target_os = "macos")]
+#[link(name = "CoreVideo", kind = "framework")]
+extern "C" {
+    pub fn CVDisplayLinkCreateWithActiveCGDisplays(display_link_out: *mut CVDisplayLinkRef) -> i32;
+    pub fn CVDisplayLinkSetOutputCallback(
+        display_link: CVDisplayLinkRef,
+        callback: CVDisplayLinkOutputCallback,
+        user_info: *mut c_void,
+    ) -> i32;
+    pub fn CVDisplayLinkStart(display_link: CVDisplayLinkRef) -> i32;
+    pub fn CVDisplayLinkStop(display_link: CVDisplayLinkRef) -> i32;
+    pub fn CVDisplayLinkRelease(display_link: CVDisplayLinkRef);
+    pub fn CVDisplayLinkGetNominalOutputVideoRefreshPeriod(display_link: CVDisplayLinkRef) -> CVTime;
+}
+
 // Foundation
 
 #[repr(C)]

--- a/src/native/macos.rs
+++ b/src/native/macos.rs
@@ -1087,19 +1087,13 @@ impl FramePacer {
     }
 
     fn wait_next_frame(&self, timeout: Duration) {
-        let mut frame_ready = match self.frame_signal.frame_ready.lock() {
-            Ok(guard) => guard,
-            Err(poisoned) => poisoned.into_inner(),
-        };
+        let mut frame_ready = self.frame_signal.frame_ready.lock().unwrap();
         if *frame_ready {
             *frame_ready = false;
             return;
         }
 
-        let (mut frame_ready, _) = match self.frame_signal.cond.wait_timeout(frame_ready, timeout) {
-            Ok(pair) => pair,
-            Err(poisoned) => poisoned.into_inner(),
-        };
+        let (mut frame_ready, _) = self.frame_signal.cond.wait_timeout(frame_ready, timeout).unwrap();
 
         if *frame_ready {
             *frame_ready = false;

--- a/src/native/macos.rs
+++ b/src/native/macos.rs
@@ -1086,14 +1086,14 @@ impl FramePacer {
         }
     }
 
-    fn wait_next_frame(&self, timeout: Duration) -> bool {
+    fn wait_next_frame(&self, timeout: Duration) {
         let mut frame_ready = match self.frame_signal.frame_ready.lock() {
             Ok(guard) => guard,
             Err(poisoned) => poisoned.into_inner(),
         };
         if *frame_ready {
             *frame_ready = false;
-            return true;
+            return;
         }
 
         let (mut frame_ready, _) = match self.frame_signal.cond.wait_timeout(frame_ready, timeout) {
@@ -1101,11 +1101,9 @@ impl FramePacer {
             Err(poisoned) => poisoned.into_inner(),
         };
 
-        let ready = *frame_ready;
-        if ready {
+        if *frame_ready {
             *frame_ready = false;
         }
-        ready
     }
 }
 
@@ -1419,9 +1417,7 @@ where
 
         // Wait at the top for just in time rendering
         if let Some(frame_pacer) = frame_pacer.as_ref() {
-            if !frame_pacer.wait_next_frame(Duration::from_millis(50)) {
-                std::thread::yield_now();
-            }
+            frame_pacer.wait_next_frame(Duration::from_millis(50));
         }
 
         while let Ok(request) = display.native_requests.try_recv() {

--- a/src/native/macos.rs
+++ b/src/native/macos.rs
@@ -15,7 +15,10 @@ use {
     std::{
         collections::HashMap,
         os::raw::c_void,
-        sync::mpsc::Receiver,
+        sync::{
+            Condvar, Mutex,
+            mpsc::Receiver,
+        },
         time::{Duration, Instant},
     },
 };
@@ -1016,6 +1019,94 @@ impl crate::native::Clipboard for MacosClipboard {
     fn set(&mut self, _data: &str) {}
 }
 
+struct FrameSignal {
+    frame_ready: Mutex<bool>,
+    cond: Condvar,
+}
+
+extern "C" fn display_link_frame_ready_callback(
+    _display_link: CVDisplayLinkRef,
+    _now: *const CVTimeStamp,
+    _output_time: *const CVTimeStamp,
+    _flags_in: CVOptionFlags,
+    _flags_out: *mut CVOptionFlags,
+    display_link_context: *mut c_void,
+) -> i32 {
+    unsafe {
+        let frame_signal = &*(display_link_context as *const FrameSignal);
+        if let Ok(mut frame_ready) = frame_signal.frame_ready.lock() {
+            *frame_ready = true;
+            frame_signal.cond.notify_one();
+        }
+    }
+    0
+}
+
+struct FramePacer {
+    display_link: CVDisplayLinkRef,
+    frame_signal: Box<FrameSignal>,
+}
+
+impl FramePacer {
+    fn new() -> Option<Self> {
+        unsafe {
+            let mut display_link: CVDisplayLinkRef = std::ptr::null_mut();
+            if CVDisplayLinkCreateWithActiveCGDisplays(&mut display_link as *mut _) != 0
+                || display_link.is_null()
+            {
+                return None;
+            }
+
+            let frame_signal = Box::new(FrameSignal {
+                frame_ready: Mutex::new(false),
+                cond: Condvar::new(),
+            });
+
+            if CVDisplayLinkSetOutputCallback(
+                display_link,
+                display_link_frame_ready_callback,
+                (&*frame_signal as *const FrameSignal) as *mut c_void,
+            ) != 0
+            {
+                CVDisplayLinkRelease(display_link);
+                return None;
+            }
+
+            let _ = CVDisplayLinkStart(display_link);
+
+            Some(Self {
+                display_link,
+                frame_signal,
+            })
+        }
+    }
+
+    fn wait_next_frame(&self) {
+        let mut frame_ready = match self.frame_signal.frame_ready.lock() {
+            Ok(guard) => guard,
+            Err(poisoned) => poisoned.into_inner(),
+        };
+        while !*frame_ready {
+            frame_ready = match self.frame_signal.cond.wait(frame_ready) {
+                Ok(guard) => guard,
+                Err(poisoned) => poisoned.into_inner(),
+            };
+        }
+        *frame_ready = false;
+    }
+}
+
+impl Drop for FramePacer {
+    fn drop(&mut self) {
+        unsafe {
+            if !self.display_link.is_null() {
+                let _ = CVDisplayLinkStop(self.display_link);
+                CVDisplayLinkRelease(self.display_link);
+            }
+        }
+    }
+}
+
 unsafe extern "C" fn release_data(info: *mut c_void, _: *const c_void, _: usize) {
     drop(Box::from_raw(info as *mut &[u8]));
 }
@@ -1305,6 +1396,11 @@ where
     // Basically reimplementing msg_send![ns_app, run] here
     let distant_future: ObjcId = msg_send![class!(NSDate), distantFuture];
     let distant_past: ObjcId = msg_send![class!(NSDate), distantPast];
+    let frame_pacer = if conf.platform.blocking_event_loop {
+        None
+    } else {
+        FramePacer::new()
+    };
     let mut done = false;
     while !(done || crate::native_display().lock().unwrap().quit_ordered) {
         while let Ok(request) = display.native_requests.try_recv() {
@@ -1335,6 +1431,10 @@ where
 
         if !conf.platform.blocking_event_loop || display.update_requested {
             perform_redraw(&mut display, conf.platform.apple_gfx_api, false);
+        }
+
+        if let Some(frame_pacer) = frame_pacer.as_ref() {
+            frame_pacer.wait_next_frame();
         }
     }
 }

--- a/src/native/macos.rs
+++ b/src/native/macos.rs
@@ -997,7 +997,9 @@ unsafe fn create_opengl_view(
 
     display.gl_context = msg_send![gl_context, initWithFormat: glpixelformat_obj shareContext: nil];
 
-    let mut swap_interval = 1;
+    // Set the swap interval to 0 to disable vsync, because we're using CVDisplayLink for frame pacing
+    // and we don't want to have an extra vsync delay on top of that.
+    let mut swap_interval = 0;
     let () = msg_send![display.gl_context,
                 setValues:&mut swap_interval
                 forParameter:NSOpenGLContextParameterSwapInterval];
@@ -1072,7 +1074,10 @@ impl FramePacer {
                 return None;
             }
 
-            let _ = CVDisplayLinkStart(display_link);
+            if CVDisplayLinkStart(display_link) != 0 {
+                CVDisplayLinkRelease(display_link);
+                return None;
+            }
 
             Some(Self {
                 display_link,
@@ -1081,18 +1086,26 @@ impl FramePacer {
         }
     }
 
-    fn wait_next_frame(&self) {
+    fn wait_next_frame(&self, timeout: Duration) -> bool {
         let mut frame_ready = match self.frame_signal.frame_ready.lock() {
             Ok(guard) => guard,
             Err(poisoned) => poisoned.into_inner(),
         };
-        while !*frame_ready {
-            frame_ready = match self.frame_signal.cond.wait(frame_ready) {
-                Ok(guard) => guard,
-                Err(poisoned) => poisoned.into_inner(),
-            };
+        if *frame_ready {
+            *frame_ready = false;
+            return true;
         }
-        *frame_ready = false;
+
+        let (mut frame_ready, _) = match self.frame_signal.cond.wait_timeout(frame_ready, timeout) {
+            Ok(pair) => pair,
+            Err(poisoned) => poisoned.into_inner(),
+        };
+
+        let ready = *frame_ready;
+        if ready {
+            *frame_ready = false;
+        }
+        ready
     }
 }
 
@@ -1403,6 +1416,14 @@ where
     };
     let mut done = false;
     while !(done || crate::native_display().lock().unwrap().quit_ordered) {
+
+        // Wait at the top for just in time rendering
+        if let Some(frame_pacer) = frame_pacer.as_ref() {
+            if !frame_pacer.wait_next_frame(Duration::from_millis(50)) {
+                std::thread::yield_now();
+            }
+        }
+
         while let Ok(request) = display.native_requests.try_recv() {
             display.process_request(request);
         }
@@ -1433,8 +1454,5 @@ where
             perform_redraw(&mut display, conf.platform.apple_gfx_api, false);
         }
 
-        if let Some(frame_pacer) = frame_pacer.as_ref() {
-            frame_pacer.wait_next_frame();
-        }
     }
 }


### PR DESCRIPTION
Fixes #559 

On macOS, if you are using OpenGL,  motion stutters. Motion is not smooth/fluent. You can see it immediately when you run
```
cargo run --example quad
```
The problem is that there isn't any real frame pacing in the current main loop. The main loop pushes out a new frame each iteration with flushBuffer and relies on VSYNC (swap_interval = 1) for pacing. But that's not enough on macOS. flushBuffer gives us the new frame, but it's up to the display server (Quartz Compositor) to decide when to use it.

This change adds a frame pacer using macOS's CVDisplayLink callback.  Basically what this change does is this:
- Adds a flag frame_ready that tells us when to start rendering the next frame.
- CVDisplayLink callback sets the flag to true
- The main loop wait for frame_ready to become true and continues with the next iteration.

There might be other ways to do it. But I wanted to keep the main loop intact as much as possible.

With this frame pacer motion is now super smooth :smile:

Before version v0.4.6 it was still reasonably smooth. That's because rendering was done differently. In v.0.4.5 each iteration of the main loop called setNeedsDisaply:YES on the view to trigger a redraw. This marks the view as 'dirty' signaling the display server to update it. The redraw performed a flushBuffer with VSYNC.