### PR TITLE
Fix file drop not working on Linux X11

### DIFF
--- a/src/native/linux_x11.rs
+++ b/src/native/linux_x11.rs
@@ -213,7 +213,11 @@ impl X11Display {
                     if let Ok(filenames) = std::str::from_utf8(&bytes) {
                         let mut d = crate::native_display().try_lock().unwrap();
                         d.dropped_files = Default::default();
-                        for filename in filenames.lines() {
+                        for mut filename in filenames.lines() {
+                            // On Linux X11, dropped file paths may contain `file://` prefix
+                            if let Some(stripped) = filename.strip_prefix("file://") {
+                                filename = stripped;
+                            }
                             let path = std::path::PathBuf::from(filename);
                             if let Ok(bytes) = std::fs::read(&path) {
                                 d.dropped_files.paths.push(path);

--- a/src/native/linux_x11/drag_n_drop.rs
+++ b/src/native/linux_x11/drag_n_drop.rs
@@ -67,7 +67,8 @@ impl X11DnD {
         };
 
         for format in formats {
-            if format == libx11.extensions.utf8_string {
+            // On X11, file managers may yield `text/uri-list` for dragged files
+            if format == libx11.extensions.utf8_string || format == libx11.extensions.mime_text_uri_lst {
                 self.format = format;
                 break;
             }

--- a/src/native/linux_x11/libx11.rs
+++ b/src/native/linux_x11/libx11.rs
@@ -869,6 +869,7 @@ declare_atoms!(
     xdnd_selection: "XdndSelection",
     xdnd_status: "XdndStatus",
     xdnd_type_list: "XdndTypeList",
+    mime_text_uri_lst: "text/uri-list",
 );
 
 use core::ffi::{c_char, c_int, c_long, c_uchar, c_uint, c_ulong, c_ushort, c_void};


### PR DESCRIPTION
- Make `text/uri-list` an accepted format.
  pcmanfm-qt for example provides this format.

- Strip `file://` prefix from filenames before trying to load them
  Some file managers, like pcmanfm-qt seems to prefix the filenames with it.

Fixes https://github.com/not-fl3/macroquad/issues/1048