### PR TITLE
Bump objc-rs to 0.3 so Apple's runtime is used off macOS/iOS

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -44,7 +44,7 @@ libc = "0.2"
 ndk-sys = "0.2"
 
 [target.'cfg(any(target_os = "macos", target_os = "ios", target_os = "tvos"))'.dependencies]
-objc = { package = "objc-rs", version = "0.2" }
+objc = { package = "objc-rs", version = "0.3" }
 
 [dev-dependencies]
 glam = { version = "0.24", features = ["scalar-math"] }


### PR DESCRIPTION
Closes #652.

## Why

`objc-rs 0.2.8` selects its Objective-C runtime with:

```rust
#[cfg(any(target_os = "macos", target_os = "ios"))]
```

so tvOS, watchOS and visionOS fall through to the **GNUstep** backend and fail to link against Apple SDKs:

```
Undefined symbol: _objc_msg_lookup
```

That's a GNUstep symbol; Apple's runtime provides `_objc_msgSend`.

`objc-rs` widened the predicate to `target_vendor = "apple"` in [raphamorim/objc-rs#3](https://github.com/raphamorim/objc-rs/pull/3), released in **0.3.2**. The maintainer opted to ship it on the 0.3.x line rather than backport to 0.2.x ([raphamorim/objc-rs#4](https://github.com/raphamorim/objc-rs/issues/4)), so moving the pin is the only way to pick it up.

This mattered immediately because #651 (tvOS build support, merged) makes miniquad *compile* for tvOS while a downstream app still couldn't *link*.

## Scope

One line in `Cargo.toml`. **No source changes** — miniquad's `objc` usage sits entirely within the API 0.2 and 0.3 share, so nothing needed adapting.

## Verification

`cargo build` clean on every Apple target:

| target | |
|---|---|
| `aarch64-apple-darwin` | ✅ |
| `aarch64-apple-ios` | ✅ |
| `aarch64-apple-ios-sim` | ✅ |
| `aarch64-apple-tvos` | ✅ |
| `aarch64-apple-tvos-sim` | ✅ |

I also checked the symptom directly rather than trusting the build: the tvOS rlib contains **zero** `_objc_msg_lookup` references after the bump.

End-to-end, a macroquad game (CHOMP) now builds, links and runs on the tvOS Simulator against **plain upstream miniquad with no `[patch.crates-io]` entry for `objc-rs`** — which wasn't possible before this.

Happy to hold if you'd rather wait for a 0.2.x backport, but the maintainer has indicated 0.3.x is where the fix lives.