### PR TITLE
ios: implement required mtkView:drawableSizeWillChange: selector

### DIFF
--- a/src/native/ios.rs
+++ b/src/native/ios.rs
@@ -371,6 +371,19 @@ pub fn define_glk_or_mtk_view_dlg(superclass: &Class) -> *const Class {
         draw_in_rect(this, s, o, nil);
     }
 
+    // `MTKViewDelegate` requires both `drawInMTKView:` AND
+    // `mtkView:drawableSizeWillChange:`. MTKView invokes the
+    // size-change selector before the first `drawInMTKView:` after
+    // any drawable-size change (window resize, rotation under a
+    // non-locked orientation set, split-view drag on iPad). Without
+    // an implementation, `_resizeDrawable` raises
+    // `NSInvalidArgumentException` and crashes the process.
+    //
+    // The real resize handling lives in `draw_in_rect`, which polls
+    // `UIScreen.mainScreen.bounds` every frame and emits
+    // `Message::Resize` on a delta — so a stub is enough here.
+    extern "C" fn drawable_size_will_change(_: &Object, _: Sel, _: ObjcId, _: NSSize) {}
+
     unsafe {
         decl.add_method(
             sel!(glkView: drawInRect:),
@@ -380,6 +393,11 @@ pub fn define_glk_or_mtk_view_dlg(superclass: &Class) -> *const Class {
         decl.add_method(
             sel!(drawInMTKView:),
             draw_in_rect2 as extern "C" fn(&Object, Sel, ObjcId),
+        );
+
+        decl.add_method(
+            sel!(mtkView: drawableSizeWillChange:),
+            drawable_size_will_change as extern "C" fn(&Object, Sel, ObjcId, NSSize),
         );
     }
 

--- a/src/native/ios.rs
+++ b/src/native/ios.rs
@@ -371,18 +371,30 @@ pub fn define_glk_or_mtk_view_dlg(superclass: &Class) -> *const Class {
         draw_in_rect(this, s, o, nil);
     }
 
-    // `MTKViewDelegate` requires both `drawInMTKView:` AND
-    // `mtkView:drawableSizeWillChange:`. MTKView invokes the
-    // size-change selector before the first `drawInMTKView:` after
-    // any drawable-size change (window resize, rotation under a
-    // non-locked orientation set, split-view drag on iPad). Without
-    // an implementation, `_resizeDrawable` raises
-    // `NSInvalidArgumentException` and crashes the process.
-    //
-    // The real resize handling lives in `draw_in_rect`, which polls
-    // `UIScreen.mainScreen.bounds` every frame and emits
-    // `Message::Resize` on a delta — so a stub is enough here.
-    extern "C" fn drawable_size_will_change(_: &Object, _: Sel, _: ObjcId, _: NSSize) {}
+    // `MTKViewDelegate` requires this alongside `drawInMTKView:`;
+    // missing it crashes `_resizeDrawable` with
+    // `NSInvalidArgumentException`. Sync `native_display` here so
+    // the next frame's `setScissorRect` (and anything else reading
+    // `screen_size`) matches the new drawable — `draw_in_rect`'s
+    // `UIScreen.bounds` poll is the fallback but lags drawableSize
+    // during rotation animations.
+    extern "C" fn drawable_size_will_change(_: &Object, _: Sel, _: ObjcId, size: NSSize) {
+        let width = size.width as i32;
+        let height = size.height as i32;
+        let changed = {
+            let mut display = native_display().lock().unwrap();
+            let changed =
+                display.screen_width != width || display.screen_height != height;
+            if changed {
+                display.screen_width = width;
+                display.screen_height = height;
+            }
+            changed
+        };
+        if changed {
+            send_message(Message::Resize { width, height });
+        }
+    }
 
     unsafe {
         decl.add_method(


### PR DESCRIPTION
`MTKViewDelegate` declares two `@required` methods: `mtkView:drawableSizeWillChange:` and `drawInMTKView:`. The `QuadViewDlg` class only registered the latter, so any actual drawable-size change (window resize, rotation under a non-locked orientation set, split-view drag on iPad) crashed:

```
*** Terminating app due to uncaught exception 'NSInvalidArgumentException',
reason: '-[QuadViewDlg mtkView:drawableSizeWillChange:]: unrecognized selector sent to instance 0x...'
... [MTKView _resizeDrawable]
... [UIView setFrame:]
... [UIWindow _rotateWindowToOrientation:...]
```

Implementing the selector as a no-op fixes the immediate crash, but the handler also needs to sync `native_display`'s `screen_width` / `screen_height` to the new drawable size and emit `Message::Resize` before the next `drawInMTKView:`. The fallback resize-detect path in `draw_in_rect` polls `UIScreen.mainScreen.bounds`, which lags MTKView's drawableSize during rotation animations — anything that depends on the framebuffer dimensions for the current pass then computes against stale values and fails Metal validation:

```
-[MTLDebugRenderCommandEncoder setScissorRect:]: failed assertion
`Set Scissor Rect Validation
(rect.y(688) + rect.height(2064))(2752) must be <= render pass height(2064)'
```

Reproduced on iPad Air 11-inch and iPad Pro 13-inch simulators on iOS 27 by rotating the device. Apps that lock orientation via `Info.plist` (or runtime supported-orientations) never see a drawable-size change and so don't hit either crash.

The full path: `drawableSizeWillChange` updates `native_display` immediately and sends `Message::Resize`; `draw_in_rect`'s own `UIScreen.bounds` poll still runs as a fallback (e.g. for size changes that don't go through the delegate).
