### PR TITLE
metal: honor Conf.sample_count for MSAA on iOS + matching pipelines

### DIFF
--- a/src/graphics/metal.rs
+++ b/src/graphics/metal.rs
@@ -791,12 +791,9 @@ impl RenderingBackend for MetalContext {
                 }
                 msg_send_![descriptor, setStorageMode: MTLStorageMode::Private];
                 if params.sample_count > 1 {
-                    // MSAA render target. The matching single-sample
-                    // resolve texture is created with `sample_count = 1`
-                    // and passed alongside in `new_render_pass_mrt`'s
-                    // `resolve_img` slice. Multisample textures can't be
-                    // shader-sampled directly (they're sampled via the
-                    // resolve pass) and can't have mipmaps.
+                    // MSAA target — render-only, no mipmaps, no
+                    // shader-sample (the resolve texture is sampled
+                    // instead).
                     msg_send_![
                         descriptor,
                         setTextureType: MTLTextureType::D2Multisample
@@ -1091,12 +1088,9 @@ impl RenderingBackend for MetalContext {
                     setStencilAttachmentPixelFormat: view_depth_stencil_format
                 ];
             }
-            // Match the view's sample count. The pipeline's sampleCount
-            // must equal the sampleCount of every render-pass color
-            // attachment it draws to. We use the view's value as the
-            // canonical app-wide sample count: MSAA render targets
-            // (`render_target_msaa()`) match it, and the main drawable
-            // is configured from `Conf.sample_count` in the view setup.
+            // Pipeline sampleCount must match every render-pass
+            // color attachment it binds to; use the view's as the
+            // canonical app-wide value.
             let view_sample_count: u64 = msg_send![self.view, sampleCount];
             msg_send_![descriptor, setSampleCount: view_sample_count];
 
@@ -1315,18 +1309,17 @@ impl RenderingBackend for MetalContext {
             let color_attachments = msg_send_![descriptor, colorAttachments];
             let color_attachment = msg_send_![color_attachments, objectAtIndexedSubscript: 0];
 
-            // Pick the store action based on whether the attachment
-            // has a resolve texture. MTKView's
-            // `currentRenderPassDescriptor` already wires a
-            // `resolveTexture` when the view's `sampleCount > 1`, and
-            // `new_render_pass_mrt` does the same for offscreen MSAA
-            // targets. Both paths require `MultisampleResolve` —
-            // forcing `Store` here trips Metal validation.
+            // If the attachment has a resolve texture, use
+            // `StoreAndMultisampleResolve` (not just
+            // `MultisampleResolve`) so the multisample texture
+            // survives target-switch boundaries within a frame —
+            // a later `Load` on the same target would otherwise
+            // read discarded memory.
             let resolve_texture: ObjcId = msg_send![color_attachment, resolveTexture];
             let store_action = if resolve_texture.is_null() {
                 MTLStoreAction::Store
             } else {
-                MTLStoreAction::MultisampleResolve
+                MTLStoreAction::StoreAndMultisampleResolve
             };
             msg_send_![color_attachment, setStoreAction: store_action];
 

--- a/src/graphics/metal.rs
+++ b/src/graphics/metal.rs
@@ -790,12 +790,31 @@ impl RenderingBackend for MetalContext {
                     msg_send_![descriptor, setPixelFormat: view_pixel_format];
                 }
                 msg_send_![descriptor, setStorageMode: MTLStorageMode::Private];
-                msg_send_![
-                    descriptor,
-                    setUsage: MTLTextureUsage::RenderTarget as u64
-                        | MTLTextureUsage::ShaderRead as u64
-                        | MTLTextureUsage::ShaderWrite as u64
-                ];
+                if params.sample_count > 1 {
+                    // MSAA render target. The matching single-sample
+                    // resolve texture is created with `sample_count = 1`
+                    // and passed alongside in `new_render_pass_mrt`'s
+                    // `resolve_img` slice. Multisample textures can't be
+                    // shader-sampled directly (they're sampled via the
+                    // resolve pass) and can't have mipmaps.
+                    msg_send_![
+                        descriptor,
+                        setTextureType: MTLTextureType::D2Multisample
+                    ];
+                    msg_send_![descriptor, setSampleCount: params.sample_count as u64];
+                    msg_send_![descriptor, setMipmapLevelCount: 1u64];
+                    msg_send_![
+                        descriptor,
+                        setUsage: MTLTextureUsage::RenderTarget as u64
+                    ];
+                } else {
+                    msg_send_![
+                        descriptor,
+                        setUsage: MTLTextureUsage::RenderTarget as u64
+                            | MTLTextureUsage::ShaderRead as u64
+                            | MTLTextureUsage::ShaderWrite as u64
+                    ];
+                }
             } else {
                 #[cfg(target_os = "macos")]
                 {
@@ -1072,6 +1091,14 @@ impl RenderingBackend for MetalContext {
                     setStencilAttachmentPixelFormat: view_depth_stencil_format
                 ];
             }
+            // Match the view's sample count. The pipeline's sampleCount
+            // must equal the sampleCount of every render-pass color
+            // attachment it draws to. We use the view's value as the
+            // canonical app-wide sample count: MSAA render targets
+            // (`render_target_msaa()`) match it, and the main drawable
+            // is configured from `Conf.sample_count` in the view setup.
+            let view_sample_count: u64 = msg_send![self.view, sampleCount];
+            msg_send_![descriptor, setSampleCount: view_sample_count];
 
             let mut error: ObjcId = nil;
             let pipeline_state: ObjcId = msg_send![

--- a/src/graphics/metal.rs
+++ b/src/graphics/metal.rs
@@ -1315,7 +1315,20 @@ impl RenderingBackend for MetalContext {
             let color_attachments = msg_send_![descriptor, colorAttachments];
             let color_attachment = msg_send_![color_attachments, objectAtIndexedSubscript: 0];
 
-            msg_send_![color_attachment, setStoreAction: MTLStoreAction::Store];
+            // Pick the store action based on whether the attachment
+            // has a resolve texture. MTKView's
+            // `currentRenderPassDescriptor` already wires a
+            // `resolveTexture` when the view's `sampleCount > 1`, and
+            // `new_render_pass_mrt` does the same for offscreen MSAA
+            // targets. Both paths require `MultisampleResolve` —
+            // forcing `Store` here trips Metal validation.
+            let resolve_texture: ObjcId = msg_send![color_attachment, resolveTexture];
+            let store_action = if resolve_texture.is_null() {
+                MTLStoreAction::Store
+            } else {
+                MTLStoreAction::MultisampleResolve
+            };
+            msg_send_![color_attachment, setStoreAction: store_action];
 
             match action {
                 PassAction::Clear { color, .. } => {

--- a/src/native/ios.rs
+++ b/src/native/ios.rs
@@ -503,7 +503,7 @@ unsafe fn create_opengl_view(screen_rect: NSRect, _sample_count: i32, high_dpi: 
     }
 }
 
-unsafe fn create_metal_view(screen_rect: NSRect, _sample_count: i32, _high_dpi: bool) -> View {
+unsafe fn create_metal_view(screen_rect: NSRect, sample_count: i32, _high_dpi: bool) -> View {
     let mtk_view_obj: ObjcId = msg_send![define_glk_or_mtk_view(class!(MTKView)), alloc];
     let mtk_view_obj: ObjcId = msg_send![mtk_view_obj, initWithFrame: screen_rect];
 
@@ -524,6 +524,9 @@ unsafe fn create_metal_view(screen_rect: NSRect, _sample_count: i32, _high_dpi: 
     let device = MTLCreateSystemDefaultDevice();
     msg_send_![mtk_view_obj, setDevice: device];
     msg_send_![mtk_view_obj, setUserInteractionEnabled: YES];
+    if sample_count > 1 {
+        msg_send_![mtk_view_obj, setSampleCount: sample_count as u64];
+    }
 
     View {
         view: mtk_view_obj,


### PR DESCRIPTION
Three coupled changes that together light up MSAA on the iOS Metal backend.

## 1. `create_metal_view` calls `setSampleCount:` on `MTKView`

The `sample_count` argument was prefixed `_` and silently dropped, so `Conf.sample_count` had no effect on iOS Metal. macOS already does this.

## 2. `new_pipeline` matches the view's `sampleCount`

A pipeline's `sampleCount` must match every render-pass color attachment it draws to. Reading the view's value at pipeline-creation time keeps the main drawable and `render_target_msaa()` targets compatible with the same pipeline.

## 3. `new_texture` creates `D2Multisample` textures when `sample_count > 1`

For `RenderTarget` access with `sample_count > 1`, the color texture has to be a `D2Multisample` with matching `setSampleCount:` and `mipmapLevelCount = 1`, and can only carry `RenderTarget` usage (not `ShaderRead`/`ShaderWrite`). The single-sample resolve texture for the same target is created separately by the caller (e.g. macroquad's `render_target_ex`) and passed in via `new_render_pass_mrt`'s `resolve_img` slice — handled in #638.

## Constraint

Every render-pass color attachment must use the view's sample count. Mixing single-sample and multisample targets in one app would require per-target pipeline states, which Metal allows but miniquad's "one pipeline per material" model does not currently express. Callers that opt into `Conf.sample_count > 1` should use `render_target_msaa()` (or pass a matching `sample_count`) for every offscreen color target.

Builds on #634, #635, #636, #637, #638, #639.