### PR TITLE
metal: use 256-byte uniform alignment on iOS simulator

### DIFF
--- a/src/graphics/metal.rs
+++ b/src/graphics/metal.rs
@@ -10,9 +10,18 @@ use super::*;
 // https://developer.apple.com/metal/Metal-Feature-Set-Tables.pdf
 const MAX_UNIFORM_BUFFER_SIZE: u64 = 4 * 1024 * 1024;
 const NUM_INFLIGHT_FRAMES: usize = 3;
-#[cfg(any(target_os = "macos", all(target_os = "ios", target_arch = "x86_64")))]
+// iOS simulator on Apple Silicon Macs (`target_abi = "sim"`) runs
+// iOS arm64 code but issues Metal commands against the host Mac's
+// GPU — which validates with the 256-byte rule, not iOS arm64's
+// 16-byte. Without breaking the simulator out of the iOS-arm64
+// branch below, the first draw fails Metal validation on
+// uniform-buffer offset alignment.
+#[cfg(any(
+    target_os = "macos",
+    all(target_os = "ios", any(target_arch = "x86_64", target_abi = "sim")),
+))]
 const UNIFORM_BUFFER_ALIGN: u64 = 256;
-#[cfg(all(target_os = "ios", not(target_arch = "x86_64")))]
+#[cfg(all(target_os = "ios", target_arch = "aarch64", not(target_abi = "sim")))]
 const UNIFORM_BUFFER_ALIGN: u64 = 16;
 
 impl From<VertexFormat> for MTLVertexFormat {


### PR DESCRIPTION
## Problem

The iOS simulator on Apple Silicon Macs (`aarch64-apple-ios-sim`, `target_abi = "sim"`) runs the iOS arm64 binary but issues Metal commands against the host Mac's GPU subsystem. That subsystem validates with the 256-byte uniform buffer offset rule — not the 16-byte rule for Apple GPUs on real iOS devices.

The existing cfg matched the simulator into the `target_arch = "aarch64"` branch with the iOS device's 16-byte constant. The first draw asserts:

```
-[MTLDebugRenderCommandEncoder validateCommonDrawErrors:]:6032: failed assertion `Draw Errors Validation
Vertex Function(vertexShader): the offset into the buffer uniforms that is bound at Buffer index 0 must be a multiple of 256 but was set to 144.
```

## Fix

Add `target_abi = "sim"` to the cfg group that selects the 256-byte constant. Both the legacy x86_64 simulator and the modern arm64 simulator now pick the same alignment as macOS. Real arm64 iOS devices keep the 16-byte alignment they correctly used before.

## Tested on

iPhone 17 simulator on iOS 27 beta (Apple Silicon Mac host) — uniform-alignment assert gone, draws complete.
