### PR TITLE
cfg-gate Android-only set_or_replace_display

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -99,6 +99,7 @@ fn set_display(display: native::NativeDisplayData) {
 }
 /// This for now is Android specific since the process can continue running but the display
 /// is restarted. We support reinitializing the display.
+#[cfg(target_os = "android")]
 fn set_or_replace_display(display: native::NativeDisplayData) {
     if let Some(m) = NATIVE_DISPLAY.get() {
         // Replace existing display


### PR DESCRIPTION
The function is only called on Android (its own doc comment says so). Without the cfg gate, every other target (iOS, macOS, desktop, web) gets a \`dead_code\` warning on every build. Adding \`#[cfg(target_os = "android")]\` so it's only compiled on the platform that actually uses it.