### PR TITLE
metal: implement multisample resolve textures

### DIFF
--- a/src/graphics/metal.rs
+++ b/src/graphics/metal.rs
@@ -539,8 +539,12 @@ impl RenderingBackend for MetalContext {
         resolve_img: Option<&[TextureId]>,
         depth_img: Option<TextureId>,
     ) -> RenderPass {
-        if resolve_img.is_some() {
-            unimplemented!("resolve textures are not yet implemented on metal");
+        if let Some(resolve_img) = resolve_img {
+            assert_eq!(
+                resolve_img.len(),
+                color_img.len(),
+                "resolve_img must have one entry per color attachment"
+            );
         }
         unsafe {
             let render_pass_desc =
@@ -552,7 +556,19 @@ impl RenderingBackend for MetalContext {
                 let color_attachment = msg_send_![msg_send_![render_pass_desc, colorAttachments], objectAtIndexedSubscript:i];
                 msg_send_![color_attachment, setTexture: color_texture];
                 msg_send_![color_attachment, setLoadAction: MTLLoadAction::Clear];
-                msg_send_![color_attachment, setStoreAction: MTLStoreAction::Store];
+                // Multisample resolve: when the caller passes a resolve
+                // texture for this attachment, downsample into it on
+                // store. Required for any MSAA render target.
+                if let Some(resolve_img) = resolve_img {
+                    let resolve_texture = self.textures.get(resolve_img[i]).texture;
+                    msg_send_![color_attachment, setResolveTexture: resolve_texture];
+                    msg_send_![
+                        color_attachment,
+                        setStoreAction: MTLStoreAction::MultisampleResolve
+                    ];
+                } else {
+                    msg_send_![color_attachment, setStoreAction: MTLStoreAction::Store];
+                }
             }
             if let Some(depth_img) = depth_img {
                 let depth_texture = self.textures.get(depth_img).texture;


### PR DESCRIPTION
## Problem

`new_render_pass_mrt` accepts an optional `resolve_img` slice (per-color-attachment resolve target) but unconditionally panics with `unimplemented!` when any caller passes one. macroquad's MSAA render targets do pass them, so any app with `sample_count > 1` aborts on the first render-target construction:

```
PanicHookInfo { ... location: Location { file: ".../graphics/metal.rs", line: 568 } }
thread caused non-unwinding panic. aborting.
```

## Fix

Wire each `resolve_img[i]` to the matching color attachment's `resolveTexture` and flip the store action to `MultisampleResolve`. The non-resolve path is unchanged (`StoreAction = Store`).

Asserts the resolve slice length matches the color slice — the per-index pairing is implicit in the API and a length mismatch would silently drop or out-of-bounds otherwise.

## Tested on

iPhone 17 simulator on iOS 27 beta — a macroquad app with `sample_count: 4` (creating MSAA render targets) no longer aborts on first construction.
