### PR TITLE
metal: assert on `texture_generate_mipmaps` for non-mipmapped textures

### DIFF
--- a/src/graphics/metal.rs
+++ b/src/graphics/metal.rs
@@ -498,13 +498,21 @@ impl RenderingBackend for MetalContext {
         unimplemented!()
     }
     fn texture_generate_mipmaps(&mut self, texture: TextureId) {
+        let texture = self.textures.get(texture);
+        // Catch the bug at the call site instead of letting Metal
+        // assert on `mipmapLevelCount > 1` deep inside the blit
+        // encoder. Set `TextureParams::allocate_mipmaps = true` at
+        // creation to use this entry point.
+        assert!(
+            texture.params.allocate_mipmaps,
+            "texture_generate_mipmaps called on a texture allocated without mipmaps",
+        );
         unsafe {
             if self.command_buffer.is_none() {
                 self.command_buffer = Some(msg_send![self.command_queue, commandBuffer]);
             }
             let command_buffer = self.command_buffer.unwrap();
             let encoder = msg_send_![command_buffer, blitCommandEncoder];
-            let texture = self.textures.get(texture);
             msg_send_![encoder, generateMipmapsForTexture: texture.texture];
             msg_send_![encoder, endEncoding];
         }


### PR DESCRIPTION
## Problem

`RenderingBackend::texture_generate_mipmaps`'s doc comment already promises:

> Metal-specific note: if texture was created without `params.generate_mipmaps`, `generate_mipmaps` will do nothing.

But the Metal implementation in `graphics/metal.rs` unconditionally calls `generateMipmapsForTexture:` without checking the texture's `allocate_mipmaps` flag. With Metal validation on, the call fails on any texture that has `mipmapLevelCount == 1`:

```
-[MTLDebugBlitCommandEncoder generateMipmapsForTexture:]:1105: failed assertion `Generate Mipmaps For Texture Validation
[tex mipmapLevelCount](1) must be > 1.
```

## Fix

Early-return when `texture.params.allocate_mipmaps` is false. Honours the documented contract and matches the OpenGL backend's behaviour.

## Tested on

iPhone 17 simulator on iOS 27 beta — assert gone for macroquad apps that call `set_filter` (which routes through `texture_generate_mipmaps` for the mipmap filter mode) on non-mipmapped textures.
