### PR TITLE
ios: report view pixel size + contentScaleFactor as dpi_scale

### DIFF
--- a/src/native/ios.rs
+++ b/src/native/ios.rs
@@ -326,32 +326,27 @@ pub fn define_glk_or_mtk_view_dlg(superclass: &Class) -> *const Class {
             payload.init_event_handler();
         }
 
-        let main_screen: ObjcId = unsafe { msg_send![class!(UIScreen), mainScreen] };
-        let screen_rect: NSRect = unsafe { msg_send![main_screen, bounds] };
-        let high_dpi = native_display().lock().unwrap().high_dpi;
+        // Measure the view, not the device screen — iOS-on-Mac
+        // windowed mode has view < UIScreen.
+        let view_bounds: NSRect = unsafe { msg_send![payload.view, bounds] };
+        let content_scale_factor: f64 =
+            unsafe { msg_send![payload.view, contentScaleFactor] };
+        let screen_width = (view_bounds.size.width * content_scale_factor) as i32;
+        let screen_height = (view_bounds.size.height * content_scale_factor) as i32;
+        let dpi_scale = content_scale_factor as f32;
 
-        let (screen_width, screen_height) = if high_dpi {
-            let scale: f64 = unsafe { msg_send![main_screen, scale] };
-
-            (
-                (screen_rect.size.width * scale) as i32,
-                (screen_rect.size.height * scale) as i32,
-            )
-        } else {
-            let content_scale_factor: f64 = unsafe { msg_send![payload.view, contentScaleFactor] };
-            (
-                (screen_rect.size.width * content_scale_factor) as i32,
-                (screen_rect.size.height * content_scale_factor) as i32,
-            )
+        let needs_update = {
+            let d = native_display().lock().unwrap();
+            d.screen_width != screen_width
+                || d.screen_height != screen_height
+                || d.dpi_scale != dpi_scale
         };
-
-        if native_display().lock().unwrap().screen_width != screen_width
-            || native_display().lock().unwrap().screen_height != screen_height
-        {
+        if needs_update {
             {
                 let mut d = native_display().lock().unwrap();
                 d.screen_width = screen_width;
                 d.screen_height = screen_height;
+                d.dpi_scale = dpi_scale;
             }
             send_message(Message::Resize {
                 width: screen_width,


### PR DESCRIPTION
## Summary

Two related changes to make iOS's reported metrics match the actual rendering surface:

1. **Populate `dpi_scale` from `contentScaleFactor`.** Upstream left `native_display().dpi_scale` at `1.0` on iOS. macroquad's `screen_width()` / `mouse_position()` divide by `dpi_scale` to return density-independent units — so without this, iOS callers got pixel values where macOS got points, and dp-positioned UI landed at the wrong place. Now iOS joins macOS in reporting a real content scale.

2. **Measure the view, not `UIScreen`.** `draw_in_rect` reported `UIScreen.bounds × UIScreen.scale` as the rendered size. Switched to `payload.view.bounds × contentScaleFactor`, which is more direct (the view IS the rendering surface) and avoids the global `UIScreen.mainScreen` call that has gotchas with multi-window configurations.

Both halves go together: the natural scale to multiply the view's `bounds` by is the view's own `contentScaleFactor`, and once we're reading it for that, exposing it as `dpi_scale` is essentially free.

The `high_dpi` toggle is no longer consulted here — the view's `contentScaleFactor` is already set to `UIScreen.scale` when `high_dpi=true` and `1.0` when `high_dpi=false` (see `create_opengl_view`), so the resulting `screen_size` / `dpi_scale` match upstream's high_dpi-aware branches on real iPhone / iPad.

## What this fixes

In a downstream macroquad app, iOS-on-Mac windowed mode was rendering at ~50 % of the window size. The fix is **the `dpi_scale` half** — macroquad's `screen_width()` was returning physical-pixel counts where the macOS desktop returned points, so the rest of the app drew at half the expected scale.

(Side note on the bounds half: iOS-on-Mac windowed reports the same `view.bounds` as fullscreen — the window chrome clips a fixed-size view rather than shrinking it. So the change from `UIScreen.bounds` is more about avoiding the `UIScreen.mainScreen` global and being more direct than about fixing the windowed-rendering bug per se.)

## Test plan

- [x] iPhone 17 Pro (`contentScaleFactor = 3`): `screen_width()` reports 402 dp instead of 1206 px.
- [x] iPad Pro 13" simulator: 1032 dp instead of 2064 px.
- [x] iPad mini 8.3" simulator: 744 dp.
- [x] iOS-on-Mac fullscreen + windowed: app renders at the correct scale (was 50 %).