### PR TITLE
android: populate dpi_scale from DisplayMetrics.density

### DIFF
--- a/src/native/android.rs
+++ b/src/native/android.rs
@@ -190,9 +190,11 @@ impl MainThreadState {
             },
             Message::SurfaceChanged { width, height } => {
                 {
+                    let density = unsafe { query_display_density() };
                     let mut d = crate::native_display().lock().unwrap();
                     d.screen_width = width as _;
                     d.screen_height = height as _;
+                    d.dpi_scale = density;
                 }
                 self.event_handler.resize_event(width as _, height as _);
             }
@@ -321,6 +323,56 @@ pub unsafe fn attach_jni_env() -> *mut ndk_sys::JNIEnv {
     assert!(res == 0);
 
     env
+}
+
+/// `Resources.getDisplayMetrics().density` — 1.0 = mdpi, 2.0 = xhdpi,
+/// etc. Returns 1.0 on any JNI hiccup.
+unsafe fn query_display_density() -> f32 {
+    if VM.is_null() || ACTIVITY.is_null() {
+        return 1.0;
+    }
+    let env = attach_jni_env();
+    if env.is_null() {
+        return 1.0;
+    }
+
+    let resources = ndk_utils::call_object_method!(
+        env,
+        ACTIVITY,
+        "getResources",
+        "()Landroid/content/res/Resources;"
+    );
+    if resources.is_null() {
+        return 1.0;
+    }
+
+    let metrics = ndk_utils::call_object_method!(
+        env,
+        resources,
+        "getDisplayMetrics",
+        "()Landroid/util/DisplayMetrics;"
+    );
+    if metrics.is_null() {
+        return 1.0;
+    }
+
+    let get_object_class = (**env).GetObjectClass.unwrap();
+    let get_field_id = (**env).GetFieldID.unwrap();
+    let get_float_field = (**env).GetFloatField.unwrap();
+
+    let metrics_class = get_object_class(env, metrics);
+    let density_field = get_field_id(
+        env,
+        metrics_class,
+        b"density\0".as_ptr() as _,
+        b"F\0".as_ptr() as _,
+    );
+    if density_field.is_null() {
+        return 1.0;
+    }
+
+    let density = get_float_field(env, metrics, density_field);
+    if density > 0.0 { density } else { 1.0 }
 }
 
 pub struct AndroidClipboard {}
@@ -454,9 +506,11 @@ where
 
         let clipboard = Box::new(AndroidClipboard::new());
         let tx_fn = Box::new(move |req| tx.send(Message::Request(req)).unwrap());
+        let density = query_display_density();
         crate::set_or_replace_display(NativeDisplayData {
             high_dpi: conf.high_dpi,
             blocking_event_loop: conf.platform.blocking_event_loop,
+            dpi_scale: density,
             ..NativeDisplayData::new(screen_width as _, screen_height as _, tx_fn, clipboard)
         });
 


### PR DESCRIPTION
## Summary

Upstream leaves `NativeDisplayData::dpi_scale` at `1.0` on Android. macroquad's `screen_width()` / `mouse_position()` divide by `dpi_scale` to return density-independent units, so the same code that returns dp on a Retina Mac returns physical pixels on Android — UI laid out in dp lands at the wrong screen position, and apps have to special-case Android to compensate.

This populates `dpi_scale` from `Resources.getDisplayMetrics().density` (mdpi = 1.0, xhdpi = 2.0, etc.) via JNI:

- in `init_with_activity` when `NativeDisplayData` is first constructed
- on every `SurfaceChanged` (covers device density changes the OS may push at runtime)

`query_display_density()` is fail-soft — every nullable JNI lookup falls back to `1.0`, preserving upstream behaviour for apps that don't expect a non-1 `dpi_scale` on Android.

## Test plan

- [x] Pixel 6 (`density = 2.625`): `screen_width()` now reports ≈ 411 dp instead of ≈ 1080 px; touch coords land on dp-positioned UI without per-platform conversion.
- [x] `cargo check --target aarch64-linux-android` clean (no new warnings).