### PR TITLE
metal: match pipeline attachment formats to the view

### DIFF
--- a/src/graphics/metal.rs
+++ b/src/graphics/metal.rs
@@ -929,8 +929,11 @@ impl RenderingBackend for MetalContext {
             msg_send_![descriptor, setVertexFunction:shader_internal.vertex_function];
             msg_send_![descriptor, setFragmentFunction:shader_internal.fragment_function];
             msg_send_![descriptor, setVertexDescriptor: vertex_descriptor];
+            // Only attachment 0 — the backend has no MRT path and
+            // setting attachment 1 to a non-Invalid pixelFormat
+            // fails Metal validation when no texture is bound.
             let color_attachments = msg_send_![descriptor, colorAttachments];
-            for i in 0..2 {
+            for i in 0..1usize {
                 let color_attachment = msg_send_![color_attachments, objectAtIndexedSubscript: i];
                 let view_pixel_format: MTLPixelFormat = msg_send![self.view, colorPixelFormat];
                 msg_send_![color_attachment, setPixelFormat: view_pixel_format];
@@ -977,14 +980,23 @@ impl RenderingBackend for MetalContext {
                     ];
                 }
             }
-            msg_send_![
-                descriptor,
-                setDepthAttachmentPixelFormat: MTLPixelFormat::Depth32Float_Stencil8
-            ];
-            msg_send_![
-                descriptor,
-                setStencilAttachmentPixelFormat: MTLPixelFormat::Depth32Float_Stencil8
-            ];
+            // Pipeline depth/stencil formats must match whatever
+            // render pass uses this pipeline. MTKView reports
+            // `Invalid` when no depth/stencil is configured —
+            // leave the descriptor's defaults (also `Invalid`)
+            // alone in that case; otherwise mirror the view.
+            let view_depth_stencil_format: MTLPixelFormat =
+                msg_send![self.view, depthStencilPixelFormat];
+            if view_depth_stencil_format != MTLPixelFormat::Invalid {
+                msg_send_![
+                    descriptor,
+                    setDepthAttachmentPixelFormat: view_depth_stencil_format
+                ];
+                msg_send_![
+                    descriptor,
+                    setStencilAttachmentPixelFormat: view_depth_stencil_format
+                ];
+            }
 
             let mut error: ObjcId = nil;
             let pipeline_state: ObjcId = msg_send![

--- a/src/native/apple/frameworks.rs
+++ b/src/native/apple/frameworks.rs
@@ -632,6 +632,7 @@ impl MTLClearColor {
 #[allow(non_camel_case_types)]
 #[derive(Debug, Copy, Clone, Hash, PartialEq, Eq)]
 pub enum MTLPixelFormat {
+    Invalid = 0,
     BGRA8Unorm = 80,
     Depth32Float = 252,
     Stencil8 = 253,


### PR DESCRIPTION
## Problem

The Metal backend unconditionally configures every render pipeline state for two color attachments (`for i in 0..2`) plus depth + stencil at `Depth32Float_Stencil8`. MTKView by default exposes only color attachment 0 and `depthStencilPixelFormat = MTLPixelFormatInvalid`. With Metal validation on, the first draw asserts:

```
-[MTLDebugRenderCommandEncoder setRenderPipelineState:]:1654: failed assertion `Set Render Pipeline State Validation
For color attachment 1, the renderPipelineState pixelFormat must be MTLPixelFormatInvalid, as no texture is set.
For depth attachment, the renderPipelineState pixelFormat must be MTLPixelFormatInvalid, as no texture is set.
For stencil attachment, the renderPipelineState pixelFormat must be MTLPixelFormatInvalid, as no texture is set.
```

Hit this trying to switch a 2D macroquad app to the Metal backend on an iPhone 17 simulator (iOS 27 beta).

## Fix

Two changes in `graphics/metal.rs::new_pipeline`:

1. Loop only over color attachment 0 (`for i in 0..1`) — miniquad's Metal backend doesn't expose multiple render targets, so attachment 1 should remain `Invalid`.
2. Read the view's `depthStencilPixelFormat` and pass it through to the pipeline's depth + stencil attachment formats — `MTLPixelFormatInvalid` when MTKView has no depth/stencil, which is the default.

After this, the pipeline state's attachment formats match whatever the encoder actually has bound, and Metal validation accepts every draw.

## Tested on

iPhone 17 simulator on iOS 27 beta — Metal validation crash gone, app launches and renders into the simulator.
