### PR TITLE
ios: support iOS 27 UIScene lifecycle (TN3187)

### DIFF
--- a/src/native/ios.rs
+++ b/src/native/ios.rs
@@ -24,6 +24,16 @@ use {
     },
 };
 
+// iOS 27 / TN3187: windows must be created via `initWithWindowScene:`
+// or they stay invisible. Window creation defers to the
+// `UISceneWillConnectNotification` observer below; both that and
+// `did_finish_launching_with_options` run on the main thread, so
+// `thread_local` storage is sound.
+thread_local! {
+    static PENDING_SCENE_VIEW: RefCell<Option<ObjcId>> = RefCell::new(None);
+    static PENDING_SCENE_VIEW_CTRL: RefCell<Option<ObjcId>> = RefCell::new(None);
+}
+
 struct MainThreadState {
     quit: bool,
     paused: bool,
@@ -493,7 +503,7 @@ pub fn define_app_delegate() -> *const Class {
     let mut decl = ClassDecl::new("NSAppDelegate", superclass).unwrap();
 
     extern "C" fn did_finish_launching_with_options(
-        _: &Object,
+        delegate_self: &Object,
         _: Sel,
         _: ObjcId,
         _: ObjcId,
@@ -518,9 +528,8 @@ pub fn define_app_delegate() -> *const Class {
                 )
             };
 
-            let window_obj: ObjcId = msg_send![class!(UIWindow), alloc];
-            let window_obj: ObjcId = msg_send![window_obj, initWithFrame: screen_rect];
-
+            // Window creation defers to `scene_will_connect`; view +
+            // view_ctrl built now so the render thread has them ready.
             let view = match conf.platform.apple_gfx_api {
                 AppleGfxApi::OpenGl => {
                     create_opengl_view(screen_rect, conf.sample_count, conf.high_dpi)
@@ -603,11 +612,34 @@ pub fn define_app_delegate() -> *const Class {
             (*view.view_dlg).set_ivar("display_ptr", payload_ptr);
             (*textfield_dlg).set_ivar("display_ptr", payload_ptr);
 
-            msg_send_![window_obj, addSubview: view.view];
+            // Stash view + view_ctrl for `scene_will_connect` to adopt
+            // into a freshly-created `initWithWindowScene:` window.
+            PENDING_SCENE_VIEW.with(|v| *v.borrow_mut() = Some(view.view));
+            PENDING_SCENE_VIEW_CTRL.with(|v| *v.borrow_mut() = Some(view.view_ctrl));
 
-            msg_send_![window_obj, setRootViewController: view.view_ctrl];
+            let notification_center: ObjcId =
+                msg_send![class!(NSNotificationCenter), defaultCenter];
+            let scene_will_connect_name =
+                apple_util::str_to_nsstring("UISceneWillConnectNotification");
+            let _: () = msg_send![notification_center,
+                addObserver: delegate_self
+                selector: sel!(sceneWillConnect:)
+                name: scene_will_connect_name
+                object: nil];
 
-            msg_send_![window_obj, makeKeyAndVisible];
+            // iOS 27 fires `applicationWillResignActive:` during the
+            // scene-attach handoff (legacy lifecycle compat path), which
+            // sends `Message::Pause` and blocks the render thread. There's
+            // no follow-up `applicationDidBecomeActive:` because the scene
+            // lifecycle drives the real activation. Re-Resume on every
+            // scene activation to recover.
+            let scene_did_activate_name =
+                apple_util::str_to_nsstring("UISceneDidActivateNotification");
+            let _: () = msg_send![notification_center,
+                addObserver: delegate_self
+                selector: sel!(sceneDidActivate:)
+                name: scene_did_activate_name
+                object: nil];
 
             struct SendHack<F>(F);
             unsafe impl<F> Send for SendHack<F> {}
@@ -694,6 +726,36 @@ pub fn define_app_delegate() -> *const Class {
         send_message(Message::Pause);
     }
 
+    extern "C" fn scene_did_activate(_: &Object, _: Sel, _: ObjcId) {
+        send_message(Message::Resume);
+    }
+
+    extern "C" fn scene_will_connect(_: &Object, _: Sel, notification: ObjcId) {
+        unsafe {
+            let scene: ObjcId = msg_send![notification, object];
+            let is_window_scene: BOOL =
+                msg_send![scene, isKindOfClass: class!(UIWindowScene)];
+            if is_window_scene == NO {
+                return;
+            }
+
+            let view = match PENDING_SCENE_VIEW.with(|v| v.borrow_mut().take()) {
+                Some(v) => v,
+                None => return,
+            };
+            let view_ctrl = match PENDING_SCENE_VIEW_CTRL.with(|v| v.borrow_mut().take()) {
+                Some(c) => c,
+                None => return,
+            };
+
+            let window: ObjcId = msg_send![class!(UIWindow), alloc];
+            let window: ObjcId = msg_send![window, initWithWindowScene: scene];
+            msg_send_![window, addSubview: view];
+            msg_send_![window, setRootViewController: view_ctrl];
+            msg_send_![window, makeKeyAndVisible];
+        }
+    }
+
     unsafe {
         decl.add_method(
             sel!(application: didFinishLaunchingWithOptions:),
@@ -707,6 +769,14 @@ pub fn define_app_delegate() -> *const Class {
         decl.add_method(
             sel!(applicationWillResignActive:),
             application_will_resign_active as extern "C" fn(&Object, Sel, ObjcId),
+        );
+        decl.add_method(
+            sel!(sceneWillConnect:),
+            scene_will_connect as extern "C" fn(&Object, Sel, ObjcId),
+        );
+        decl.add_method(
+            sel!(sceneDidActivate:),
+            scene_did_activate as extern "C" fn(&Object, Sel, ObjcId),
         );
     }
     decl.register()

--- a/src/native/ios.rs
+++ b/src/native/ios.rs
@@ -30,8 +30,8 @@ use {
 // `did_finish_launching_with_options` run on the main thread, so
 // `thread_local` storage is sound.
 thread_local! {
-    static PENDING_SCENE_VIEW: RefCell<Option<ObjcId>> = RefCell::new(None);
-    static PENDING_SCENE_VIEW_CTRL: RefCell<Option<ObjcId>> = RefCell::new(None);
+    static PENDING_SCENE_VIEW_AND_CTRL: RefCell<Option<(ObjcId, ObjcId)>> =
+        RefCell::new(None);
 }
 
 struct MainThreadState {
@@ -614,8 +614,8 @@ pub fn define_app_delegate() -> *const Class {
 
             // Stash view + view_ctrl for `scene_will_connect` to adopt
             // into a freshly-created `initWithWindowScene:` window.
-            PENDING_SCENE_VIEW.with(|v| *v.borrow_mut() = Some(view.view));
-            PENDING_SCENE_VIEW_CTRL.with(|v| *v.borrow_mut() = Some(view.view_ctrl));
+            PENDING_SCENE_VIEW_AND_CTRL
+                .with(|cell| *cell.borrow_mut() = Some((view.view, view.view_ctrl)));
 
             let notification_center: ObjcId =
                 msg_send![class!(NSNotificationCenter), defaultCenter];
@@ -726,10 +726,6 @@ pub fn define_app_delegate() -> *const Class {
         send_message(Message::Pause);
     }
 
-    extern "C" fn scene_did_activate(_: &Object, _: Sel, _: ObjcId) {
-        send_message(Message::Resume);
-    }
-
     extern "C" fn scene_will_connect(_: &Object, _: Sel, notification: ObjcId) {
         unsafe {
             let scene: ObjcId = msg_send![notification, object];
@@ -739,14 +735,11 @@ pub fn define_app_delegate() -> *const Class {
                 return;
             }
 
-            let view = match PENDING_SCENE_VIEW.with(|v| v.borrow_mut().take()) {
-                Some(v) => v,
-                None => return,
-            };
-            let view_ctrl = match PENDING_SCENE_VIEW_CTRL.with(|v| v.borrow_mut().take()) {
-                Some(c) => c,
-                None => return,
-            };
+            let (view, view_ctrl) =
+                match PENDING_SCENE_VIEW_AND_CTRL.with(|cell| cell.borrow_mut().take()) {
+                    Some(pair) => pair,
+                    None => return,
+                };
 
             let window: ObjcId = msg_send![class!(UIWindow), alloc];
             let window: ObjcId = msg_send![window, initWithWindowScene: scene];
@@ -754,6 +747,10 @@ pub fn define_app_delegate() -> *const Class {
             msg_send_![window, setRootViewController: view_ctrl];
             msg_send_![window, makeKeyAndVisible];
         }
+    }
+
+    extern "C" fn scene_did_activate(_: &Object, _: Sel, _: ObjcId) {
+        send_message(Message::Resume);
     }
 
     unsafe {


### PR DESCRIPTION
## Problem

The iOS 27 SDK enforces the UIScene lifecycle for window management (per Apple's [TN3187](https://developer.apple.com/documentation/technotes/tn3187-migrating-to-the-uikit-scene-based-life-cycle)). Two consequences for apps built with the new SDK:

1. Apps that don't declare `UIApplicationSceneManifest` in `Info.plist` refuse to launch with the error _"UIScene life cycle is required for apps built with this SDK"_.
2. A `UIWindow` created via `initWithFrame:` from `application:didFinishLaunchingWithOptions:` is no longer auto-attached to a scene, so it stays orphan and invisible. The user sees a black screen after the splash; the GL/Metal view is never visible.

miniquad's current iOS path hits both. Note that **already-shipped apps run fine on iOS 27** — the enforcement is SDK-bound, not runtime-bound. The bug only appears when rebuilding against Xcode 27 / the iOS 27 SDK.

## Fix

This patch:

1. **Defers `UIWindow` creation** from `did_finish_launching_with_options` to a `UISceneWillConnectNotification` observer (`scene_will_connect`). The observer creates the window via `initWithWindowScene:` with the scene iOS provides, then adopts the view + view controller that `didFinishLaunching` had already set up. The view + view_ctrl are stashed in `thread_local` storage between the two callbacks (both run on the main thread).

2. **Observes `UISceneDidActivateNotification`** to re-send `Message::Resume`. Without this, iOS 27 fires a spurious `applicationWillResignActive:` during the scene-attach handoff (legacy lifecycle compat path) which sends `Message::Pause` and blocks the render thread on `rx.recv()`, with no follow-up `applicationDidBecomeActive:` to wake it back up. The symptom is exactly one frame of work happening (whatever ran synchronously up to the first `next_frame().await`), then nothing.

The patch is iOS-only and additive — pre-iOS-13 paths aren't touched, and `UISceneWillConnectNotification` has been available since iOS 13.

## Caller responsibilities

Apps using a miniquad with this patch **must declare `UIApplicationSceneManifest` in `Info.plist`** with at least one scene configuration, including a `UISceneDelegateClassName` pointing to either a stub `UIWindowSceneDelegate`-conforming class or the platform-provided default. Without the manifest, iOS 27 still refuses to launch the app — that part of the enforcement is unrelated to the patch.

A minimal stub delegate is enough; this patch handles all window/view wiring itself, so the scene delegate doesn't need any methods implemented:

```objc
@interface MySceneDelegate : UIResponder <UIWindowSceneDelegate>
@property (strong, nonatomic) UIWindow *window;
@end

@implementation MySceneDelegate
@end
```

## Tested on

iPhone running iOS 27 beta. Verified: launches past splash, window is visible, render thread runs continuously, asset loading completes, game renders + responds to input. Tested against the unpatched `miniquad@0.4.10` baseline (black screen / hang after first frame) for comparison.

## Why not a separate version bump

Happy to bump if preferred — this branch is built on top of the last commit at `version = "0.4.10"` on master to keep the diff minimal. Patch is ~80 lines net.