### PR TITLE
macos: refresh dpi_scale per Metal frame; guard backingScaleFactor=0

### DIFF
--- a/src/native/macos.rs
+++ b/src/native/macos.rs
@@ -214,8 +214,11 @@ impl MacosDisplay {
             }
         }
         if d.high_dpi {
+            // 0.0 before the window is on-screen; skip until a real value lands.
             let dpi_scale: f64 = msg_send![self.window, backingScaleFactor];
-            d.dpi_scale = dpi_scale as f32;
+            if dpi_scale > 0.0 {
+                d.dpi_scale = dpi_scale as f32;
+            }
         } else {
             let bounds: NSRect = msg_send![self.view, bounds];
             let backing_size: NSSize = msg_send![self.view, convertSizeToBacking: NSSize {width: bounds.size.width, height: bounds.size.height}];
@@ -954,6 +957,13 @@ pub fn define_metal_view_class() -> *const Class {
     extern "C" fn draw_rect(this: &Object, _sel: Sel, _: ObjcId) {
         let payload = get_window_payload(this);
         unsafe {
+            // Per-frame refresh matching the OpenGL path — otherwise
+            // dpi_scale stays at the startup 1.0 default on Retina.
+            if let Some((w, h)) = payload.update_dimensions() {
+                if let Some(event_handler) = payload.context() {
+                    event_handler.resize_event(w as _, h as _);
+                }
+            }
             let current_runloop = msg_send_![class!(NSRunLoop), currentRunLoop];
             let current_mode: ObjcId = msg_send![current_runloop, currentMode];
             // Not checking name, assuming that this is NSEventTrackingRunLoopMode


### PR DESCRIPTION
## Summary

Two related fixes for macOS Metal high-DPI behaviour:

1. **Guard `backingScaleFactor = 0`.** `NSWindow.backingScaleFactor` returns `0.0` when the window isn't yet attached to a screen — exactly the state during the startup `update_dimensions()` call (before `makeKeyAndOrderFront`). Upstream then stores `dpi_scale = 0`, and any downstream divide by `dpi_scale` (e.g. macroquad's `screen_width()`) either NaN's or pins the UI to 0×0. Now we skip the assignment when the value is non-positive, leaving the prior (correct) value in place until a later call catches a real scale.

2. **Refresh `dpi_scale` per Metal frame.** OpenGL's `draw_rect` calls `update_dimensions()` every frame; the Metal `draw_rect` didn't, so even after the guarded startup case the initial `dpi_scale` was never refreshed. Retina apps using the Metal backend rendered at point resolution. This change adds the matching call to Metal's `draw_rect`.

## Test plan

- [x] Retina MacBook (`backingScaleFactor = 2`): macOS Metal app now reports `dpi_scale = 2.0` consistently from frame 1.
- [x] Resize + display-move: `dpi_scale` follows when the window is dragged between Retina and non-Retina displays.