### PR TITLE
metal: render-target color textures must use the view's pixel format

### DIFF
--- a/src/graphics/metal.rs
+++ b/src/graphics/metal.rs
@@ -711,8 +711,14 @@ impl RenderingBackend for MetalContext {
 
             if access == TextureAccess::RenderTarget {
                 if params.format != TextureFormat::Depth {
-                    let pixel_format: MTLPixelFormat = params.format.into();
-                    msg_send_![descriptor, setPixelFormat: pixel_format];
+                    // Match the view's `colorPixelFormat` — pipelines
+                    // bake it and reject mismatched attachments, and
+                    // MTKView's presentable formats are all `BGRA*` /
+                    // `RGBA16Float` so honoring `RGBA8` literally
+                    // would break every offscreen color target.
+                    let view_pixel_format: MTLPixelFormat =
+                        msg_send![self.view, colorPixelFormat];
+                    msg_send_![descriptor, setPixelFormat: view_pixel_format];
                 }
                 msg_send_![descriptor, setStorageMode: MTLStorageMode::Private];
                 msg_send_![


### PR DESCRIPTION
`new_pipeline` builds each pipeline's color attachment with the view's `colorPixelFormat`, so Metal pipelines effectively bake in that format at creation time. Color render textures created via `new_render_texture` were following the requested `TextureFormat` instead (e.g. `RGBA8` → `RGBA8Unorm`). The instant such a target was bound to that pipeline, Metal validation tripped:

```
For color attachment 0, the render pipeline's pixelFormat (MTLPixelFormatBGRA8Unorm) does not match the framebuffer's pixelFormat (MTLPixelFormatRGBA8Unorm).
```

[MTKView's allowed presentable formats](https://developer.apple.com/documentation/metalkit/mtkview/colorpixelformat) are all `BGRA*` (or `RGBA16Float`) — `RGBA8Unorm` isn't among them — so honoring `TextureFormat::RGBA8` literally for color render targets silently breaks every offscreen color attachment.

Use the view's actual `colorPixelFormat` for color render-target textures so they round-trip through the pipeline without a format mismatch. Sampling them in a shader is unaffected: Metal's hardware swizzle returns RGBA semantics regardless of memory order.

Caught while wiring up macroquad's `render_target()` on the iPhone 17 simulator running iOS 27.