### PR TITLE
native/linux_wayland: Respect window_resizable

### DIFF
--- a/src/native/linux_wayland.rs
+++ b/src/native/linux_wayland.rs
@@ -1177,8 +1177,7 @@ where
             (libegl.eglGetProcAddress)(name.as_ptr() as _)
         });
 
-        display.decorations =
-            decorations::Decorations::new(&mut display, conf.platform.wayland_decorations);
+        display.decorations = decorations::Decorations::new(&mut display, conf);
         assert!(!display.xdg_toplevel.is_null());
 
         display.decorations.set_title(

--- a/src/native/linux_wayland/decorations.rs
+++ b/src/native/linux_wayland/decorations.rs
@@ -60,18 +60,17 @@ unsafe fn create_xdg_toplevel(display: &mut WaylandPayload) {
 }
 
 impl Decorations {
-    pub(super) fn new(
-        display: &mut WaylandPayload,
-        fallback: crate::conf::WaylandDecorations,
-    ) -> Self {
+    pub(super) fn new(display: &mut WaylandPayload, conf: &crate::conf::Conf) -> Self {
         use crate::conf::WaylandDecorations::*;
         unsafe {
             if !display.decoration_manager.is_null() {
                 Decorations::server(display)
             } else {
-                match fallback {
+                match conf.platform.wayland_decorations {
                     ServerOnly => Decorations::none(display),
-                    ServerWithLibDecorFallback => Decorations::try_libdecor(display),
+                    ServerWithLibDecorFallback => {
+                        Decorations::try_libdecor(display, conf.window_resizable)
+                    }
                     ServerWithMiniquadFallback => Decorations::fallback(display),
                 }
             }
@@ -140,7 +139,7 @@ impl Decorations {
         Decorations::Server
     }
 
-    unsafe fn try_libdecor(display: &mut WaylandPayload) -> Self {
+    unsafe fn try_libdecor(display: &mut WaylandPayload, resizable: bool) -> Self {
         if let Ok(libdecor) = LibDecor::try_load() {
             let context = (libdecor.libdecor_new)(display.display, &mut LIBDECOR_INTERFACE as _);
             let frame = (libdecor.libdecor_decorate)(
@@ -151,6 +150,12 @@ impl Decorations {
             );
             (libdecor.libdecor_frame_map)(frame);
             display.xdg_toplevel = (libdecor.libdecor_frame_get_xdg_toplevel)(frame);
+            use extensions::libdecor::LIBDECOR_ACTION_RESIZE as RESIZE;
+            if resizable {
+                (libdecor.libdecor_frame_set_capabilities)(frame, RESIZE);
+            } else {
+                (libdecor.libdecor_frame_unset_capabilities)(frame, RESIZE);
+            }
             Decorations::LibDecor {
                 libdecor,
                 context,

--- a/src/native/linux_wayland/extensions/libdecor.rs
+++ b/src/native/linux_wayland/extensions/libdecor.rs
@@ -51,6 +51,8 @@ pub struct libdecor_frame_interface {
 
 use core::ffi::{c_char, c_int, c_void};
 
+pub const LIBDECOR_ACTION_RESIZE: c_int = 1 << 1;
+
 declare_module! {
     LibDecor,
     "libdecor-0.so",
@@ -66,6 +68,8 @@ declare_module! {
     ) -> *mut libdecor_frame,
     pub fn libdecor_frame_set_app_id(*mut libdecor_frame, *const c_char),
     pub fn libdecor_frame_set_title(*mut libdecor_frame, *const c_char),
+    pub fn libdecor_frame_set_capabilities(*mut libdecor_frame, c_int),
+    pub fn libdecor_frame_unset_capabilities(*mut libdecor_frame, c_int),
     pub fn libdecor_frame_map(*mut libdecor_frame),
     pub fn libdecor_state_new(c_int, c_int) -> *mut libdecor_state,
     pub fn libdecor_frame_commit(


### PR DESCRIPTION
Sorry didn't test under gnome last time; we are using libdecor for the window decoration, and to disable window resizing we have to go through libdecor as well.